### PR TITLE
fix: stop duplicate issue work failure notices

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -334,6 +334,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
     ["stale filter", "issue-stale-filter"],
     ["issue body markdown", "issue-body-markdown"],
     ["issue work failed", "issue-work-failed"],
+    ["clear issue failures action", "button-clear-issue-failures"],
     ["issue work stage", "issue-work-stage"],
     ["issue work attempt", "issue-work-attempt"],
     ["issue auto work state", "issue-auto-work-state"],

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -285,6 +285,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
 
   assertHasExpression(sourceFile, "feedback retry action", /\bretryMutation\b/);
   assertHasExpression(sourceFile, "feedback manual decisions", /\[\s*["']accept["']\s*,\s*["']reject["']\s*,\s*["']flag["']\s*\]/);
+  assertHasExpression(sourceFile, "dashboard error scroll action", /\bscrollToDashboardErrors\b/);
 
   for (const [label, endpoint] of [
     ["active PR API", "/api/prs"],

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -278,6 +278,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["ask submit", "button-ask"],
     ["dashboard error pill", "dashboard-error-pill"],
     ["dashboard errors panel", "dashboard-errors-panel"],
+    ["dashboard clear issue failure", "dashboard-clear-issue-failure"],
   ] satisfies SourceExpectation[]) {
     assertHasTestId(sourceFile, label, testId);
   }
@@ -298,6 +299,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   }
 
   assertHasApiRequest(sourceFile, "failed activity clear mutation", "DELETE", "/api/activities/failed");
+  assertHasApiRequest(sourceFile, "issue failure clear mutation", "DELETE", "/api/issues/work/failures");
   assertHasApiRequest(sourceFile, "ask agent mutation", "POST", /`\/api\/prs\/\$\{prId\}\/questions`/);
   assertHasTestId(sourceFile, "dashboard drain banner", "dashboard-drain-banner");
   assertHasTestId(sourceFile, "dashboard drain reason", "dashboard-drain-reason");

