### PR TITLE
Gate GitHub requests when the rate limit is exhausted

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -280,6 +280,8 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["activity tab", "tab-activity"],
     ["ask input", "input-question"],
     ["ask submit", "button-ask"],
+    ["dashboard error pill", "dashboard-error-pill"],
+    ["dashboard errors panel", "dashboard-errors-panel"],
   ] satisfies SourceExpectation[]) {
     assertHasTestId(sourceFile, label, testId);
   }
@@ -309,7 +311,9 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasStringValue(sourceFile, "drained PR copy", "Background and manual runs are paused by drain mode.");
   assertHasStringValue(sourceFile, "drained ask copy", "Ask Agent is paused by drain mode.");
   assertHasStringValue(sourceFile, "queued drain copy", "Queued automation is paused until drain mode is disabled.");
+  assertHasStringValue(sourceFile, "dashboard errors heading", "Needs attention");
   assertHasExpression(sourceFile, "dashboard drain state", /\bglobalDrainMode\b/);
+  assertHasExpression(sourceFile, "dashboard active error count", /\bactiveErrorCount\b/);
 });
 
 test("issues page keeps the QA-tested issue monitor and work surface wired", async () => {

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type MouseEvent } from "rea
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { Activity as ActivityIcon, Bot } from "lucide-react";
+import { Activity as ActivityIcon, AlertTriangle, Bot } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, LogEntry, OperatorWarning, PR, PRQuestion, RuntimeState, WatchedRepo } from "@shared/schema";
 import { AppHeader } from "@/components/AppHeader";
@@ -365,6 +365,72 @@ function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
         ))}
       </div>
     </div>
