### PR TITLE
Refuse to start when another PatchDeck instance owns the lock

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,8 @@ import { serveStatic } from "./static";
 import { configureWebAuth } from "./webAuth";
 import { createServer } from "http";
 import { childLogger, logger } from "./logger";
+import { acquireInstanceLock, InstanceLockError } from "./instanceLock";
+import { getCodeFactoryPaths } from "./paths";
 
 const serverLog = childLogger("server");
 
@@ -59,6 +61,16 @@ async function openDashboard(url: string) {
 }
 
 (async () => {
+  try {
+    acquireInstanceLock(getCodeFactoryPaths().rootDir);
+  } catch (err) {
+    if (err instanceof InstanceLockError) {
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+
   await registerRoutes(httpServer, app);
 
   app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {

--- a/server/instanceLock.test.ts
+++ b/server/instanceLock.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawn } from "child_process";
+import { acquireInstanceLock, InstanceLockError } from "./instanceLock";
+
+function makeRoot(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `instance-lock-${prefix}-`));
+}
+
+test("acquireInstanceLock writes our pid and releases cleanly", () => {
+  const root = makeRoot("happy");
+  const release = acquireInstanceLock(root);
+  const lockPath = path.join(root, ".lock");
+
+  assert.equal(fs.readFileSync(lockPath, "utf8"), String(process.pid));
+  release();
+  assert.equal(fs.existsSync(lockPath), false);
+});
+
+test("acquireInstanceLock takes over a stale lock from a dead pid", () => {
+  const root = makeRoot("stale");
+  const lockPath = path.join(root, ".lock");
+  fs.mkdirSync(root, { recursive: true });
+  // PID 0 is invalid on every Unix; process.kill(0, 0) throws ESRCH.
+  // We use a very high pid we know is unlikely to be live.
+  const fakeDeadPid = 2 ** 22;
+  fs.writeFileSync(lockPath, String(fakeDeadPid));
+
+  const release = acquireInstanceLock(root);
+  assert.equal(fs.readFileSync(lockPath, "utf8"), String(process.pid));
+  release();
+});
+
+test("acquireInstanceLock refuses when an alive pid already holds the lock", async () => {
+  const root = makeRoot("alive");
+  const lockPath = path.join(root, ".lock");
+  fs.mkdirSync(root, { recursive: true });
+
+  // Spawn a sleeping child whose pid we can use as a "live holder".
+  const child = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60_000)"]);
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    fs.writeFileSync(lockPath, String(child.pid));
+
+    assert.throws(() => acquireInstanceLock(root), (err: unknown) => {
+      assert.ok(err instanceof InstanceLockError);
+      assert.equal((err as InstanceLockError).pid, child.pid);
+      return true;
+    });
+  } finally {
+    child.kill();
+    await new Promise((resolve) => child.once("exit", resolve));
+  }
+});
+
+test("acquireInstanceLock release is idempotent and only removes our own lock", () => {
+  const root = makeRoot("idem");
+  const lockPath = path.join(root, ".lock");
+  const release = acquireInstanceLock(root);
+
+  release();
+  assert.equal(fs.existsSync(lockPath), false);
+
+  // Simulate a second instance writing the lock with a different pid; our second
+  // release() call must not delete that file.
+  fs.writeFileSync(lockPath, "999999");
+  release();
+  assert.equal(fs.existsSync(lockPath), true);
+  fs.unlinkSync(lockPath);
+});

--- a/server/instanceLock.ts
+++ b/server/instanceLock.ts
@@ -1,0 +1,97 @@
+import fs from "fs";
+import path from "path";
+import { childLogger } from "./logger";
+
+const log = childLogger("instanceLock");
+
+export class InstanceLockError extends Error {
+  readonly pid: number;
+  constructor(pid: number, lockPath: string) {
+    super(
+      `Another PatchDeck instance (pid ${pid}) is already running. `
+        + `If that's wrong, remove the stale lockfile at ${lockPath} and retry.`,
+    );
+    this.pid = pid;
+    this.name = "InstanceLockError";
+  }
+}
+
+export type ReleaseLock = () => void;
+
+function isPidAlive(pid: number): boolean {
+  try {
+    // Signal 0 sends no signal but performs the permission/existence check.
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the process exists but is owned by another user — still alive.
+    return code === "EPERM";
+  }
+}
+
+function tryWriteExclusive(lockPath: string, pid: number): boolean {
+  try {
+    fs.writeFileSync(lockPath, String(pid), { flag: "wx" });
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export function acquireInstanceLock(rootDir: string): ReleaseLock {
+  fs.mkdirSync(rootDir, { recursive: true });
+  const lockPath = path.join(rootDir, ".lock");
+  const myPid = process.pid;
+
+  if (!tryWriteExclusive(lockPath, myPid)) {
+    const existingRaw = fs.readFileSync(lockPath, "utf8").trim();
+    const existingPid = Number.parseInt(existingRaw, 10);
+    const valid = Number.isFinite(existingPid) && existingPid > 0;
+
+    if (valid && existingPid !== myPid && isPidAlive(existingPid)) {
+      throw new InstanceLockError(existingPid, lockPath);
+    }
+
+    log.warn(
+      { staleLockPid: valid ? existingPid : existingRaw, lockPath },
+      "Stale instance lock detected; taking over",
+    );
+    fs.unlinkSync(lockPath);
+    if (!tryWriteExclusive(lockPath, myPid)) {
+      // Another process raced us between unlink and create. Re-read and decide.
+      const racedRaw = fs.readFileSync(lockPath, "utf8").trim();
+      const racedPid = Number.parseInt(racedRaw, 10);
+      throw new InstanceLockError(Number.isFinite(racedPid) ? racedPid : -1, lockPath);
+    }
+  }
+
+  let released = false;
+  const release: ReleaseLock = () => {
+    if (released) return;
+    released = true;
+    try {
+      const currentRaw = fs.readFileSync(lockPath, "utf8").trim();
+      const currentPid = Number.parseInt(currentRaw, 10);
+      if (currentPid === myPid) {
+        fs.unlinkSync(lockPath);
+      }
+    } catch {
+      // Lockfile already removed or unreadable; nothing to clean up.
+    }
+  };
+
+  const onExit = () => release();
+  process.once("exit", onExit);
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.once(signal, () => {
+      release();
+      process.exit(0);
+    });
+  }
+
+  return release;
+}


### PR DESCRIPTION
## Summary

- Adds a PID lockfile at `<root>/.lock` (where `<root>` is `~/.oh-my-pr` / `~/.patchdeck` / `PATCHDECK_HOME`).
- On startup, server refuses to run if another live PID already holds the lock; takes over (with warn log) if the holder is dead.
- `SIGINT`/`SIGTERM`/`SIGHUP`/`exit` cleanly release the lock.

## Why

Three concurrent PatchDeck instances were running against the same SQLite home and the same GitHub account — measured ~10,200 octokit calls/hr against the 5,000/hr authenticated limit. Three writers on one SQLite file is also a corruption risk under contention.

## Test plan

- [x] `npm run check` — clean
- [x] `npm run test` — 4 new instance-lock tests pass; pre-existing dyld failure in `agentRunner.test.ts` is unaffected
- [ ] Manual: start two `npm run dev` instances back-to-back; second should exit with `InstanceLockError`
- [ ] Manual: write a fake PID to `~/.oh-my-pr/.lock`, start server, confirm takeover warn log