--- a/client/src/lib/hashRouteSearch.test.ts
+++ b/client/src/lib/hashRouteSearch.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { normalizeHashRouteSearch } from "./hashRouteSearch";
+import { normalizeHashRouteSearch, normalizeInitialHashRoute } from "./hashRouteSearch";
 
 test("normalizeHashRouteSearch merges hash query params with existing search params", () => {
   assert.equal(
@@ -18,4 +18,24 @@ test("normalizeHashRouteSearch lowercases hash query keys before matching", () =
 
 test("normalizeHashRouteSearch leaves hashes without query params unchanged", () => {
   assert.equal(normalizeHashRouteSearch("https://example.test/#/logs"), null);
+});
+
+test("normalizeInitialHashRoute preserves dashboard anchor ids as scroll targets", () => {
+  assert.deepEqual(
+    normalizeInitialHashRoute("https://example.test/?level=warn#dashboard-errors"),
+    {
+      href: "https://example.test/?level=warn#/",
+      anchorId: "dashboard-errors",
+    },
+  );
+});
+
+test("normalizeInitialHashRoute preserves hash route query normalization", () => {
+  assert.deepEqual(
+    normalizeInitialHashRoute("https://example.test/?level=warn#/logs?LEVEL=info"),
+    {
+      href: "https://example.test/?level=info#/logs",
+      anchorId: null,
+    },
+  );
 });

--- a/client/src/lib/hashRouteSearch.ts
+++ b/client/src/lib/hashRouteSearch.ts
@@ -1,3 +1,8 @@
+export type InitialHashRouteNormalization = {
+  href: string;
+  anchorId: string | null;
+};
+
 export function normalizeHashRouteSearch(href: string): string | null {
   const url = new URL(href);
   const rawHash = url.hash;
@@ -18,4 +23,21 @@ export function normalizeHashRouteSearch(href: string): string | null {
   url.search = searchParams.toString();
 
   return url.href;
+}
+
+export function normalizeInitialHashRoute(href: string): InitialHashRouteNormalization | null {
+  const normalizedSearchHref = normalizeHashRouteSearch(href);
+  const url = new URL(normalizedSearchHref ?? href);
+  const rawHash = url.hash;
+
+  if (!rawHash || rawHash.startsWith("#/")) {
+    return normalizedSearchHref ? { href: normalizedSearchHref, anchorId: null } : null;
+  }
+
+  url.hash = "#/";
+
+  return {
+    href: url.href,
+    anchorId: decodeURIComponent(rawHash.slice(1)),
+  };
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,14 +1,17 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
-import { normalizeHashRouteSearch } from "./lib/hashRouteSearch";
+import { normalizeInitialHashRoute } from "./lib/hashRouteSearch";
 import "./index.css";
 
 // wouter's hash router expects the path in location.hash and the query in
-// location.search. Normalize deep links like #/logs?level=info before mount.
+// location.search. Normalize deep links like #/logs?level=info before mount,
+// and preserve legacy dashboard anchors like #dashboard-errors.
+let initialAnchorId: string | null = null;
 {
-  const normalizedHref = normalizeHashRouteSearch(window.location.href);
-  if (normalizedHref) {
-    history.replaceState(history.state, "", normalizedHref);
+  const normalized = normalizeInitialHashRoute(window.location.href);
+  if (normalized) {
+    initialAnchorId = normalized.anchorId;
+    history.replaceState(history.state, "", normalized.href);
   }
 }
 
@@ -17,3 +20,20 @@ if (!window.location.hash) {
 }
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+if (initialAnchorId) {
+  const startedAt = Date.now();
+  const scrollWhenReady = () => {
+    const target = document.getElementById(initialAnchorId);
+    if (target) {
+      target.scrollIntoView({ block: "start" });
+      return;
+    }
+
+    if (Date.now() - startedAt < 2_000) {
+      window.setTimeout(scrollWhenReady, 50);
+    }
+  };
+
+  window.requestAnimationFrame(scrollWhenReady);
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -91,6 +91,10 @@ function parseIssueTargetId(targetId: string): { repo: string; number: number } 
   return { repo, number };
 }
 
+function scrollToDashboardErrors() {
+  document.getElementById("dashboard-errors")?.scrollIntoView({ block: "start" });
+}
+
 function getPRFeedbackFailureReason(pr: PR): string | null {
   const failedItem = pr.feedbackItems.find((item) =>
     (item.status === "failed" || item.status === "warning") && Boolean(item.statusReason),
@@ -1359,15 +1363,16 @@ export default function Dashboard() {
               <option value="claude">claude</option>
             </select>
             {activeErrorCount > 0 && (
-              <a
-                href="#dashboard-errors"
+              <button
+                type="button"
+                onClick={scrollToDashboardErrors}
                 data-testid="dashboard-error-pill"
                 className="inline-flex items-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 px-2 py-0.5 text-[11px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
                 <AlertTriangle className="h-3 w-3" aria-hidden="true" />
                 errors
                 <span className="font-mono">{activeErrorCount}</span>
-              </a>
+              </button>
             )}
             <ActivityMenu
               activities={activities}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type MouseEvent } from "rea
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { Activity as ActivityIcon, AlertTriangle, Bot } from "lucide-react";
+import { Activity as ActivityIcon, AlertTriangle, Bot, Trash2 } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, LogEntry, OperatorWarning, PR, PRQuestion, RuntimeState, WatchedRepo } from "@shared/schema";
 import { AppHeader } from "@/components/AppHeader";
@@ -74,6 +74,21 @@ function latestActivityForTarget(activities: ActivityItem[], targetId: string): 
     }
     return latest;
   }, undefined as ActivityItem | undefined);
+}
+
+function parseIssueTargetId(targetId: string): { repo: string; number: number } | null {
+  const separator = targetId.lastIndexOf("#");
+  if (separator === -1) {
+    return null;
+  }
+
+  const repo = targetId.slice(0, separator);
+  const number = Number(targetId.slice(separator + 1));
+  if (!repo || !Number.isInteger(number) || number <= 0) {
+    return null;
+  }
+
+  return { repo, number };
 }
 
 function getPRFeedbackFailureReason(pr: PR): string | null {
@@ -368,7 +383,15 @@ function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
   );
 }
 
-function DashboardErrorsPanel({ activities }: { activities: ActivitySnapshot }) {
+function DashboardErrorsPanel({
+  activities,
+  onClearIssueFailure,
+  isClearingIssueFailure,
+}: {
+  activities: ActivitySnapshot;
+  onClearIssueFailure: (activity: ActivityItem) => void;
+  isClearingIssueFailure: boolean;
+}) {
   if (activities.failed.length === 0) {
     return null;
   }
@@ -403,16 +426,36 @@ function DashboardErrorsPanel({ activities }: { activities: ActivitySnapshot }) 
                   <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
                 )}
               </div>
-              {activity.targetUrl && (
-                <a
-                  href={activity.targetUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                >
-                  Open
-                </a>
-              )}
+              <div className="flex shrink-0 flex-wrap justify-end gap-2">
+                {activity.kind === "work_issue" && parseIssueTargetId(activity.targetId) && (
+                  <button
+                    type="button"
+                    onClick={() => onClearIssueFailure(activity)}
+                    disabled={isClearingIssueFailure}
+                    className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                    data-testid="dashboard-clear-issue-failure"
+                  >
+                    {isClearingIssueFailure ? (
+                      "Clearing"
+                    ) : (
+                      <>
+                        <Trash2 className="h-3 w-3" aria-hidden="true" />
+                        Clear
+                      </>
+                    )}
+                  </button>
+                )}
+                {activity.targetUrl && (
+                  <a
+                    href={activity.targetUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                  >
+                    Open
+                  </a>
+                )}
+              </div>
             </div>
             {activity.lastError && (
               <div
@@ -1259,6 +1302,28 @@ export default function Dashboard() {
     },
   });
 
+  const clearIssueFailureMutation = useMutation({
+    mutationFn: async (activity: ActivityItem) => {
+      const issueTarget = parseIssueTargetId(activity.targetId);
+      if (!issueTarget) {
+        throw new Error(`Could not parse issue target ${activity.targetId}`);
+      }
+
+      const res = await apiRequest("DELETE", "/api/issues/work/failures", issueTarget);
+      return res.json() as Promise<{ repo: string; number: number; id: string }>;
+    },
+    onSuccess: (issue) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/issues"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] });
+      toast({ description: `Cleared failed work attempts for #${issue.number}.` });
+    },
+    onError: (error) => {
+      showMutationError("Could not clear issue failure", error);
+    },
+  });
+
   return (
     <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
       <UpdateBanner />
@@ -1316,7 +1381,11 @@ export default function Dashboard() {
 
       <OnboardingPanel />
       <OperatorWarningsBanner warnings={activities.warnings} />
-      <DashboardErrorsPanel activities={activities} />
+      <DashboardErrorsPanel
+        activities={activities}
+        onClearIssueFailure={(activity) => clearIssueFailureMutation.mutate(activity)}
+        isClearingIssueFailure={clearIssueFailureMutation.isPending}
+      />
       <DashboardDrainBanner runtimeState={runtimeState} />
 
       <div className="flex flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -446,7 +446,7 @@ export default function Issues() {
         repo: issue.repo,
         number: issue.number,
       });
-      return res.json() as Promise<Issue>;
+      return res.json() as Promise<{ repo: string; number: number; id: string }>;
     },
     onSuccess: async (issue) => {
       await Promise.all([

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -827,28 +827,6 @@ export default function Issues() {
                         </>
                       )}
                     </button>
-                    {selectedIssue.workStatus === "failed" && (
-                      <button
-                        type="button"
-                        onClick={() => clearFailuresMutation.mutate(selectedIssue)}
-                        disabled={clearFailuresMutation.isPending}
-                        title="Clear failed issue work attempts"
-                        data-testid="button-clear-issue-failures"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-destructive/50 bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        {clearFailuresMutation.isPending ? (
-                          <>
-                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                            Clearing
-                          </>
-                        ) : (
-                          <>
-                            <Trash2 className="h-3.5 w-3.5" />
-                            Clear failures
-                          </>
-                        )}
-                      </button>
-                    )}
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-1">
@@ -891,12 +869,34 @@ export default function Issues() {
                 {selectedIssue.workStatus === "failed" && selectedIssue.lastError && (
                   <div
                     data-testid="issue-work-failed"
-                    className="mt-3 border border-destructive/40 bg-destructive/10 px-3 py-2 text-[11px] text-destructive"
+                    className="mt-3 border border-destructive/40 bg-destructive/10 text-[11px] text-destructive"
                   >
-                    <div className="text-[10px] uppercase tracking-wider text-destructive/70">
-                      Issue work failed
+                    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-destructive/20 px-3 py-2">
+                      <div className="text-[10px] uppercase tracking-wider text-destructive/70">
+                        Issue work failed
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => clearFailuresMutation.mutate(selectedIssue)}
+                        disabled={clearFailuresMutation.isPending}
+                        title="Clear failed issue work attempts"
+                        data-testid="button-clear-issue-failures"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-destructive/50 bg-background/40 px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        {clearFailuresMutation.isPending ? (
+                          <>
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            Clearing
+                          </>
+                        ) : (
+                          <>
+                            <Trash2 className="h-3.5 w-3.5" />
+                            Clear failures
+                          </>
+                        )}
+                      </button>
                     </div>
-                    <div className="mt-1 whitespace-pre-wrap leading-5">
+                    <div className="max-h-80 overflow-auto whitespace-pre-wrap px-3 py-2 leading-5">
                       {selectedIssue.lastError}
                     </div>
                   </div>

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLink, Loader2, RefreshCw, ShieldCheck, Wrench } from "lucide-react";
+import { ExternalLink, Loader2, RefreshCw, ShieldCheck, Trash2, Wrench } from "lucide-react";
 import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -462,6 +462,28 @@ export default function Issues() {
     },
   });
 
+  const clearFailuresMutation = useMutation({
+    mutationFn: async (issue: Issue) => {
+      const res = await apiRequest("DELETE", "/api/issues/work/failures", {
+        repo: issue.repo,
+        number: issue.number,
+      });
+      return res.json() as Promise<Issue>;
+    },
+    onSuccess: async (issue) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] }),
+      ]);
+      toast({ description: `Cleared failed work attempts for #${issue.number}.` });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Could not clear issue failures: ${error.message}` });
+    },
+  });
+
   const evaluateMutation = useMutation({
     mutationFn: async (issue: Issue) => {
       const res = await apiRequest("POST", "/api/issues/evaluate", {
@@ -805,6 +827,28 @@ export default function Issues() {
                         </>
                       )}
                     </button>
+                    {selectedIssue.workStatus === "failed" && (
+                      <button
+                        type="button"
+                        onClick={() => clearFailuresMutation.mutate(selectedIssue)}
+                        disabled={clearFailuresMutation.isPending}
+                        title="Clear failed issue work attempts"
+                        data-testid="button-clear-issue-failures"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-destructive/50 bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        {clearFailuresMutation.isPending ? (
+                          <>
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            Clearing
+                          </>
+                        ) : (
+                          <>
+                            <Trash2 className="h-3.5 w-3.5" />
+                            Clear failures
+                          </>
+                        )}
+                      </button>
+                    )}
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-1">

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -148,7 +148,7 @@ export type AppRuntime = {
   getIssue(repo: string, number: number): Promise<Issue>;
   evaluateIssue(repo: string, number: number): Promise<Issue>;
   workIssue(repo: string, number: number): Promise<Issue>;
-  clearIssueWorkFailures(repo: string, number: number): Promise<Issue>;
+  clearIssueWorkFailures(repo: string, number: number): Promise<{ repo: string; number: number; id: string; cleared: number }>;
 };
 
 function getErrorMessage(error: unknown): string {
@@ -1005,7 +1005,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     return applyIssueWorkState(issue, { includePrMergeability: true });
   }
 
-  async function clearIssueWorkFailuresInternal(repoInput: string, number: number): Promise<Issue> {
+  async function clearIssueWorkFailuresInternal(
+    repoInput: string,
+    number: number,
+  ): Promise<{ repo: string; number: number; id: string; cleared: number }> {
     const parsedRepo = parseRepoSlug(repoInput);
     if (!parsedRepo) {
       throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
@@ -1017,13 +1020,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
     }
 
+    const targetId = formatIssueTargetId(canonical, number);
     const cleared = await storage.clearFailedBackgroundJobs({
       kind: "work_issue",
-      targetId: formatIssueTargetId(canonical, number),
+      targetId,
     });
 
     await storage.addLog(
-      formatIssueTargetId(canonical, number),
+      targetId,
       "info",
       cleared === 1 ? "Cleared 1 failed issue work attempt" : `Cleared ${cleared} failed issue work attempts`,
       {
@@ -1037,7 +1041,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     );
 
     notifyChange();
-    return getIssueInternal(canonical, number);
+    return {
+      repo: canonical,
+      number,
+      id: targetId,
+      cleared,
+    };
   }
 
   async function queueAutomaticIssueWorkInternal(): Promise<void> {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -148,6 +148,7 @@ export type AppRuntime = {
   getIssue(repo: string, number: number): Promise<Issue>;
   evaluateIssue(repo: string, number: number): Promise<Issue>;
   workIssue(repo: string, number: number): Promise<Issue>;
+  clearIssueWorkFailures(repo: string, number: number): Promise<Issue>;
 };
 
 function getErrorMessage(error: unknown): string {
@@ -1004,6 +1005,41 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     return applyIssueWorkState(issue, { includePrMergeability: true });
   }
 
+  async function clearIssueWorkFailuresInternal(repoInput: string, number: number): Promise<Issue> {
+    const parsedRepo = parseRepoSlug(repoInput);
+    if (!parsedRepo) {
+      throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+    }
+
+    const canonical = formatRepoSlug(parsedRepo);
+    const config = await storage.getConfig();
+    if (!config.watchedRepos.includes(canonical)) {
+      throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
+    }
+
+    const cleared = await storage.clearFailedBackgroundJobs({
+      kind: "work_issue",
+      targetId: formatIssueTargetId(canonical, number),
+    });
+
+    await storage.addLog(
+      formatIssueTargetId(canonical, number),
+      "info",
+      cleared === 1 ? "Cleared 1 failed issue work attempt" : `Cleared ${cleared} failed issue work attempts`,
+      {
+        metadata: {
+          repo: canonical,
+          issueNumber: number,
+          cleared,
+          stage: "reset_failures",
+        },
+      },
+    );
+
+    notifyChange();
+    return getIssueInternal(canonical, number);
+  }
+
   async function queueAutomaticIssueWorkInternal(): Promise<void> {
     const [runtimeState, config, repoSettings, issues, evaluationJobs, workJobs] = await Promise.all([
       storage.getRuntimeState(),
@@ -1575,6 +1611,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     async workIssue(repoInput, number) {
       return queueIssueWorkInternal(repoInput, number, "manual");
+    },
+
+    async clearIssueWorkFailures(repoInput, number) {
+      return clearIssueWorkFailuresInternal(repoInput, number);
     },
 
     async listPRs(view = "active") {

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { TerminalBabysitterError } from "./babysitter";
-import { CancelBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
+import { BackgroundJobDispatcher, CancelBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
 import { createBackgroundJobHandlers } from "./backgroundJobHandlers";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
@@ -25,6 +25,25 @@ async function seedPR(storage: MemStorage): Promise<string> {
     lastChecked: null,
   });
   return pr.id;
+}
+
+async function waitForCondition(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 250,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (true) {
+    if (await condition()) {
+      return;
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(`Condition not met within ${timeoutMs}ms`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 test("answer_pr_question handler delegates for non-terminal questions", async () => {
@@ -303,6 +322,100 @@ test("work_issue handler opens a PR after a successful repair run", async () => 
     issueLogs.map((entry) => entry.metadata?.stage),
     ["started", "working", "verifying", "opening_pr", "completed"],
   );
+});
+
+test("work_issue handler stops rejected repair runs after one failed notice", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["acme/widgets"],
+    codingAgent: "claude",
+    postGitHubProgressReplies: true,
+  });
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "work_issue",
+    "acme/widgets#17",
+    "work_issue:acme/widgets#17",
+    {
+      repo: "acme/widgets",
+      issueNumber: 17,
+      issueTitle: "Fix the toggle",
+      issueUrl: "https://github.com/acme/widgets/issues/17",
+      baseBranch: "main",
+    },
+  );
+  const commentsCreated: Array<Record<string, unknown>> = [];
+  let repairCalls = 0;
+  const octokit = {
+    issues: {
+      get: async () => ({
+        data: {
+          number: 17,
+          title: "Fix the toggle",
+          body: "The toggle is stuck",
+          html_url: "https://github.com/acme/widgets/issues/17",
+          user: { login: "alice" },
+          labels: [{ name: "bug" }],
+          assignees: [],
+          comments: 2,
+          created_at: "2026-05-03T17:00:00.000Z",
+          updated_at: "2026-05-03T18:00:00.000Z",
+        },
+      }),
+      createComment: async (params: Record<string, unknown>) => {
+        commentsCreated.push(params);
+        return { data: { id: 123 } };
+      },
+    },
+    pulls: {
+      create: async () => {
+        throw new Error("PR creation should not run after rejected repair");
+      },
+    },
+  };
+
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    maxAttempts: 3,
+    retryBackoffMs: 0,
+    handlers: createBackgroundJobHandlers({
+      storage,
+      deps: {
+        buildOctokitFn: async () => octokit as never,
+        resolveGitHubAuthTokenFn: async () => "gho_token",
+        runIssueWorkRepairFn: async () => {
+          repairCalls += 1;
+          return {
+            accepted: false,
+            rejectionReason: "agent failed (124): command timed out",
+            summary: "No agent summary provided",
+            fixBranch: "issue/17-fix-the-toggle-123",
+            agentResult: { stdout: "", stderr: "command timed out", code: 124 },
+          };
+        },
+      },
+    }),
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 500);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(repairCalls, 1);
+    assert.equal(stored?.attemptCount, 1);
+    assert.match(stored?.lastError ?? "", /agent failed \(124\)/);
+    assert.equal(commentsCreated.length, 2);
+    assert.match(String(commentsCreated[0]?.body), /Issue work started/);
+    assert.match(String(commentsCreated[1]?.body), /Issue work failed/);
+  } finally {
+    dispatcher.stop();
+  }
 });
 
 test("babysit_pr handler marks terminal babysitter failures as terminal background failures", async () => {

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -47,6 +47,10 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function shouldPostInitialIssueWorkNotice(job: BackgroundJob): boolean {
+  return job.attemptCount <= 1;
+}
+
 export function createBackgroundJobHandlers(params: {
   storage: IStorage;
   babysitter?: Pick<PRBabysitter, "runQueuedBabysitPR" | "syncAndBabysitTrackedRepos">;
@@ -245,7 +249,7 @@ export function createBackgroundJobHandlers(params: {
         baseMetadata,
       );
 
-      if (progressRepliesEnabled) {
+      if (progressRepliesEnabled && shouldPostInitialIssueWorkNotice(job)) {
         await postIssueWorkStatusComment(
           octokit,
           parsedRepo,
@@ -310,7 +314,7 @@ export function createBackgroundJobHandlers(params: {
           },
           "error",
         );
-        throw error;
+        throw new TerminalBackgroundJobError(error instanceof Error ? error.message : String(error));
       }
 
       if (!repairResult.accepted) {
@@ -341,7 +345,7 @@ export function createBackgroundJobHandlers(params: {
             "failed",
           );
         }
-        throw new Error(repairResult.rejectionReason ?? "Issue work not accepted");
+        throw new TerminalBackgroundJobError(repairResult.rejectionReason ?? "Issue work not accepted");
       }
 
       await addIssueWorkStageLog(

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -662,6 +662,57 @@ describe("MemStorage", () => {
       assert.equal(canceled?.status, "canceled");
       assert.equal(canceled?.lastError, "no-op");
     });
+
+    it("clears failed jobs by kind and target", async () => {
+      const issueJob = await storage.enqueueBackgroundJob(makeBackgroundJobInput({
+        targetId: "acme/widgets#17",
+        dedupeKey: "work_issue:acme/widgets#17",
+        kind: "work_issue",
+        payload: { issueNumber: 17 },
+      }));
+      const otherIssueJob = await storage.enqueueBackgroundJob(makeBackgroundJobInput({
+        targetId: "acme/widgets#18",
+        dedupeKey: "work_issue:acme/widgets#18",
+        kind: "work_issue",
+        payload: { issueNumber: 18 },
+      }));
+      const prJob = await storage.enqueueBackgroundJob(makeBackgroundJobInput({
+        targetId: "pr-1",
+        dedupeKey: "babysit_pr:pr-1",
+        kind: "babysit_pr",
+        payload: { prId: "pr-1" },
+      }));
+
+      for (const [job, leaseToken] of [
+        [issueJob, "lease-issue"],
+        [otherIssueJob, "lease-other-issue"],
+        [prJob, "lease-pr"],
+      ] as const) {
+        await storage.claimNextBackgroundJob({
+          workerId: "worker-1",
+          leaseToken,
+          leaseExpiresAt: "2026-04-02T10:00:30.000Z",
+          now: "2026-04-02T10:00:00.000Z",
+          kinds: [job.kind],
+        });
+        await storage.failBackgroundJob(
+          job.id,
+          leaseToken,
+          "boom",
+          "2026-04-02T10:00:15.000Z",
+        );
+      }
+
+      const cleared = await storage.clearFailedBackgroundJobs({
+        kind: "work_issue",
+        targetId: "acme/widgets#17",
+      });
+
+      assert.equal(cleared, 1);
+      assert.equal(await storage.getBackgroundJob(issueJob.id), undefined);
+      assert.equal((await storage.getBackgroundJob(otherIssueJob.id))?.status, "failed");
+      assert.equal((await storage.getBackgroundJob(prJob.id))?.status, "failed");
+    });
   });
 
   // ── CI healing ──────────────────────────────────────────

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -682,8 +682,12 @@ export class MemStorage implements IStorage {
     return expired.length;
   }
 
-  async clearFailedBackgroundJobs(): Promise<number> {
-    const failed = Array.from(this.backgroundJobs.values()).filter((job) => job.status === "failed");
+  async clearFailedBackgroundJobs(filters: { kind?: BackgroundJobKind; targetId?: string } = {}): Promise<number> {
+    const failed = Array.from(this.backgroundJobs.values()).filter((job) =>
+      job.status === "failed"
+      && (!filters.kind || job.kind === filters.kind)
+      && (!filters.targetId || job.targetId === filters.targetId),
+    );
     for (const job of failed) {
       this.backgroundJobs.delete(job.id);
     }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1478,6 +1478,7 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
   }];
   const workCalls: Array<{ repo: string; number: number }> = [];
   const evaluateCalls: Array<{ repo: string; number: number }> = [];
+  const clearFailureCalls: Array<{ repo: string; number: number }> = [];
   const fakeRuntime = {
     start: async () => undefined,
     stop: () => undefined,
@@ -1495,6 +1496,10 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
     evaluateIssue: async (repo: string, number: number) => {
       evaluateCalls.push({ repo, number });
       return { ...issues[0], evaluationStatus: "approved", evaluationSummary: "Ready for automatic work" };
+    },
+    clearIssueWorkFailures: async (repo: string, number: number) => {
+      clearFailureCalls.push({ repo, number });
+      return { ...issues[0], workStatus: "idle", workJobId: null, lastError: null };
     },
     listActivities: async () => ({ failed: [], inProgress: [], queued: [], warnings: [], generatedAt: "2026-05-03T00:00:00.000Z" }),
     getRuntimeSnapshot: async () => ({ drainMode: false, drainRequestedAt: null, drainReason: null, activeRuns: 0 }),
@@ -1619,6 +1624,15 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
 
     assert.equal(evaluateResponse.status, 201);
     assert.deepEqual(evaluateCalls, [{ repo: "acme/widgets", number: 17 }]);
+
+    const clearResponse = await fetch(`${harness.baseUrl}/api/issues/work/failures`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo: "acme/widgets", number: 17 }),
+    });
+
+    assert.equal(clearResponse.status, 200);
+    assert.deepEqual(clearFailureCalls, [{ repo: "acme/widgets", number: 17 }]);
   } finally {
     await harness.close();
   }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1499,7 +1499,7 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
     },
     clearIssueWorkFailures: async (repo: string, number: number) => {
       clearFailureCalls.push({ repo, number });
-      return { ...issues[0], workStatus: "idle", workJobId: null, lastError: null };
+      return { repo, number, id: `${repo}#${number}`, cleared: 1 };
     },
     listActivities: async () => ({ failed: [], inProgress: [], queued: [], warnings: [], generatedAt: "2026-05-03T00:00:00.000Z" }),
     getRuntimeSnapshot: async () => ({ drainMode: false, drainRequestedAt: null, drainReason: null, activeRuns: 0 }),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -449,6 +449,19 @@ export async function registerRoutes(
     }
   });
 