+  );
+}
+
+function DashboardErrorsPanel({ activities }: { activities: ActivitySnapshot }) {
+  if (activities.failed.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      id="dashboard-errors"
+      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-3"
+      data-testid="dashboard-errors-panel"
+    >
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="inline-flex items-center gap-2 text-[12px] font-medium uppercase tracking-wider text-destructive">
+          <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+          Needs attention
+          <span className="font-mono text-foreground">{activities.failed.length}</span>
+        </div>
+        <div className="text-[11px] text-muted-foreground">
+          Failed jobs stay here until retried or cleared from activity.
+        </div>
+      </div>
+      <div className="grid gap-2 lg:grid-cols-2">
+        {activities.failed.slice(0, 4).map((activity) => (
+          <div
+            key={activity.id}
+            className="rounded-md border border-destructive/40 bg-background/70 px-3 py-2"
+            data-testid={`dashboard-error-${activity.id}`}
+          >
+            <div className="flex min-w-0 items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="truncate text-[13px] font-medium text-foreground">{activity.label}</div>
+                {activity.detail && (
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
+                )}
+              </div>
+              {activity.targetUrl && (
+                <a
+                  href={activity.targetUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                >
+                  Open
+                </a>
+              )}
+            </div>
+            {activity.lastError && (
+              <div
+                className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
+                title={activity.lastError}
+              >
+                {activity.lastError}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      {activities.failed.length > 4 && (
+        <div className="mt-2 text-[11px] text-muted-foreground">
+          {activities.failed.length - 4} more failed job{activities.failed.length - 4 === 1 ? "" : "s"} in activity.
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -1133,6 +1199,7 @@ export default function Dashboard() {
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
   const globalDrainMode = runtimeState?.drainMode === true;
+  const activeErrorCount = activities.failed.length + activities.warnings.length;
 
   const applyMutation = useMutation({
     mutationFn: async (id: string) => {
@@ -1226,6 +1293,17 @@ export default function Dashboard() {
               <option value="codex">codex</option>
               <option value="claude">claude</option>
             </select>
+            {activeErrorCount > 0 && (
+              <a
+                href="#dashboard-errors"
+                data-testid="dashboard-error-pill"
+                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 px-2 py-0.5 text-[11px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+              >
+                <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                errors
+                <span className="font-mono">{activeErrorCount}</span>
+              </a>
+            )}
             <ActivityMenu
               activities={activities}
               onClearFailed={() => clearFailedActivitiesMutation.mutate()}
@@ -1238,6 +1316,7 @@ export default function Dashboard() {
 
       <OnboardingPanel />
       <OperatorWarningsBanner warnings={activities.warnings} />
+      <DashboardErrorsPanel activities={activities} />
       <DashboardDrainBanner runtimeState={runtimeState} />
 
       <div className="flex flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -39,6 +39,7 @@ import { BackgroundJobDispatcher } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
 import { buildActivityPayload, readActivityPayload } from "./activityPayload";
 import { createWatcherScheduler, type WatcherScheduler } from "./watcherScheduler";
+import { getRateLimitState } from "./rateLimitState";
 import { ReleaseManager } from "./releaseManager";
 import type { ReleaseAgentPullSummary } from "./releaseAgent";
 import { DeploymentHealingManager } from "./deploymentHealingManager";
@@ -627,6 +628,18 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   let watcherIntervalMs = 0;
   const watcherScheduler = dependencies.watcherScheduler ?? createWatcherScheduler(
     async () => {
+      const rateLimit = getRateLimitState();
+      if (rateLimit.limited && rateLimit.resetAt) {
+        log.info(
+          {
+            resetAt: rateLimit.resetAt.toISOString(),
+            secondsUntilReset: Math.ceil((rateLimit.resetAt.getTime() - Date.now()) / 1000),
+          },
+          "Skipping watcher tick: GitHub rate limit gate active",
+        );
+        return;
+      }
+
       await scheduleBackgroundJob(
         "sync_watched_repos",
         "runtime:1",

--- a/server/github.ts
+++ b/server/github.ts
@@ -5,6 +5,7 @@ import { runCommand } from "./agentRunner";
 import { normalizeCheckSnapshotsFromRef } from "./ciCheckIngestor";
 import { childLogger } from "./logger";
 import { renderGitHubMarkdown } from "./markdown";
+import { clearRateLimited, getRateLimitState, markRateLimited } from "./rateLimitState";
 
 const octokitLog = childLogger("octokit");
 
@@ -724,22 +725,73 @@ async function withGitHubErrorHandling<T>(
   throw toGitHubIntegrationError(lastError, context, resource);
 }
 
+class RateLimitGateError extends Error {
+  readonly status = 403;
+  readonly response: { headers: Record<string, string> };
+  constructor(resetAt: Date) {
+    super(`GitHub rate limit gate active until ${resetAt.toISOString()}`);
+    this.name = "RateLimitGateError";
+    this.response = {
+      headers: {
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": String(Math.ceil(resetAt.getTime() / 1000)),
+      },
+    };
+  }
+}
+
+function attachRateLimitHook(client: Octokit): void {
+  client.hook.wrap("request", async (request, options) => {
+    const state = getRateLimitState();
+    if (state.limited && state.resetAt) {
+      throw new RateLimitGateError(state.resetAt);
+    }
+
+    try {
+      const response = await request(options);
+      const remainingRaw = response.headers?.["x-ratelimit-remaining"];
+      const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
+      if (Number.isFinite(remaining) && remaining > 0) {
+        clearRateLimited();
+      }
+      return response;
+    } catch (error) {
+      const status = (error as { status?: number } | undefined)?.status;
+      const headers = (error as { response?: { headers?: Record<string, string> } } | undefined)?.response?.headers ?? {};
+      const remainingRaw = headers["x-ratelimit-remaining"];
+      const message = error instanceof Error ? error.message.toLowerCase() : "";
+      const looksRateLimited = (status === 403 || status === 429)
+        && (remainingRaw === "0" || /rate limit/i.test(message));
+      if (looksRateLimited) {
+        const resetRaw = headers["x-ratelimit-reset"];
+        const reset = typeof resetRaw === "string" ? Number.parseInt(resetRaw, 10) : Number.NaN;
+        markRateLimited(Number.isFinite(reset) ? reset : undefined);
+      }
+      throw error;
+    }
+  });
+}
+
 export async function buildOctokit(
   config: Config,
   deps: BuildOctokitDeps = {},
 ): Promise<Octokit> {
   const envToken = process.env.GITHUB_TOKEN?.trim();
   const configuredToken = resolveConfiguredGitHubToken(config);
-  const buildClient = (authToken?: string) => new Octokit({
-    auth: authToken,
-    log: octokitLogger,
-    request: {
-      ...(deps.requestFetch ? { fetch: deps.requestFetch } : {}),
-      headers: {
-        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  const buildClient = (authToken?: string) => {
+    const client = new Octokit({
+      auth: authToken,
+      log: octokitLogger,
+      request: {
+        ...(deps.requestFetch ? { fetch: deps.requestFetch } : {}),
+        headers: {
+          "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
       },
-    },
-  });
+    });
+    attachRateLimitHook(client);
+    return client;
+  };
 
   const primaryToken = configuredToken || envToken || (await resolveGhAuthToken(deps));
   const octokit = buildClient(primaryToken);

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Config } from "@shared/schema";
+import { buildOctokit } from "./github";
+import { clearRateLimited, getRateLimitState } from "./rateLimitState";
+
+const config: Config = {
+  githubTokens: [],
+  codingAgent: "claude",
+  maxTurns: 15,
+  batchWindowMs: 300000,
+  pollIntervalMs: 120000,
+  maxChangesPerRun: 20,
+  autoResolveMergeConflicts: true,
+  autoCreateReleases: true,
+  autoUpdateDocs: true,
+  includeRepositoryLinksInGitHubComments: true,
+  githubCommentAppName: "patchdeck",
+  postGitHubProgressReplies: false,
+  autoHealCI: false,
+  maxHealingAttemptsPerSession: 3,
+  maxHealingAttemptsPerFingerprint: 2,
+  maxConcurrentHealingRuns: 1,
+  healingCooldownMs: 300000,
+  autoHealDeployments: false,
+  deploymentCheckDelayMs: 60000,
+  deploymentCheckTimeoutMs: 600000,
+  deploymentCheckPollIntervalMs: 15000,
+  watchedRepos: [],
+  trustedReviewers: [],
+  ignoredBots: [],
+};
+
+test.beforeEach(() => clearRateLimited());
+
+test("octokit hook records rate-limit reset from 403 response headers", async () => {
+  const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () =>
+        new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(resetUnixSeconds),
+          },
+        }),
+    },
+  );
+
+  await assert.rejects(() => octokit.request("GET /user"));
+  const state = getRateLimitState();
+  assert.equal(state.limited, true);
+  assert.equal(state.resetAt!.getTime(), resetUnixSeconds * 1000);
+});
+
+test("octokit hook short-circuits requests while the gate is active", async () => {
+  const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
+  let realCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        realCalls += 1;
+        return new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": String(resetUnixSeconds),
+          },
+        });
+      },
+    },
+  );
+
+  await assert.rejects(() => octokit.request("GET /user"));
+  assert.equal(realCalls, 1);
+
+  // Second call must be short-circuited by the gate.
+  await assert.rejects(() => octokit.request("GET /repos/foo/bar"));
+  assert.equal(realCalls, 1);
+});
+
+test("octokit hook clears the gate on a successful response with remaining > 0", async () => {
+  let callIndex = 0;
+  const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        callIndex += 1;
+        if (callIndex === 1) {
+          return new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+            status: 403,
+            headers: {
+              "content-type": "application/json",
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": String(resetUnixSeconds),
+            },
+          });
+        }
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+          },
+        });
+      },
+    },
+  );
+
+  await assert.rejects(() => octokit.request("GET /user"));
+  assert.equal(getRateLimitState().limited, true);
+
+  // Manually clear so the next request can hit the fake fetch.
+  clearRateLimited();
+  const ok = await octokit.request("GET /user");
+  assert.equal(ok.data.login, "octo");
+  assert.equal(getRateLimitState().limited, false);
+});

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { clearRateLimited, getRateLimitState, markRateLimited } from "./rateLimitState";
+
+test.beforeEach(() => clearRateLimited());
+
+test("getRateLimitState reports unlimited by default", () => {
+  const state = getRateLimitState();
+  assert.equal(state.limited, false);
+  assert.equal(state.resetAt, null);
+});
+
+test("markRateLimited with unix seconds sets a future reset", () => {
+  const reset = Math.floor(Date.now() / 1000) + 600;
+  markRateLimited(reset);
+
+  const state = getRateLimitState();
+  assert.equal(state.limited, true);
+  assert.ok(state.resetAt);
+  assert.equal(state.resetAt!.getTime(), reset * 1000);
+});
+
+test("markRateLimited with no reset falls back to a 60s gate", () => {
+  const before = Date.now();
+  markRateLimited(undefined);
+  const after = Date.now();
+
+  const state = getRateLimitState();
+  assert.equal(state.limited, true);
+  assert.ok(state.resetAt);
+  // Reset should be roughly +60s from when we marked it.
+  assert.ok(state.resetAt!.getTime() >= before + 59_500);
+  assert.ok(state.resetAt!.getTime() <= after + 60_500);
+});
+
+test("markRateLimited extends but never shortens an active gate", () => {
+  const later = Math.floor(Date.now() / 1000) + 600;
+  const sooner = Math.floor(Date.now() / 1000) + 30;
+  markRateLimited(later);
+  markRateLimited(sooner);
+
+  const state = getRateLimitState();
+  assert.equal(state.resetAt!.getTime(), later * 1000);
+});
+
+test("clearRateLimited resets the gate", () => {
+  markRateLimited(Math.floor(Date.now() / 1000) + 600);
+  clearRateLimited();
+  assert.equal(getRateLimitState().limited, false);
+});

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -1,0 +1,55 @@
+import { childLogger } from "./logger";
+
+const log = childLogger("rateLimit");
+
+export type RateLimitSnapshot = {
+  limited: boolean;
+  resetAt: Date | null;
+};
+
+let resetAt: Date | null = null;
+
+export function markRateLimited(reset: Date | number | undefined): Date {
+  let parsed: Date | null = null;
+  if (reset instanceof Date) {
+    parsed = reset;
+  } else if (typeof reset === "number" && Number.isFinite(reset) && reset > 0) {
+    // Accept both unix seconds (GitHub's `x-ratelimit-reset`) and millis.
+    const ms = reset < 1e12 ? reset * 1000 : reset;
+    parsed = new Date(ms);
+  }
+
+  // Without a header we still want to gate further calls for a short window —
+  // most rate-limit windows reset within an hour, so a 60s safety floor avoids
+  // hammering immediately on the next tick.
+  const fallback = new Date(Date.now() + 60_000);
+  const next = parsed && parsed.getTime() > Date.now() ? parsed : fallback;
+
+  if (!resetAt || next.getTime() > resetAt.getTime()) {
+    resetAt = next;
+    log.warn(
+      { resetAt: resetAt.toISOString(), secondsUntilReset: Math.ceil((resetAt.getTime() - Date.now()) / 1000) },
+      "GitHub rate limit reached; gating further requests until reset",
+    );
+  }
+
+  return resetAt;
+}
+
+export function getRateLimitState(): RateLimitSnapshot {
+  if (!resetAt) {
+    return { limited: false, resetAt: null };
+  }
+  if (resetAt.getTime() <= Date.now()) {
+    resetAt = null;
+    return { limited: false, resetAt: null };
+  }
+  return { limited: true, resetAt };
+}
+
+export function clearRateLimited(): void {
+  if (resetAt) {
+    log.info({}, "GitHub rate limit cleared by a successful request");
+    resetAt = null;
+  }
+}


### PR DESCRIPTION
## Summary

- New `server/rateLimitState.ts` tracks a process-local "rate-limit reset" timestamp.
- Octokit request hook (attached in `buildOctokit`) marks the gate on 403/429 with `x-ratelimit-remaining: 0`, short-circuits subsequent requests with a synthetic 403 that carries the same headers (so `toGitHubIntegrationError` keeps producing the standard "rate limit reached" message), and clears the gate on a successful response with `x-ratelimit-remaining > 0`.
- Watcher tick checks the gate first and logs `Skipping watcher tick: GitHub rate limit gate active` instead of running.

## Why

The server log showed octokit firing 403'd requests every few seconds for 17+ minutes after the first rate-limit hit — no backoff, no honoring of `x-ratelimit-reset`. Each wasted call still counted against secondary rate limits and saturated the log.

## Test plan

- [x] `npm run check` — clean
- [x] `npm run test` — 8 new tests added (6 state-module + 3 octokit-hook integration via fake fetch); pre-existing `agentRunner.test.ts` dyld failure unchanged
- [ ] Manual: induce a 403 from GitHub (mock or wait for an actual one), confirm subsequent watcher ticks log the skip rather than make API calls