### PR TITLE
Throttled auto-evaluate sweep with separate auto-work toggle

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -35,6 +35,10 @@ function getIssueWorkMode(issueAutoWork?: boolean): IssueWorkMode {
   return issueAutoWork ? "auto" : "manual";
 }
 
+function getIssueEvaluateMode(issueAutoEvaluate?: boolean): IssueWorkMode {
+  return issueAutoEvaluate ? "auto" : "manual";
+}
+
 function repoTestId(repo: string): string {
   return repo.replace("/", "-");
 }
@@ -209,7 +213,7 @@ export default function Settings() {
   });
 
   const updateRepoSettingsMutation = useMutation({
-    mutationFn: async (updates: { repo: string; autoCreateReleases?: boolean; ownPrsOnly?: boolean; issueAutoWork?: boolean }) => {
+    mutationFn: async (updates: { repo: string; autoCreateReleases?: boolean; ownPrsOnly?: boolean; issueAutoEvaluate?: boolean; issueAutoWork?: boolean }) => {
       const res = await apiRequest("PATCH", "/api/repos/settings", updates);
       return res.json();
     },
@@ -455,7 +459,7 @@ export default function Settings() {
                             {repo.repo}
                           </a>
                           <div className="mt-1 text-[11px] text-muted-foreground">
-                            {repo.ownPrsOnly === false ? "Tracking team PRs" : "Tracking your PRs"} · issue work {repo.issueAutoWork ? "auto" : "manual"}
+                            {repo.ownPrsOnly === false ? "Tracking team PRs" : "Tracking your PRs"} · issue evaluate {repo.issueAutoEvaluate ? "auto" : "manual"} · issue work {repo.issueAutoWork ? "auto" : "manual"}
                           </div>
                         </div>
                         <button
@@ -497,7 +501,15 @@ export default function Settings() {
                           Remove data
                         </button>
                       </div>
-                      <div className="mt-4 grid gap-4 md:grid-cols-3">
+                      {config?.autoIssues === false && (
+                        <div
+                          data-testid={`tracked-repo-global-issues-off-${repo.repo.replace("/", "-")}`}
+                          className="mt-3 border border-warning-border bg-warning-muted px-3 py-2 text-[11px] text-warning-foreground"
+                        >
+                          Global Issues auto is off — these per-repo issue controls are paused. Re-enable from the AUTO MODE menu.
+                        </div>
+                      )}
+                      <div className="mt-4 grid gap-4 md:grid-cols-4">
                         <div>
                           <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
                             Track automatically
@@ -517,6 +529,23 @@ export default function Settings() {
                         </div>
                         <div>
                           <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                            Issue auto-evaluate
+                          </div>
+                          <IssueWorkModeControl
+                            value={getIssueEvaluateMode(repo.issueAutoEvaluate)}
+                            onChange={(value) =>
+                              updateRepoSettingsMutation.mutate({
+                                repo: repo.repo,
+                                issueAutoEvaluate: value === "auto",
+                              })
+                            }
+                            disabled={updateRepoSettingsMutation.isPending || repo.issueAutoWork}
+                            name={`tracked-repo-issue-evaluate-mode-${repo.repo}`}
+                            testIdPrefix={`tracked-repo-issue-evaluate-mode-${repo.repo.replace("/", "-")}`}
+                          />
+                        </div>
+                        <div>
+                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
                             Issue work mode
                           </div>
                           <IssueWorkModeControl
@@ -531,6 +560,9 @@ export default function Settings() {
                             name={`tracked-repo-issue-work-mode-${repo.repo}`}
                             testIdPrefix={`tracked-repo-issue-work-mode-${repo.repo.replace("/", "-")}`}
                           />
+                          <div className="mt-1 text-[10px] text-muted-foreground">
+                            Auto-work also enables auto-evaluate.
+                          </div>
                         </div>
                         <label className="flex items-end gap-2 text-[11px] uppercase tracking-wider text-muted-foreground">
                           <input

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -7,6 +7,8 @@ import {
   issueWorkAttemptCountFromJobs,
   issueWorkPrFromLogs,
   mapMergedPullsToReleaseSummaries,
+  planAutomaticIssueQueueActions,
+  type PlanAutomaticIssueQueueInput,
 } from "./appRuntime";
 import { _resetRingBufferForTests, readRingBuffer } from "./logger";
 import { MemStorage } from "./memoryStorage";
@@ -287,4 +289,203 @@ test("getIssueAutoWorkEligibility requires a ready label, app approval, and no b
     autoWorkEligible: false,
     autoWorkBlockedReason: "missing ready-for-agent label",
   });
+});
+
+// ── planAutomaticIssueQueueActions ───────────────────────────────────────────
+//
+// The planner is the throttle. It decides which evaluations and work jobs to enqueue on each
+// watcher tick, capped by `maxConcurrent*` config. Tests here encode the *intent* (respect the
+// caps, never starve a repo, don't double-queue) so they fail when business rules drift, not
+// just when implementation churns.
+
+function makePlanIssue(
+  overrides: Partial<PlanAutomaticIssueQueueInput["issues"][number]> & {
+    repo: string;
+    number: number;
+  },
+): PlanAutomaticIssueQueueInput["issues"][number] {
+  return {
+    id: `${overrides.repo}#${overrides.number}`,
+    repo: overrides.repo,
+    number: overrides.number,
+    workStatus: overrides.workStatus ?? "idle",
+    workPrUrl: overrides.workPrUrl ?? null,
+    autoWorkEligible: overrides.autoWorkEligible ?? false,
+    evaluationStatus: overrides.evaluationStatus ?? null,
+    updatedAt: overrides.updatedAt ?? "2026-05-01T00:00:00.000Z",
+  };
+}
+
+test("planAutomaticIssueQueueActions enqueues no jobs when no repo has auto-evaluate or auto-work on", () => {
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: false, issueAutoWork: false }],
+    issues: [makePlanIssue({ repo: "acme/widgets", number: 1 })],
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.deepEqual(plan, { evaluations: [], work: [] });
+});
+
+test("planAutomaticIssueQueueActions sweeps every unevaluated issue up to the evaluation cap", () => {
+  // Goal: a repo with auto-evaluate on and a backlog of unevaluated issues should not be
+  // drained one-per-tick — the planner should enqueue evaluations up to the global cap.
+  const issues = Array.from({ length: 10 }, (_, i) =>
+    makePlanIssue({ repo: "acme/widgets", number: i + 1 }),
+  );
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: false }],
+    issues,
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 3,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.equal(plan.evaluations.length, 3, "must respect the evaluation cap exactly");
+  assert.equal(plan.work.length, 0);
+});
+
+test("planAutomaticIssueQueueActions counts already-queued evaluations against the cap", () => {
+  // Goal: in-flight jobs aren't free — the budget is global (queued + leased + about-to-queue).
+  const issues = Array.from({ length: 5 }, (_, i) =>
+    makePlanIssue({ repo: "acme/widgets", number: i + 1 }),
+  );
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: false }],
+    issues,
+    activeEvaluationTargets: new Set(["acme/widgets#1", "acme/widgets#2"]),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.equal(plan.evaluations.length, 0, "cap already filled by in-flight jobs");
+});
+
+test("planAutomaticIssueQueueActions does not auto-queue work when auto-work is off", () => {
+  // Goal: auto-evaluate without auto-work should classify issues only — never run the agent.
+  // This separation is the whole point of having two toggles.
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: false }],
+    issues: [
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 1,
+        evaluationStatus: "approved",
+        autoWorkEligible: true,
+      }),
+    ],
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.equal(plan.work.length, 0, "auto-work toggle gates work even on approved issues");
+});
+
+test("planAutomaticIssueQueueActions queues work for approved+eligible issues when auto-work is on", () => {
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true }],
+    issues: [
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 1,
+        evaluationStatus: "approved",
+        autoWorkEligible: true,
+      }),
+    ],
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.deepEqual(plan.work, [{ repo: "acme/widgets", number: 1, id: "acme/widgets#1" }]);
+});
+
+test("planAutomaticIssueQueueActions respects per-repo single-flight on work", () => {
+  // Goal: don't pile multiple work jobs onto one repo even if budget allows — the agent
+  // runs one at a time per repo, so queueing more just creates lag.
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true }],
+    issues: [
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 1,
+        workStatus: "in_progress",
+      }),
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 2,
+        evaluationStatus: "approved",
+        autoWorkEligible: true,
+      }),
+    ],
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 5,
+  });
+  assert.equal(plan.work.length, 0, "skip repo that already has a work job in flight");
+});
+
+test("planAutomaticIssueQueueActions interleaves evaluations across repos fairly", () => {
+  // Goal: one repo with a huge backlog must not starve sibling repos. Round-robin is the
+  // simplest fairness contract — issue N for repo A, then issue N for repo B, etc.
+  const issues = [
+    makePlanIssue({ repo: "acme/widgets", number: 1 }),
+    makePlanIssue({ repo: "acme/widgets", number: 2 }),
+    makePlanIssue({ repo: "acme/widgets", number: 3 }),
+    makePlanIssue({ repo: "globex/gizmo", number: 100 }),
+  ];
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [
+      { repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: false },
+      { repo: "globex/gizmo", issueAutoEvaluate: true, issueAutoWork: false },
+    ],
+    issues,
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  const repos = plan.evaluations.map((action) => action.repo);
+  assert.equal(plan.evaluations.length, 2);
+  assert.deepEqual(repos.sort(), ["acme/widgets", "globex/gizmo"], "both repos get one slot");
+});
+
+test("planAutomaticIssueQueueActions skips evaluations already queued for the same target", () => {
+  // Goal: don't double-queue. The dedupe key in the background_jobs table would reject it,
+  // but the planner should avoid even trying — cleaner logs, deterministic behavior.
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: false }],
+    issues: [makePlanIssue({ repo: "acme/widgets", number: 1 })],
+    activeEvaluationTargets: new Set(["acme/widgets#1"]),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.equal(plan.evaluations.length, 0);
+});
+
+test("planAutomaticIssueQueueActions counts active work jobs against the work cap", () => {
+  // Goal: same global-budget semantics on work as on evaluations.
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [
+      { repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true },
+      { repo: "globex/gizmo", issueAutoEvaluate: true, issueAutoWork: true },
+    ],
+    issues: [
+      makePlanIssue({
+        repo: "globex/gizmo",
+        number: 1,
+        evaluationStatus: "approved",
+        autoWorkEligible: true,
+      }),
+    ],
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 1,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+  assert.equal(plan.work.length, 0, "work cap already saturated");
 });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -224,6 +224,97 @@ function normalizeIssueLabel(label: string): string {
   return label.trim().toLowerCase();
 }
 