+  app.delete("/api/issues/work/failures", async (req, res) => {
+    try {
+      const payload = z.object({
+        repo: z.string().min(1),
+        number: z.number().int().positive(),
+      }).parse(req.body);
+
+      res.json(await runtime.clearIssueWorkFailures(payload.repo, payload.number));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.post("/api/issues/evaluate", async (req, res) => {
     try {
       const payload = z.object({

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -2547,11 +2547,24 @@ export class SqliteStorage implements IStorage {
     return Number(result.changes);
   }
 
-  async clearFailedBackgroundJobs(): Promise<number> {
+  async clearFailedBackgroundJobs(filters: { kind?: BackgroundJobKind; targetId?: string } = {}): Promise<number> {
+    const clauses = ["status = 'failed'"];
+    const values: Array<SQLInputValue> = [];
+
+    if (filters.kind) {
+      clauses.push("kind = ?");
+      values.push(filters.kind);
+    }
+
+    if (filters.targetId) {
+      clauses.push("target_id = ?");
+      values.push(filters.targetId);
+    }
+
     const result = this.run(`
       DELETE FROM background_jobs
-      WHERE status = 'failed'
-    `);
+      WHERE ${clauses.join(" AND ")}
+    `, ...values);
     return Number(result.changes);
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -140,7 +140,7 @@ export interface IStorage {
   failBackgroundJob(id: string, leaseToken: string, error: string, completedAt: string): Promise<BackgroundJob | undefined>;
   cancelBackgroundJob(id: string, leaseToken: string, error: string | null, completedAt: string): Promise<BackgroundJob | undefined>;
   requeueExpiredBackgroundJobs(now: string): Promise<number>;
-  clearFailedBackgroundJobs(): Promise<number>;
+  clearFailedBackgroundJobs(filters?: { kind?: BackgroundJobKind; targetId?: string }): Promise<number>;
 
   // Social media changelogs
   getSocialChangelogs(): Promise<SocialChangelog[]>;


### PR DESCRIPTION
## Summary
- stop issue-work repair failures from going through the background retry loop after a failed GitHub progress notice is posted
- avoid reposting the initial issue-work started notice on retry attempts
- add regression coverage for the duplicate started/failed notice path

## Root Cause
Issue work posted GitHub progress comments from inside the job handler, but ordinary repair failures were returned to the durable dispatcher as retryable errors. Each retry re-entered the handler and created another started/failed comment pair.

## Verification
- `node --import tsx --test server/backgroundJobHandlers.test.ts`
- `node --import tsx --test server/logger.test.ts`
- `npm run check`
- `npm run test -- --test-name-pattern "work_issue handler"` (518/519 passed; unrelated logger file-redaction test read an empty log file during the broad run, then passed when rerun directly)

Closes #11
