### PR TITLE
Migrate ~/.oh-my-pr to ~/.patchdeck on first launch

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import { serveStatic } from "./static";
 import { configureWebAuth } from "./webAuth";
 import { createServer } from "http";
 import { childLogger, logger } from "./logger";
+import { migrateLegacyHomeIfNeeded } from "./migrateLegacyHome";
 
 const serverLog = childLogger("server");
 
@@ -59,6 +60,11 @@ async function openDashboard(url: string) {
 }
 
 (async () => {
+  // Move ~/.oh-my-pr to ~/.patchdeck before anything else reads the state
+  // directory. Idempotent: skipped when an env override is set, when the new
+  // directory already exists, or when the legacy directory is absent.
+  migrateLegacyHomeIfNeeded();
+
   await registerRoutes(httpServer, app);
 
   app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {

--- a/server/migrateLegacyHome.test.ts
+++ b/server/migrateLegacyHome.test.ts
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { migrateLegacyHomeIfNeeded } from "./migrateLegacyHome";
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `migrate-home-${prefix}-`));
+}
+
+function seed(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "state.sqlite"), "deadbeef");
+  fs.mkdirSync(path.join(dir, "log", "2026-05-12"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "log", "2026-05-12", "x.log"), "line\n");
+}
+
+test("migrateLegacyHomeIfNeeded skips when env override is set", () => {
+  const root = tmpDir("env");
+  const legacy = path.join(root, "legacy");
+  const preferred = path.join(root, "preferred");
+  seed(legacy);
+
+  const result = migrateLegacyHomeIfNeeded({
+    legacy,
+    preferred,
+    env: { PATCHDECK_HOME: "/somewhere/else" },
+  });
+
+  assert.equal(result.migrated, false);
+  assert.equal(fs.existsSync(legacy), true);
+  assert.equal(fs.existsSync(preferred), false);
+});
+
+test("migrateLegacyHomeIfNeeded skips when preferred already exists", () => {
+  const root = tmpDir("both");
+  const legacy = path.join(root, "legacy");
+  const preferred = path.join(root, "preferred");
+  seed(legacy);
+  fs.mkdirSync(preferred);
+
+  const result = migrateLegacyHomeIfNeeded({ legacy, preferred, env: {} });
+
+  assert.equal(result.migrated, false);
+  assert.equal(fs.existsSync(legacy), true);
+  assert.equal(fs.existsSync(preferred), true);
+});
+
+test("migrateLegacyHomeIfNeeded skips when legacy does not exist", () => {
+  const root = tmpDir("none");
+  const legacy = path.join(root, "legacy");
+  const preferred = path.join(root, "preferred");
+
+  const result = migrateLegacyHomeIfNeeded({ legacy, preferred, env: {} });
+
+  assert.equal(result.migrated, false);
+  assert.equal(fs.existsSync(preferred), false);
+});
+
+test("migrateLegacyHomeIfNeeded renames legacy to preferred and preserves contents", () => {
+  const root = tmpDir("happy");
+  const legacy = path.join(root, "legacy");
+  const preferred = path.join(root, "preferred");
+  seed(legacy);
+
+  const result = migrateLegacyHomeIfNeeded({ legacy, preferred, env: {} });
+
+  assert.equal(result.migrated, true);
+  if (result.migrated) {
+    assert.equal(result.from, legacy);
+    assert.equal(result.to, preferred);
+  }
+  assert.equal(fs.existsSync(legacy), false);
+  assert.equal(fs.existsSync(preferred), true);
+  assert.equal(fs.readFileSync(path.join(preferred, "state.sqlite"), "utf8"), "deadbeef");
+  assert.equal(fs.readFileSync(path.join(preferred, "log", "2026-05-12", "x.log"), "utf8"), "line\n");
+});
+
+test("migrateLegacyHomeIfNeeded is idempotent on a second run", () => {
+  const root = tmpDir("idem");
+  const legacy = path.join(root, "legacy");
+  const preferred = path.join(root, "preferred");
+  seed(legacy);
+
+  const first = migrateLegacyHomeIfNeeded({ legacy, preferred, env: {} });
+  assert.equal(first.migrated, true);
+
+  const second = migrateLegacyHomeIfNeeded({ legacy, preferred, env: {} });
+  assert.equal(second.migrated, false);
+});

