### PR TITLE
Stop persisting agent stderr to logs DB and prune historical bloat

### DIFF
--- a/script/prune-state.ts
+++ b/script/prune-state.ts
@@ -1,0 +1,81 @@
+import { performance } from "node:perf_hooks";
+import { statSync } from "node:fs";
+import { getCodeFactoryPaths } from "../server/paths";
+import { getDefaultStorage } from "../server/storage";
+import { pruneLogsOnce, DEFAULT_LOG_RETENTION_DAYS, STDERR_LOG_MESSAGE_PREFIX } from "../server/logsRetention";
+import { SqliteStorage } from "../server/sqliteStorage";
+
+function parseArgs(argv: string[]): { daysToKeep: number; skipVacuum: boolean; skipStderr: boolean } {
+  let daysToKeep = DEFAULT_LOG_RETENTION_DAYS;
+  let skipVacuum = false;
+  let skipStderr = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--days" && i + 1 < argv.length) {
+      const value = Number.parseInt(argv[i + 1], 10);
+      if (Number.isFinite(value) && value > 0) {
+        daysToKeep = value;
+      }
+      i += 1;
+    } else if (arg === "--no-vacuum") {
+      skipVacuum = true;
+    } else if (arg === "--no-stderr-prune") {
+      skipStderr = true;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        [
+          "Usage: tsx script/prune-state.ts [options]",
+          "",
+          "Options:",
+          `  --days <n>           keep logs newer than n days (default ${DEFAULT_LOG_RETENTION_DAYS})`,
+          `  --no-stderr-prune    skip deletion of rows starting with "${STDERR_LOG_MESSAGE_PREFIX}"`,
+          "  --no-vacuum          skip VACUUM after the prune (keeps freelist as-is)",
+        ].join("\n"),
+      );
+      process.exit(0);
+    }
+  }
+
+  return { daysToKeep, skipVacuum, skipStderr };
+}
+
+function fileSizeMb(path: string): string {
+  try {
+    return (statSync(path).size / (1024 * 1024)).toFixed(1);
+  } catch {
+    return "?";
+  }
+}
+
+async function main(): Promise<void> {
+  const { daysToKeep, skipVacuum, skipStderr } = parseArgs(process.argv.slice(2));
+  const paths = getCodeFactoryPaths();
+  console.log(`PatchDeck home: ${paths.rootDir}`);
+  console.log(`Before:  state.sqlite = ${fileSizeMb(paths.stateDbPath)} MB`);
+
+  const storage = getDefaultStorage();
+
+  const start = performance.now();
+  const result = await pruneLogsOnce(storage, { daysToKeep, pruneStderr: !skipStderr });
+  console.log(
+    `Pruned: ${result.byAge} rows older than ${daysToKeep} day(s)`
+      + (skipStderr ? "" : `, ${result.byStderrPrefix} stderr-prefixed rows`),
+  );
+
+  if (!skipVacuum) {
+    if (!(storage instanceof SqliteStorage)) {
+      console.log("Skipping VACUUM: storage backend is not SQLite");
+    } else {
+      console.log("Running VACUUM...");
+      storage.vacuum();
+    }
+  }
+  console.log(`Elapsed: ${((performance.now() - start) / 1000).toFixed(1)}s`);
+  console.log(`After:   state.sqlite = ${fileSizeMb(paths.stateDbPath)} MB`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -39,6 +39,7 @@ import { BackgroundJobDispatcher } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
 import { buildActivityPayload, readActivityPayload } from "./activityPayload";
 import { createWatcherScheduler, type WatcherScheduler } from "./watcherScheduler";
+import { startLogsRetentionJob, type RetentionJobHandle } from "./logsRetention";
 import { ReleaseManager } from "./releaseManager";
 import type { ReleaseAgentPullSummary } from "./releaseAgent";
 import { DeploymentHealingManager } from "./deploymentHealingManager";
@@ -625,6 +626,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
   let watcherTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
+  let logsRetentionJob: RetentionJobHandle | null = null;
   const watcherScheduler = dependencies.watcherScheduler ?? createWatcherScheduler(
     async () => {
       await scheduleBackgroundJob(
@@ -1253,6 +1255,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
       if (startBackgroundServices) {
         await backgroundJobDispatcher.start();
+        logsRetentionJob = startLogsRetentionJob(storage);
       }
 
       if (startWatcher) {
@@ -1265,6 +1268,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     stop() {
       started = false;
       backgroundJobDispatcher.stop();
+      if (logsRetentionJob) {
+        logsRetentionJob.stop();
+        logsRetentionJob = null;
+      }
       if (watcherTimer) {
         clearInterval(watcherTimer);
         watcherTimer = null;

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -6014,17 +6014,12 @@ test("babysitPR skips conflict resolution when PR is mergeable", async () => {
   assert.equal(mergeAttempted, false, "Should not attempt merge when PR is mergeable");
   assert.equal(updated?.status, "watching");
   assert.ok(!logs.some((log) => log.phase === "conflict"));
-  const stderrLogs = logs.filter((log) => log.phase === "agent" && log.metadata?.stream === "stderr");
-  assert.ok(stderrLogs.length > 0);
-  assert.ok(stderrLogs.every((log) => log.level === "info"));
-  assert.ok(stderrLogs.some((log) => log.message === "[stderr] stderr line 1"));
-  assert.ok(logs.some((log) =>
-    log.level === "info"
-    && log.phase === "agent"
-    && log.message.includes("output truncated after")
-    && log.metadata?.truncated === true
-  ));
-  assert.ok(!logs.some((log) => log.message.includes("stderr line 121")));
+  // Stderr is intentionally not persisted to the logs DB (file-only); only stdout
+  // and higher-level info/warn lines should land here.
+  const stderrLogs = logs.filter((log) => log.metadata?.stream === "stderr");
+  assert.equal(stderrLogs.length, 0, "stderr chunks must stay out of the logs DB");
+  const stdoutLogs = logs.filter((log) => log.metadata?.stream === "stdout");
+  assert.ok(stdoutLogs.some((log) => log.message === "[stdout] applied fix"));
 
   delete process.env.CODEFACTORY_HOME;
 });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -2294,11 +2294,13 @@ export class PRBabysitter {
       details?: {
         phase?: string | null;
         metadata?: Record<string, unknown> | null;
+        fileOnly?: boolean;
       },
 	    ) => {
 	      logQueue = logQueue
 	        .then(async () => {
-	          await this.storage.addLog(currentPrId, level, message, {
+	          const write = details?.fileOnly ? this.storage.addLogToFile : this.storage.addLog;
+	          await write.call(this.storage, currentPrId, level, message, {
 	            runId,
 	            phase: details?.phase ?? null,
 	            metadata: details?.metadata ?? null,
@@ -2337,6 +2339,11 @@ export class PRBabysitter {
       let loggedLines = 0;
       let loggedTruncation = false;
 
+      // Stderr is high-volume noise that bloated the logs table to >1 GB. Keep it in
+      // the per-PR log files only; the DB still gets the stdout stream and the
+      // higher-level warn/error/info messages the babysitter writes directly.
+      const fileOnly = stream === "stderr";
+
       const enqueueLine = (trimmed: string) => {
         if (maxLines !== undefined && loggedLines >= maxLines) {
           if (!loggedTruncation) {
@@ -2344,6 +2351,7 @@ export class PRBabysitter {
             return queueLog(currentPrId, level, `[${stream}] output truncated after ${maxLines} line(s)`, {
               phase,
               metadata: { stream, truncated: true, maxLines },
+              fileOnly,
             });
           }
           return logQueue;
@@ -2353,6 +2361,7 @@ export class PRBabysitter {
         return queueLog(currentPrId, level, `[${stream}] ${trimmed}`, {
           phase,
           metadata: { stream },
+          fileOnly,
         });
       };
 

--- a/server/logsRetention.test.ts
+++ b/server/logsRetention.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { MemStorage } from "./storage";
+import { DEFAULT_LOG_RETENTION_DAYS, pruneLogsOnce, STDERR_LOG_MESSAGE_PREFIX, startLogsRetentionJob } from "./logsRetention";
+
+async function seedLog(storage: MemStorage, message: string, timestampOverride?: string) {
+  const entry = await storage.addLog("pr-1", "info", message);
+  if (timestampOverride) {
+    (entry as { timestamp: string }).timestamp = timestampOverride;
+    // The MemStorage stores entries by reference; the in-memory list already
+    // contains this same object, so the override propagates.
+  }
+}
+
+test("pruneLogsOnce drops rows older than the retention window", async () => {
+  const storage = new MemStorage();
+  const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+  const recent = new Date().toISOString();
+
+  await seedLog(storage, "old message", eightDaysAgo);
+  await seedLog(storage, "fresh message", recent);
+
+  const result = await pruneLogsOnce(storage, { daysToKeep: DEFAULT_LOG_RETENTION_DAYS, pruneStderr: false });
+  assert.equal(result.byAge, 1);
+
+  const remaining = await storage.getLogs("pr-1");
+  assert.equal(remaining.length, 1);
+  assert.equal(remaining[0].message, "fresh message");
+});
+
+test("pruneLogsOnce drops stderr-prefixed rows even when fresh", async () => {
+  const storage = new MemStorage();
+  await seedLog(storage, `${STDERR_LOG_MESSAGE_PREFIX}}}`);
+  await seedLog(storage, `${STDERR_LOG_MESSAGE_PREFIX}+`);
+  await seedLog(storage, "[stdout] hi");
+
+  const result = await pruneLogsOnce(storage, { daysToKeep: 30, pruneStderr: true });
+  assert.equal(result.byStderrPrefix, 2);
+
+  const remaining = await storage.getLogs("pr-1");
+  assert.deepEqual(remaining.map((entry) => entry.message), ["[stdout] hi"]);
+});
+
+test("startLogsRetentionJob ticks once at startup and on the interval", async () => {
+  const storage = new MemStorage();
+  const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+  await seedLog(storage, "old-1", eightDaysAgo);
+  await seedLog(storage, "old-2", eightDaysAgo);
+
+  const handle = startLogsRetentionJob(storage, { intervalMs: 60_000 });
+  try {
+    // Allow the synchronous tick scheduled at startup to flush.
+    await new Promise((resolve) => setImmediate(resolve));
+    const remaining = await storage.getLogs("pr-1");
+    assert.equal(remaining.length, 0);
+  } finally {
+    handle.stop();
+  }
+});

--- a/server/logsRetention.ts
+++ b/server/logsRetention.ts
@@ -1,0 +1,73 @@
+import { childLogger } from "./logger";
+import type { IStorage } from "./storage";
+
+const log = childLogger("logsRetention");
+
+export const DEFAULT_LOG_RETENTION_DAYS = 7;
+export const DEFAULT_RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+export const STDERR_LOG_MESSAGE_PREFIX = "[stderr] ";
+
+export type PruneResult = {
+  byAge: number;
+  byStderrPrefix: number;
+};
+
+export async function pruneLogsOnce(
+  storage: IStorage,
+  options: { daysToKeep?: number; pruneStderr?: boolean } = {},
+): Promise<PruneResult> {
+  const daysToKeep = options.daysToKeep ?? DEFAULT_LOG_RETENTION_DAYS;
+  const pruneStderr = options.pruneStderr ?? true;
+
+  const threshold = new Date(Date.now() - daysToKeep * 24 * 60 * 60 * 1000).toISOString();
+  const byAge = await storage.pruneLogs({ olderThan: threshold });
+  const byStderrPrefix = pruneStderr
+    ? await storage.pruneLogs({ messagePrefix: STDERR_LOG_MESSAGE_PREFIX })
+    : 0;
+
+  log.info(
+    { daysToKeep, threshold, byAge, byStderrPrefix },
+    "Pruned logs table",
+  );
+
+  return { byAge, byStderrPrefix };
+}
+
+export type RetentionJobHandle = {
+  stop: () => void;
+};
+
+export function startLogsRetentionJob(
+  storage: IStorage,
+  options: {
+    daysToKeep?: number;
+    intervalMs?: number;
+    pruneStderr?: boolean;
+  } = {},
+): RetentionJobHandle {
+  const intervalMs = options.intervalMs ?? DEFAULT_RETENTION_INTERVAL_MS;
+
+  let stopped = false;
+  const tick = () => {
+    if (stopped) return;
+    pruneLogsOnce(storage, options).catch((err) => {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Scheduled logs prune failed",
+      );
+    });
+  };
+
+  // Run once at startup so existing bloat starts shrinking immediately, then on
+  // the interval.
+  tick();
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+    },
+  };
+}

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -198,6 +198,19 @@ export class MemStorage implements IStorage {
     return entry;
   }
 
+  async addLogToFile(
+    prId: string,
+    level: "info" | "warn" | "error",
+    message: string,
+    details?: {
+      runId?: string | null;
+      phase?: string | null;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): Promise<LogEntry> {
+    return createLogEntry(prId, level, message, details);
+  }
+
   async clearLogs(prId?: string): Promise<void> {
     if (prId) {
       this.logs = this.logs.filter((l) => l.prId !== prId);
@@ -205,6 +218,16 @@ export class MemStorage implements IStorage {
     }
 
     this.logs = [];
+  }
+
+  async pruneLogs(options: { olderThan?: string; messagePrefix?: string }): Promise<number> {
+    const before = this.logs.length;
+    this.logs = this.logs.filter((entry) => {
+      if (options.olderThan && entry.timestamp < options.olderThan) return false;
+      if (options.messagePrefix && entry.message.startsWith(options.messagePrefix)) return false;
+      return true;
+    });
+    return before - this.logs.length;
   }
 
   async getConfig(): Promise<Config> {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1644,6 +1644,27 @@ export class SqliteStorage implements IStorage {
     return entry;
   }
 
+  async addLogToFile(
+    prId: string,
+    level: "info" | "warn" | "error",
+    message: string,
+    details?: {
+      runId?: string | null;
+      phase?: string | null;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): Promise<LogEntry> {
+    const entry = createLogEntry(prId, level, message, details);
+    const pr = this.get<{ repo: string; number: number }>(
+      "SELECT repo, number FROM prs WHERE id = ?",
+      prId,
+    );
+    if (pr) {
+      appendLogFile(this.logRootDir, pr, entry);
+    }
+    return entry;
+  }
+
   async clearLogs(prId?: string): Promise<void> {
     if (prId) {
       this.run("DELETE FROM logs WHERE pr_id = ?", prId);
@@ -1651,6 +1672,30 @@ export class SqliteStorage implements IStorage {
     }
 
     this.exec("DELETE FROM logs");
+  }
+
+  vacuum(): void {
+    this.exec("VACUUM");
+  }
+
+  async pruneLogs(options: { olderThan?: string; messagePrefix?: string }): Promise<number> {
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+
+    if (options.olderThan) {
+      clauses.push("datetime(timestamp) < datetime(?)");
+      params.push(options.olderThan);
+    }
+    if (options.messagePrefix) {
+      clauses.push("message LIKE ?");
+      params.push(`${options.messagePrefix}%`);
+    }
+    if (clauses.length === 0) {
+      return 0;
+    }
+
+    const result = this.run(`DELETE FROM logs WHERE ${clauses.join(" AND ")}`, ...params as SQLInputValue[]);
+    return Number(result.changes ?? 0);
   }
 
   async getConfig(): Promise<Config> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -54,7 +54,18 @@ export interface IStorage {
       metadata?: Record<string, unknown> | null;
     },
   ): Promise<LogEntry>;
+  addLogToFile(
+    prId: string,
+    level: "info" | "warn" | "error",
+    message: string,
+    details?: {
+      runId?: string | null;
+      phase?: string | null;
+      metadata?: Record<string, unknown> | null;
+    },
+  ): Promise<LogEntry>;
   clearLogs(prId?: string): Promise<void>;
+  pruneLogs(options: { olderThan?: string; messagePrefix?: string }): Promise<number>;
 
   // Config
   getConfig(): Promise<Config>;


### PR DESCRIPTION
## Summary

The `logs` table in `state.sqlite` was **1.8 GB across 4.17M rows** — 3.65M of those were `warn`-level rows with `phase='agent'` whose messages were diff fragments like \`[stderr] }\`, \`[stderr] -\`, \`[stderr] +\`. Every stderr line from `codex`/`claude` was being inserted as its own row.

This PR does three things:

1. **Stops the bleed.** `IStorage.addLogToFile` skips the DB insert but still writes the per-PR file log. The babysitter's `createChunkLogger` uses this for stderr. Stdout still goes to the DB so the dashboard's logs view is unaffected.
2. **Prunes ongoing.** New `server/logsRetention.ts` schedules a daily job at startup that drops rows older than 7 days and any leftover \`[stderr] \` rows. Configurable via options.
3. **One-shot cleanup.** `script/prune-state.ts` for the existing 3.7 GB DB — supports `--days`, `--no-vacuum`, `--no-stderr-prune`, prints before/after file sizes. Calls `SqliteStorage.vacuum()` to reclaim free pages (already ~1.5 GB reclaimable in the wild).

## Why

Diagnosed locally: the `dbstat` query showed `logs` (1.30 GB) + `idx_logs_pr_id_timestamp` (295 MB) + `sqlite_autoindex_logs_1` (211 MB) = ~1.8 GB. Free pages already at 1.5 GB waiting for VACUUM.

## Test plan

- [x] `npm run check` — clean
- [x] `npm run test` — 3 new retention tests pass; existing `babysitPR skips conflict resolution when PR is mergeable` test updated to assert the new contract (stderr is *not* in DB, stdout still is); pre-existing `agentRunner.test.ts` dyld failure unchanged
- [ ] Manual: `tsx script/prune-state.ts` against an actual fat DB; verify before/after size drop matches expectation
- [ ] Manual: restart server, watch first daily prune run in the log