### PR TITLE
fix: run tauri build after main merges

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,6 +1,9 @@
 name: Build Tauri App
 
 on:
+  push:
+    branches: [main]
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -62,6 +65,15 @@ jobs:
       - run: npm ci
 
       - name: Build Tauri app
+        if: github.event_name != 'release'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --target ${{ matrix.target }}
+
+      - name: Build and upload Tauri app
+        if: github.event_name == 'release'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds post-merge Tauri build coverage so the native app workflow runs after changes land on `main`.

## Root cause

The Tauri workflow only listened for published release events, so merging the release-build fix did not create a Tauri workflow run. Only the regular CI and Pages workflows ran after the merge.

## Changes

- Trigger the Tauri workflow on pushes to `main`.
- Add `workflow_dispatch` for manual verification.
- Split the Tauri action into build-only runs for non-release events and build/upload runs for published releases.

## Verification

- Parsed `.github/workflows/tauri-build.yml` with Ruby YAML loader.
- Inspected the scoped workflow diff.