--- a/server/migrateLegacyHome.ts
+++ b/server/migrateLegacyHome.ts
@@ -1,0 +1,69 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { childLogger } from "./logger";
+
+const log = childLogger("migrateLegacyHome");
+
+const ENV_OVERRIDE_VARS = ["PATCHDECK_HOME", "OH_MY_PR_HOME", "CODEFACTORY_HOME"] as const;
+
+export type MigrationResult =
+  | { migrated: false; reason: string }
+  | { migrated: true; from: string; to: string; mode: "rename" | "copy" };
+
+export type MigrateLegacyHomeOptions = {
+  legacy?: string;
+  preferred?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+function isEnvOverrideSet(env: NodeJS.ProcessEnv): boolean {
+  return ENV_OVERRIDE_VARS.some((name) => {
+    const value = env[name];
+    return typeof value === "string" && value.trim() !== "";
+  });
+}
+
+export function migrateLegacyHomeIfNeeded(options: MigrateLegacyHomeOptions = {}): MigrationResult {
+  const env = options.env ?? process.env;
+  const legacy = options.legacy ?? path.join(os.homedir(), ".oh-my-pr");
+  const preferred = options.preferred ?? path.join(os.homedir(), ".patchdeck");
+
+  if (isEnvOverrideSet(env)) {
+    return { migrated: false, reason: "PATCHDECK_HOME / OH_MY_PR_HOME / CODEFACTORY_HOME is set" };
+  }
+  if (!fs.existsSync(legacy)) {
+    return { migrated: false, reason: "no legacy directory" };
+  }
+  if (fs.existsSync(preferred)) {
+    return { migrated: false, reason: "preferred directory already exists" };
+  }
+
+  log.info({ from: legacy, to: preferred }, "Migrating legacy PatchDeck home directory");
+
+  try {
+    fs.renameSync(legacy, preferred);
+    log.info({ from: legacy, to: preferred, mode: "rename" }, "Legacy home migration complete");
+    return { migrated: true, from: legacy, to: preferred, mode: "rename" };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "EXDEV") {
+      throw err;
+    }
+  }
+
+  // Cross-volume: copy then delete. Not atomic; on interruption the next launch
+  // sees both directories exist and skips migration, requiring manual cleanup.
+  fs.cpSync(legacy, preferred, { recursive: true, preserveTimestamps: true });
+  try {
+    fs.rmSync(legacy, { recursive: true, force: true });
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), legacy },
+      "Copied legacy home but failed to remove the original; delete it manually",
+    );
+  }
+
+  log.info({ from: legacy, to: preferred, mode: "copy" }, "Legacy home migration complete (cross-volume copy)");
+  return { migrated: true, from: legacy, to: preferred, mode: "copy" };
+}


### PR DESCRIPTION
## Summary

Runs once on server startup: if `~/.oh-my-pr` exists and `~/.patchdeck` does not, move the directory. Same-volume `renameSync` (atomic) with a cross-volume `cpSync` + `rmSync` fallback. Skips when any of `PATCHDECK_HOME` / `OH_MY_PR_HOME` / `CODEFACTORY_HOME` is set, when the target already exists, or when there's nothing to move.

## Why

The existing `paths.ts` fallback keeps reading from `~/.oh-my-pr` indefinitely as long as that directory exists and `~/.patchdeck` does not. That means state stays under the old name forever, which is confusing and risks divergence if someone manually creates `~/.patchdeck` later.

## Test plan

- [x] `npm run check` — clean
- [x] `npm run test` — 5 new migration tests pass; pre-existing `agentRunner.test.ts` dyld failure unchanged
- [ ] Manual: start the server with state in `~/.oh-my-pr` and no `~/.patchdeck`; confirm the directory moves and the dashboard still loads PRs/issues
- [ ] Manual: re-launch; confirm migration is skipped (idempotent)

## Notes

- Cross-volume copy is not atomic. If interrupted between copy and delete, the next launch sees both directories and skips migration — the user would need to delete the legacy directory manually. The fallback path logs a warning if `rmSync` fails after a successful copy.
- Independent of (and orders-before) the instance-lock PR (#1) — if both merge, ensure the migration runs before lock acquisition so the lockfile lands in the new home.