### PR TITLE
fix: repair tauri release builds

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -52,7 +52,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libgtk-3-dev \

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:all": "node --import tsx --test server/*.test.ts client/src/lib/*.test.ts",
     "check": "tsc",
     "db:push": "drizzle-kit push",
+    "tauri": "tauri",
     "tauri:dev": "TAURI_DEV=1 tauri dev",
     "tauri:build": "tauri build"
   },


### PR DESCRIPTION
## Summary

Fixes the release-triggered Tauri build workflow failures from the v1.0.2 run.

## Root cause

The macOS and Windows jobs failed because `tauri-apps/tauri-action` invokes `npm run tauri build`, but the project only exposed `tauri:build`.

The Linux job failed before build because the workflow installed both `libappindicator3-dev` and `libayatana-appindicator3-dev`, which conflict on Ubuntu 22.04.

## Changes

- Add the standard `tauri` npm script expected by `tauri-action`.
- Remove the conflicting `libappindicator3-dev` package from the Linux dependency install step.

## Verification

- `npm run tauri -- --version`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `npm run check`
- `npm run tauri build -- --no-bundle`