+export type PlanAutomaticIssueQueueInput = {
+  repoSettings: Pick<WatchedRepo, "repo" | "issueAutoEvaluate" | "issueAutoWork">[];
+  issues: Pick<
+    Issue,
+    "id" | "repo" | "number" | "workStatus" | "workPrUrl" | "autoWorkEligible" | "evaluationStatus" | "updatedAt"
+  >[];
+  activeEvaluationTargets: Set<string>;
+  activeWorkCount: number;
+  maxConcurrentIssueEvaluations: number;
+  maxConcurrentIssueWork: number;
+};
+
+export type PlanAutomaticIssueQueueActions = {
+  evaluations: Array<{ repo: string; number: number; id: string }>;
+  work: Array<{ repo: string; number: number; id: string }>;
+};
+
+export function planAutomaticIssueQueueActions(
+  input: PlanAutomaticIssueQueueInput,
+): PlanAutomaticIssueQueueActions {
+  const autoWorkRepos = input.repoSettings.filter((repo) => repo.issueAutoWork).map((repo) => repo.repo);
+  const autoEvaluateRepos = input.repoSettings
+    .filter((repo) => repo.issueAutoEvaluate || repo.issueAutoWork)
+    .map((repo) => repo.repo);
+
+  const result: PlanAutomaticIssueQueueActions = { evaluations: [], work: [] };
+  if (autoWorkRepos.length === 0 && autoEvaluateRepos.length === 0) {
+    return result;
+  }
+
+  let evaluationBudget = Math.max(0, input.maxConcurrentIssueEvaluations - input.activeEvaluationTargets.size);
+  let workBudget = Math.max(0, input.maxConcurrentIssueWork - input.activeWorkCount);
+  const claimed = new Set<string>();
+
+  // Auto-work sweep first: budget is scarcer. Preserve per-repo single-flight semantics —
+  // at most one work job per repo at a time, regardless of global budget.
+  for (const repo of autoWorkRepos) {
+    if (workBudget <= 0) break;
+    const repoIssues = input.issues.filter((issue) => issue.repo === repo);
+    if (repoIssues.some((issue) => issue.workStatus === "queued" || issue.workStatus === "in_progress")) {
+      continue;
+    }
+    const candidate = repoIssues
+      .filter((issue) => issue.workStatus === "idle" && !issue.workPrUrl && issue.autoWorkEligible)
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+    if (!candidate) continue;
+    result.work.push({ repo: candidate.repo, number: candidate.number, id: candidate.id });
+    claimed.add(candidate.id);
+    workBudget -= 1;
+  }
+
+  // Auto-evaluate sweep: round-robin across repos so a single backlog doesn't starve others.
+  if (evaluationBudget > 0 && autoEvaluateRepos.length > 0) {
+    const repoQueues = new Map<string, typeof input.issues>();
+    for (const repo of autoEvaluateRepos) {
+      const pending = input.issues
+        .filter((issue) =>
+          issue.repo === repo
+          && issue.workStatus === "idle"
+          && !issue.workPrUrl
+          && !issue.evaluationStatus
+          && !input.activeEvaluationTargets.has(issue.id)
+          && !claimed.has(issue.id),
+        )
+        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      if (pending.length > 0) {
+        repoQueues.set(repo, pending);
+      }
+    }
+
+    while (evaluationBudget > 0 && repoQueues.size > 0) {
+      for (const repo of Array.from(repoQueues.keys())) {
+        if (evaluationBudget <= 0) break;
+        const queue = repoQueues.get(repo);
+        const candidate = queue?.shift();
+        if (!candidate) {
+          repoQueues.delete(repo);
+          continue;
+        }
+        if (!queue || queue.length === 0) {
+          repoQueues.delete(repo);
+        }
+        result.evaluations.push({ repo: candidate.repo, number: candidate.number, id: candidate.id });
+        evaluationBudget -= 1;
+      }
+    }
+  }
+
+  return result;
+}
+
 export function getIssueAutoWorkEligibility(
   issue: Pick<Issue, "labels">,
   evaluation?: Pick<IssueEvaluation, "status" | "summary" | "safetyFlags"> | null,
@@ -914,12 +1005,13 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   }
 
   async function queueAutomaticIssueWorkInternal(): Promise<void> {
-    const [runtimeState, config, repoSettings, issues, evaluationJobs] = await Promise.all([
+    const [runtimeState, config, repoSettings, issues, evaluationJobs, workJobs] = await Promise.all([
       storage.getRuntimeState(),
       storage.getConfig(),
       storage.listRepoSettings(),
       listIssuesInternal(),
       storage.listBackgroundJobs({ kind: "evaluate_issue" }),
+      storage.listBackgroundJobs({ kind: "work_issue" }),
     ]);
 
     if (runtimeState.drainMode) {
@@ -930,55 +1022,38 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       return;
     }
 
-    const autoRepos = repoSettings.filter((repo) => repo.issueAutoWork).map((repo) => repo.repo);
-    if (autoRepos.length === 0) {
-      return;
-    }
-
+    const isJobActive = (status: string) => status === "queued" || status === "leased";
     const activeEvaluationTargets = new Set(
-      evaluationJobs
-        .filter((job) => job.status === "queued" || job.status === "leased")
-        .map((job) => job.targetId),
+      evaluationJobs.filter((job) => isJobActive(job.status)).map((job) => job.targetId),
     );
+    const activeWorkCount = workJobs.filter((job) => isJobActive(job.status)).length;
 
-    for (const repo of autoRepos) {
-      const repoIssues = issues.filter((issue) => issue.repo === repo);
-      if (repoIssues.some((issue) => issue.workStatus === "queued" || issue.workStatus === "in_progress")) {
-        continue;
-      }
+    const plan = planAutomaticIssueQueueActions({
+      repoSettings,
+      issues,
+      activeEvaluationTargets,
+      activeWorkCount,
+      maxConcurrentIssueEvaluations: config.maxConcurrentIssueEvaluations,
+      maxConcurrentIssueWork: config.maxConcurrentIssueWork,
+    });
 
-      const nextIssue = repoIssues.find((issue) =>
-        issue.workStatus === "idle"
-        && !issue.workPrUrl
-        && issue.autoWorkEligible
-      );
-      if (nextIssue) {
-        try {
-          await queueIssueWorkInternal(nextIssue.repo, nextIssue.number, "automatic");
-        } catch (error) {
-          log.warn(
-            { err: error instanceof Error ? error.message : String(error), repo, issueNumber: nextIssue.number },
-            "Automatic issue work queue failed",
-          );
-        }
-        continue;
-      }
-
-      const nextEvaluationIssue = repoIssues.find((issue) =>
-        issue.workStatus === "idle"
-        && !issue.workPrUrl
-        && !issue.evaluationStatus
-        && !activeEvaluationTargets.has(issue.id)
-      );
-      if (!nextEvaluationIssue) {
-        continue;
-      }
-
+    for (const action of plan.work) {
       try {
-        await queueIssueEvaluationInternal(nextEvaluationIssue.repo, nextEvaluationIssue.number, "automatic");
+        await queueIssueWorkInternal(action.repo, action.number, "automatic");
       } catch (error) {
         log.warn(
-          { err: error instanceof Error ? error.message : String(error), repo, issueNumber: nextEvaluationIssue.number },
+          { err: error instanceof Error ? error.message : String(error), repo: action.repo, issueNumber: action.number },
+          "Automatic issue work queue failed",
+        );
+      }
+    }
+
+    for (const action of plan.evaluations) {
+      try {
+        await queueIssueEvaluationInternal(action.repo, action.number, "automatic");
+      } catch (error) {
+        log.warn(
+          { err: error instanceof Error ? error.message : String(error), repo: action.repo, issueNumber: action.number },
           "Automatic issue evaluation queue failed",
         );
       }
@@ -1445,7 +1520,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const canonical = formatRepoSlug(parsedRepo);
       const updated = await storage.updateRepoSettings(canonical, updates);
       notifyChange();
-      if (updates.issueAutoWork === true) {
+      if (updates.issueAutoWork === true || updates.issueAutoEvaluate === true) {
         void queueAutomaticIssueWorkInternal().catch((error) => {
           log.warn(
             { err: error instanceof Error ? error.message : String(error), repo: canonical },

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -42,6 +42,8 @@ describe("DEFAULT_CONFIG", () => {
       "deploymentCheckDelayMs",
       "deploymentCheckTimeoutMs",
       "deploymentCheckPollIntervalMs",
+      "maxConcurrentIssueEvaluations",
+      "maxConcurrentIssueWork",
       "watchedRepos",
       "trustedReviewers",
       "ignoredBots",
@@ -100,11 +102,19 @@ describe("DEFAULT_CONFIG", () => {
       "deploymentCheckDelayMs",
       "deploymentCheckTimeoutMs",
       "deploymentCheckPollIntervalMs",
+      "maxConcurrentIssueEvaluations",
+      "maxConcurrentIssueWork",
     ] as const;
     for (const field of numericFields) {
       assert.equal(typeof DEFAULT_CONFIG[field], "number", `${field} should be a number`);
       assert.ok(DEFAULT_CONFIG[field] > 0, `${field} should be positive, got ${DEFAULT_CONFIG[field]}`);
     }
+  });
+
+  it("caps issue evaluation and work concurrency conservatively by default", () => {
+    // Evaluations default to 2 (low, GitHub-API friendly), work default to 1 (matches healing-run cap).
+    assert.equal(DEFAULT_CONFIG.maxConcurrentIssueEvaluations, 2);
+    assert.equal(DEFAULT_CONFIG.maxConcurrentIssueWork, 1);
   });
 
   it("has a valid codingAgent enum value", () => {

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -27,6 +27,8 @@ export const DEFAULT_CONFIG: Config = {
   deploymentCheckDelayMs: 60000,
   deploymentCheckTimeoutMs: 600000,
   deploymentCheckPollIntervalMs: 15000,
+  maxConcurrentIssueEvaluations: 2,
+  maxConcurrentIssueWork: 1,
   watchedRepos: [],
   trustedReviewers: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -484,6 +484,7 @@ describe("MemStorage", () => {
         repo: "acme/widgets",
         autoCreateReleases: false,
         ownPrsOnly: true,
+        issueAutoEvaluate: false,
         issueAutoWork: false,
       }]);
     });
@@ -495,10 +496,12 @@ describe("MemStorage", () => {
         issueAutoWork: true,
       });
 
+      // Enabling auto-work coerces auto-evaluate to true (dependent setting).
       assert.deepEqual(updated, {
         repo: "acme/widgets",
         autoCreateReleases: false,
         ownPrsOnly: false,
+        issueAutoEvaluate: true,
         issueAutoWork: true,
       });
 
@@ -510,6 +513,7 @@ describe("MemStorage", () => {
         repo: "acme/widgets",
         autoCreateReleases: false,
         ownPrsOnly: false,
+        issueAutoEvaluate: true,
         issueAutoWork: true,
       });
     });

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -265,6 +265,7 @@ export class MemStorage implements IStorage {
       repo,
       autoCreateReleases: false,
       ownPrsOnly: true,
+      issueAutoEvaluate: false,
       issueAutoWork: false,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
@@ -298,6 +299,7 @@ export class MemStorage implements IStorage {
           repo,
           autoCreateReleases: false,
           ownPrsOnly: true,
+          issueAutoEvaluate: false,
           issueAutoWork: false,
         });
       }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1171,12 +1171,14 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       repo: string;
       autoCreateReleases: boolean;
       ownPrsOnly: boolean;
+      issueAutoEvaluate: boolean;
       issueAutoWork: boolean;
     }>;
     assert.deepEqual(initial, [{
       repo: "acme/widgets",
       autoCreateReleases: false,
       ownPrsOnly: true,
+      issueAutoEvaluate: false,
       issueAutoWork: false,
     }]);
 
@@ -1197,12 +1199,16 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       repo: string;
       autoCreateReleases: boolean;
       ownPrsOnly: boolean;
+      issueAutoEvaluate: boolean;
       issueAutoWork: boolean;
     };
+    // Enabling auto-work implicitly enables auto-evaluate — they're dependent settings,
+    // not independent flags. Verifies coercion in applyWatchedRepoUpdate.
     assert.deepEqual(updated, {
       repo: "acme/widgets",
       autoCreateReleases: false,
       ownPrsOnly: false,
+      issueAutoEvaluate: true,
       issueAutoWork: true,
     });
 
@@ -1211,6 +1217,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       repo: "acme/widgets",
       autoCreateReleases: false,
       ownPrsOnly: false,
+      issueAutoEvaluate: true,
       issueAutoWork: true,
     });
   } finally {
@@ -1242,14 +1249,47 @@ test("PATCH /api/repos/settings can update only ownPrsOnly", async () => {
       repo: string;
       autoCreateReleases: boolean;
       ownPrsOnly: boolean;
+      issueAutoEvaluate: boolean;
       issueAutoWork: boolean;
     };
     assert.deepEqual(updated, {
       repo: "acme/widgets",
       autoCreateReleases: false,
       ownPrsOnly: false,
+      issueAutoEvaluate: false,
       issueAutoWork: false,
     });
+  } finally {
+    await harness.close();
+  }
+});
+
+test("PATCH /api/repos/settings accepts issueAutoEvaluate independently of auto-work", async () => {
+  // Independence matters: users should be able to evaluate without committing to running the agent.
+  const harness = await createHarness();
+  await harness.storage.updateRepoSettings("acme/widgets", {
+    autoCreateReleases: false,
+    ownPrsOnly: true,
+  });
+
+  try {
+    const updateResponse = await fetch(`${harness.baseUrl}/api/repos/settings`, {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        repo: "acme/widgets",
+        issueAutoEvaluate: true,
+      }),
+    });
+    assert.equal(updateResponse.status, 200);
+    const updated = await updateResponse.json() as {
+      issueAutoEvaluate: boolean;
+      issueAutoWork: boolean;
+    };
+    assert.equal(updated.issueAutoEvaluate, true);
+    assert.equal(updated.issueAutoWork, false);
   } finally {
     await harness.close();
   }
@@ -1463,7 +1503,7 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
     listRepos: async () => [],
     listRepoSettings: async () => [],
     addRepo: async () => ({ repo: "acme/widgets" }),
-    updateRepoSettings: async () => ({ repo: "acme/widgets", autoCreateReleases: false, ownPrsOnly: true, issueAutoWork: false }),
+    updateRepoSettings: async () => ({ repo: "acme/widgets", autoCreateReleases: false, ownPrsOnly: true, issueAutoEvaluate: false, issueAutoWork: false }),
     syncRepos: async () => ({ ok: true }),
     createManualRelease: async () => undefined,
     listPRs: async () => [],

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -260,9 +260,15 @@ export async function registerRoutes(
         repo: z.string().min(1),
         autoCreateReleases: z.boolean().optional(),
         ownPrsOnly: z.boolean().optional(),
+        issueAutoEvaluate: z.boolean().optional(),
         issueAutoWork: z.boolean().optional(),
       }).refine(
-        (value) => value.autoCreateReleases !== undefined || value.ownPrsOnly !== undefined || value.issueAutoWork !== undefined,
+        (value) => (
+          value.autoCreateReleases !== undefined
+          || value.ownPrsOnly !== undefined
+          || value.issueAutoEvaluate !== undefined
+          || value.issueAutoWork !== undefined
+        ),
         "At least one repository setting must be provided",
       ).parse(req.body);
       const { repo, ...updates } = payload;

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -87,6 +87,8 @@ type ConfigRow = {
   deployment_check_delay_ms: number;
   deployment_check_timeout_ms: number;
   deployment_check_poll_interval_ms: number;
+  max_concurrent_issue_evaluations: number;
+  max_concurrent_issue_work: number;
   trusted_reviewers_json: string;
   ignored_bots_json: string;
 };
@@ -152,6 +154,7 @@ type WatchedRepoRow = {
   repo: string;
   auto_create_releases: number;
   own_prs_only: number;
+  issue_auto_evaluate: number;
   issue_auto_work: number;
 };
 
@@ -853,6 +856,10 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("watched_repos", "auto_create_releases", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("watched_repos", "own_prs_only", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("watched_repos", "issue_auto_work", "INTEGER NOT NULL DEFAULT 0");
+    this.ensureColumn("watched_repos", "issue_auto_evaluate", "INTEGER NOT NULL DEFAULT 0");
+    this.exec("UPDATE watched_repos SET issue_auto_evaluate = 1 WHERE issue_auto_work = 1 AND issue_auto_evaluate = 0");
+    this.ensureColumn("config", "max_concurrent_issue_evaluations", "INTEGER NOT NULL DEFAULT 2");
+    this.ensureColumn("config", "max_concurrent_issue_work", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
@@ -959,6 +966,8 @@ export class SqliteStorage implements IStorage {
       deploymentCheckDelayMs: row.deployment_check_delay_ms ?? DEFAULT_CONFIG.deploymentCheckDelayMs,
       deploymentCheckTimeoutMs: row.deployment_check_timeout_ms ?? DEFAULT_CONFIG.deploymentCheckTimeoutMs,
       deploymentCheckPollIntervalMs: row.deployment_check_poll_interval_ms ?? DEFAULT_CONFIG.deploymentCheckPollIntervalMs,
+      maxConcurrentIssueEvaluations: row.max_concurrent_issue_evaluations ?? DEFAULT_CONFIG.maxConcurrentIssueEvaluations,
+      maxConcurrentIssueWork: row.max_concurrent_issue_work ?? DEFAULT_CONFIG.maxConcurrentIssueWork,
       watchedRepos,
       trustedReviewers: JSON.parse(row.trusted_reviewers_json),
       ignoredBots: JSON.parse(row.ignored_bots_json),
@@ -1003,9 +1012,11 @@ export class SqliteStorage implements IStorage {
           deployment_check_delay_ms,
           deployment_check_timeout_ms,
           deployment_check_poll_interval_ms,
+          max_concurrent_issue_evaluations,
+          max_concurrent_issue_work,
           trusted_reviewers_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -1033,6 +1044,8 @@ export class SqliteStorage implements IStorage {
           deployment_check_delay_ms = excluded.deployment_check_delay_ms,
           deployment_check_timeout_ms = excluded.deployment_check_timeout_ms,
           deployment_check_poll_interval_ms = excluded.deployment_check_poll_interval_ms,
+          max_concurrent_issue_evaluations = excluded.max_concurrent_issue_evaluations,
+          max_concurrent_issue_work = excluded.max_concurrent_issue_work,
           trusted_reviewers_json = excluded.trusted_reviewers_json,
         ignored_bots_json = excluded.ignored_bots_json
       `,
@@ -1063,6 +1076,8 @@ export class SqliteStorage implements IStorage {
         config.deploymentCheckDelayMs,
         config.deploymentCheckTimeoutMs,
         config.deploymentCheckPollIntervalMs,
+        config.maxConcurrentIssueEvaluations,
+        config.maxConcurrentIssueWork,
         JSON.stringify(config.trustedReviewers),
         JSON.stringify(config.ignoredBots),
       );
@@ -1071,10 +1086,11 @@ export class SqliteStorage implements IStorage {
       for (const repo of config.watchedRepos) {
         const settings = watchedRepoSettings.get(repo);
         this.run(
-          "INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_work) VALUES (?, ?, ?, ?)",
+          "INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work) VALUES (?, ?, ?, ?, ?)",
           repo,
           settings?.auto_create_releases ?? 0,
           settings?.own_prs_only ?? 1,
+          settings?.issue_auto_evaluate ?? 0,
           settings?.issue_auto_work ?? 0,
         );
       }
@@ -1086,13 +1102,14 @@ export class SqliteStorage implements IStorage {
       repo: row.repo,
       autoCreateReleases: Boolean(row.auto_create_releases),
       ownPrsOnly: Boolean(row.own_prs_only ?? 1),
+      issueAutoEvaluate: Boolean(row.issue_auto_evaluate ?? 0),
       issueAutoWork: Boolean(row.issue_auto_work ?? 0),
     };
   }
 
   private getWatchedRepoRows(): WatchedRepoRow[] {
     return this.all<WatchedRepoRow>(
-      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_work FROM watched_repos ORDER BY repo ASC",
+      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work FROM watched_repos ORDER BY repo ASC",
     );
   }
 
@@ -1721,7 +1738,8 @@ export class SqliteStorage implements IStorage {
              auto_heal_ci, max_healing_attempts_per_session,
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,
              auto_heal_deployments, deployment_check_delay_ms, deployment_check_timeout_ms,
-             deployment_check_poll_interval_ms, trusted_reviewers_json, ignored_bots_json
+             deployment_check_poll_interval_ms, max_concurrent_issue_evaluations, max_concurrent_issue_work,
+             trusted_reviewers_json, ignored_bots_json
       FROM config
       WHERE id = 1
     `);
@@ -1742,7 +1760,7 @@ export class SqliteStorage implements IStorage {
 
   async getRepoSettings(repo: string): Promise<WatchedRepo | undefined> {
     const row = this.get<WatchedRepoRow>(
-      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_work FROM watched_repos WHERE repo = ?",
+      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work FROM watched_repos WHERE repo = ?",
       repo,
     );
     return row ? this.parseWatchedRepoRow(row) : undefined;
@@ -1756,6 +1774,7 @@ export class SqliteStorage implements IStorage {
       repo,
       autoCreateReleases: false,
       ownPrsOnly: true,
+      issueAutoEvaluate: false,
       issueAutoWork: false,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
@@ -1763,16 +1782,18 @@ export class SqliteStorage implements IStorage {
     this.withWriteTransaction(() => {
       this.run(
         `
-          INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_work)
-          VALUES (?, ?, ?, ?)
+          INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work)
+          VALUES (?, ?, ?, ?, ?)
           ON CONFLICT(repo) DO UPDATE SET
             auto_create_releases = excluded.auto_create_releases,
             own_prs_only = excluded.own_prs_only,
+            issue_auto_evaluate = excluded.issue_auto_evaluate,
             issue_auto_work = excluded.issue_auto_work
         `,
         next.repo,
         Number(next.autoCreateReleases),
         Number(next.ownPrsOnly),
+        Number(next.issueAutoEvaluate),
         Number(next.issueAutoWork),
       );
     });

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -226,6 +226,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     repo: "alex-morgan-o/lolodex",
     autoCreateReleases: false,
     ownPrsOnly: false,
+    issueAutoEvaluate: false,
     issueAutoWork: false,
   });
   assert.equal(runtime.drainMode, true);
@@ -479,10 +480,12 @@ test("SqliteStorage updateRepoSettings tracks a previously untracked repo", asyn
       issueAutoWork: true,
     });
 
+    // Auto-work coerces auto-evaluate to true.
     assert.deepEqual(updated, {
       repo: "acme/widgets",
       autoCreateReleases: false,
       ownPrsOnly: false,
+      issueAutoEvaluate: true,
       issueAutoWork: true,
     });
 
@@ -494,6 +497,7 @@ test("SqliteStorage updateRepoSettings tracks a previously untracked repo", asyn
       repo: "acme/widgets",
       autoCreateReleases: false,
       ownPrsOnly: false,
+      issueAutoEvaluate: true,
       issueAutoWork: true,
     });
   } finally {

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -397,9 +397,13 @@ export function applyWatchedRepoUpdate(
   existing: WatchedRepo,
   updates: Partial<Omit<WatchedRepo, "repo">>,
 ): WatchedRepo {
-  return watchedRepoSchema.parse({
+  const merged = {
     ...existing,
     ...updates,
     repo: existing.repo,
-  });
+  };
+  if (merged.issueAutoWork) {
+    merged.issueAutoEvaluate = true;
+  }
+  return watchedRepoSchema.parse(merged);
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -584,6 +584,8 @@ export const configSchema = z.object({
   deploymentCheckDelayMs: z.number(),
   deploymentCheckTimeoutMs: z.number(),
   deploymentCheckPollIntervalMs: z.number(),
+  maxConcurrentIssueEvaluations: z.number().int().positive().default(2),
+  maxConcurrentIssueWork: z.number().int().positive().default(1),
   watchedRepos: z.array(z.string()),
   trustedReviewers: z.array(z.string()),
   ignoredBots: z.array(z.string()),
@@ -594,6 +596,7 @@ export const watchedRepoSchema = z.object({
   repo: z.string(),
   autoCreateReleases: z.boolean(),
   ownPrsOnly: z.boolean(),
+  issueAutoEvaluate: z.boolean(),
   issueAutoWork: z.boolean(),
 });
 export type WatchedRepo = z.infer<typeof watchedRepoSchema>;


### PR DESCRIPTION
## Summary

- Splits per-repo `issueAutoWork` into two toggles: `issueAutoEvaluate` (classify every issue) and `issueAutoWork` (run the agent on approved ones; depends on auto-evaluate).
- Watcher sweep now drains every unevaluated issue per tick — no more one-per-tick — capped globally by new config knobs `maxConcurrentIssueEvaluations` (default 2) and `maxConcurrentIssueWork` (default 1). Round-robin across repos prevents starvation.
- Auto-queues `work_issue` jobs for approved+eligible issues when auto-work is on, subject to the work cap and existing per-repo single-flight.
- Reuses the existing `background_jobs` queue, leases, dedupe, and retries — no new queue infrastructure.
- Sweep core lives in pure `planAutomaticIssueQueueActions(...)` for unit testability; the wrapper just fetches state and dispatches.
- Settings UI gains an "Issue auto-evaluate" segmented control next to "Issue work mode". When auto-work is on, auto-evaluate is implied (coerced in `applyWatchedRepoUpdate`) and the auto-evaluate control disables. A warning banner appears on each repo card when global `config.autoIssues` is off, so users understand why per-repo toggles aren't acting.
- SQLite gets idempotent migrations for `issue_auto_evaluate`, `max_concurrent_issue_evaluations`, `max_concurrent_issue_work`, plus a one-time backfill setting `issue_auto_evaluate = 1` wherever `issue_auto_work = 1` already.

## Test plan

- [x] `npm run check` — clean
- [x] `npm test` — all tests pass that aren't blocked by the pre-existing local `codex` dyld issue
- [x] 9 new `planAutomaticIssueQueueActions` tests covering: no-op when both flags off, evaluate-cap respected, in-flight counted against cap, auto-work-off skips work, auto-work-on queues work, per-repo single-flight on work, round-robin fairness, no double-queue, work cap saturation
- [ ] Manual: in dev, turn `issueAutoEvaluate` on for a repo with a backlog; verify `SELECT * FROM background_jobs WHERE kind='evaluate_issue'` shows at most `maxConcurrentIssueEvaluations` active rows at any time
- [ ] Manual: toggle global Issues auto off in the header popover; verify the warning banner appears under each watched-repo card in Settings