### PR TITLE
[codex] harden issue evaluation gate

### DIFF
--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -96,6 +96,18 @@ function formatEvaluationState(issue: Issue): string {
   return issue.evaluationStatus.replace("_", " ");
 }
 
+function formatEvaluationConfidence(confidence: number): string {
+  const grade = confidence >= 0.9
+    ? "very high"
+    : confidence >= 0.75
+    ? "high"
+    : confidence >= 0.5
+    ? "medium"
+    : "low";
+
+  return `${grade} (${Math.round(confidence * 100)}%)`;
+}
+
 function getEvaluationBadgeClass(issue: Issue): string {
   if (issue.evaluationStatus === "approved") {
     return "border-success-border bg-success-muted text-success-foreground";
@@ -922,7 +934,7 @@ export default function Issues() {
                     </span>
                     {typeof selectedIssue.evaluationConfidence === "number" && (
                       <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                        confidence: {Math.round(selectedIssue.evaluationConfidence * 100)}%
+                        confidence: {formatEvaluationConfidence(selectedIssue.evaluationConfidence)}
                       </span>
                     )}
                     {selectedIssue.evaluationUpdatedAt && (

--- a/server/issueEvaluator.test.ts
+++ b/server/issueEvaluator.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { evaluateIssueForAutomation } from "./issueEvaluator";
+import {
+  buildIssueEvaluationComment,
+  evaluateIssueForAutomation,
+  formatIssueEvaluationConfidence,
+  gradeIssueEvaluationConfidence,
+} from "./issueEvaluator";
 
 test("evaluateIssueForAutomation approves actionable bugs without safety flags", () => {
   const decision = evaluateIssueForAutomation({
@@ -30,4 +35,62 @@ test("evaluateIssueForAutomation blocks secret exfiltration requests", () => {
   assert.equal(decision.status, "blocked");
   assert.deepEqual(decision.safetyFlags, ["secret-access", "exfiltration-risk"]);
   assert.deepEqual(decision.recommendedLabels, ["needs-maintainer-review", "blocked"]);
+});
+
+test("evaluateIssueForAutomation does not approve vague bug labels without evidence", () => {
+  const decision = evaluateIssueForAutomation({
+    repo: "acme/widgets",
+    issueNumber: 19,
+    title: "Dashboard is broken",
+    body: "It does not work correctly.",
+    labels: ["bug"],
+    author: "alice",
+  });
+
+  assert.equal(decision.status, "needs_review");
+  assert.deepEqual(decision.safetyFlags, []);
+  assert.deepEqual(decision.recommendedLabels, ["needs-maintainer-review"]);
+});
+
+test("evaluateIssueForAutomation flags broad blast radius work", () => {
+  const decision = evaluateIssueForAutomation({
+    repo: "acme/widgets",
+    issueNumber: 20,
+    title: "Rewrite the authentication flow across the entire app",
+    body: "Replace the auth system and update all routes so login works differently everywhere.",
+    labels: ["bug"],
+    author: "alice",
+  });
+
+  assert.equal(decision.status, "needs_review");
+  assert.deepEqual(decision.safetyFlags, ["privileged-area", "broad-blast-radius"]);
+  assert.deepEqual(decision.recommendedLabels, ["needs-maintainer-review", "large-scope"]);
+});
+
+test("gradeIssueEvaluationConfidence maps numeric confidence to stable bands", () => {
+  assert.equal(gradeIssueEvaluationConfidence(0.95), "very_high");
+  assert.equal(gradeIssueEvaluationConfidence(0.82), "high");
+  assert.equal(gradeIssueEvaluationConfidence(0.55), "medium");
+  assert.equal(gradeIssueEvaluationConfidence(0.2), "low");
+  assert.equal(formatIssueEvaluationConfidence(0.82), "high (82%)");
+});
+
+test("buildIssueEvaluationComment includes confidence grade and percent", () => {
+  const decision = evaluateIssueForAutomation({
+    repo: "acme/widgets",
+    issueNumber: 21,
+    title: "Toggle fails after refresh",
+    body: "Steps to reproduce: refresh and click the toggle. Expected on, actual off.",
+    labels: ["bug"],
+    author: "alice",
+  });
+
+  const comment = buildIssueEvaluationComment({
+    targetId: "acme/widgets#21",
+    issueTitle: "Toggle fails after refresh",
+    issueUrl: "https://github.com/acme/widgets/issues/21",
+    decision,
+  });
+
+  assert.match(comment, /Confidence: high \(82%\)/);
 });

--- a/server/issueEvaluator.ts
+++ b/server/issueEvaluator.ts
@@ -19,6 +19,15 @@ export type IssueEvaluationDecision = {
   recommendedLabels: string[];
 };
 
+export type IssueEvaluationConfidenceGrade = "very_high" | "high" | "medium" | "low";
+
+const CONFIDENCE = {
+  veryHigh: 0.95,
+  high: 0.82,
+  needsReviewHigh: 0.75,
+  medium: 0.55,
+} as const;
+
 const BLOCKED_LABELS = new Set([
   "blocked",
   "question",
@@ -88,6 +97,37 @@ const ACTIONABLE_PATTERNS = [
   /\bsteps?\s+to\s+reproduce\b/i,
 ];
 
+const ACTIONABLE_DETAIL_PATTERNS = [
+  /\bexpected\b.*\bactual\b/i,
+  /\bactual\b.*\bexpected\b/i,
+  /\bsteps?\s+to\s+reproduce\b/i,
+  /\brepro(duce|duction)?\b/i,
+  /\bafter\s+(refresh|reload|click|submit|save|login|sign in|sign out|deploy|build)\b/i,
+  /\bwhen\s+i\b/i,
+  /\bthrows?\b/i,
+  /\bstack trace\b/i,
+  /\bstatus\s+code\b/i,
+  /\bconsole\b/i,
+];
+
+const BROAD_BLAST_RADIUS_PATTERNS = [
+  /\brewrite\b/i,
+  /\bredesign\b/i,
+  /\bre-?architect\b/i,
+  /\barchitecture\b/i,
+  /\brefactor\b/i,
+  /\bmigrat(e|ion)\b/i,
+  /\breplace\b.*\b(system|framework|database|auth|authentication|api)\b/i,
+  /\b(entire|whole)\s+(app|application|codebase|system|dashboard|backend|frontend)\b/i,
+  /\ball\s+(pages|routes|components|endpoints|models|tables|repos|repositories)\b/i,
+  /\bevery(where|thing| page| route| component| endpoint| model| table)\b/i,
+  /\bcross-?cutting\b/i,
+  /\bbreaking\s+change\b/i,
+  /\bdatabase\s+(schema|migration)\b/i,
+  /\bauth(entication)?\s+(flow|system|layer)\b/i,
+  /\bpermission\s+(model|system)\b/i,
+];
+
 const DISCUSSION_PATTERNS = [
   /\bhow\s+do\s+i\b/i,
   /\bquestion\b/i,
@@ -112,6 +152,17 @@ function addFlag(flags: string[], flag: string): void {
   }
 }
 
+export function gradeIssueEvaluationConfidence(confidence: number): IssueEvaluationConfidenceGrade {
+  if (confidence >= 0.9) return "very_high";
+  if (confidence >= 0.75) return "high";
+  if (confidence >= 0.5) return "medium";
+  return "low";
+}
+
+export function formatIssueEvaluationConfidence(confidence: number): string {
+  return `${gradeIssueEvaluationConfidence(confidence).replace("_", " ")} (${Math.round(confidence * 100)}%)`;
+}
+
 export function evaluateIssueForAutomation(input: IssueEvaluationInput): IssueEvaluationDecision {
   const labels = normalizeLabels(input.labels);
   const text = `${input.title}\n${input.body ?? ""}\n${labels.join("\n")}`;
@@ -125,6 +176,7 @@ export function evaluateIssueForAutomation(input: IssueEvaluationInput): IssueEv
   if (matchesAny(text, EXFILTRATION_PATTERNS)) addFlag(safetyFlags, "exfiltration-risk");
   if (matchesAny(text, DESTRUCTIVE_PATTERNS)) addFlag(safetyFlags, "destructive-request");
   if (matchesAny(text, PRIVILEGED_PATTERNS)) addFlag(safetyFlags, "privileged-area");
+  if (matchesAny(text, BROAD_BLAST_RADIUS_PATTERNS)) addFlag(safetyFlags, "broad-blast-radius");
 
   const hardBlock = safetyFlags.some((flag) =>
     flag === "secret-access" || flag === "exfiltration-risk" || flag === "destructive-request"
@@ -132,7 +184,7 @@ export function evaluateIssueForAutomation(input: IssueEvaluationInput): IssueEv
   if (hardBlock || blockedLabel) {
     return {
       status: "blocked",
-      confidence: 0.9,
+      confidence: CONFIDENCE.veryHigh,
       summary: hardBlock
         ? "Blocked from automatic work because the issue asks for risky secret, network, or destructive behavior."
         : `Blocked from automatic work by label: ${blockedLabel}.`,
@@ -141,27 +193,34 @@ export function evaluateIssueForAutomation(input: IssueEvaluationInput): IssueEv
     };
   }
 
-  const needsReview = safetyFlags.includes("privileged-area") || matchesAny(text, DISCUSSION_PATTERNS);
+  const needsReview = safetyFlags.includes("privileged-area")
+    || safetyFlags.includes("broad-blast-radius")
+    || matchesAny(text, DISCUSSION_PATTERNS);
   if (needsReview) {
+    const recommendedLabels = safetyFlags.includes("broad-blast-radius")
+      ? ["needs-maintainer-review", "large-scope"]
+      : ["needs-maintainer-review"];
     return {
       status: "needs_review",
-      confidence: 0.75,
-      summary: safetyFlags.includes("privileged-area")
+      confidence: CONFIDENCE.needsReviewHigh,
+      summary: safetyFlags.includes("broad-blast-radius")
+        ? "Needs maintainer review because the issue appears larger than a surgical fix and may have broad blast radius."
+        : safetyFlags.includes("privileged-area")
         ? "Needs maintainer review because it touches a privileged area."
         : "Needs maintainer review because the issue looks like discussion or support, not direct implementation work.",
       safetyFlags,
-      recommendedLabels: ["needs-maintainer-review"],
+      recommendedLabels,
     };
   }
 
-  const actionable = labels.some((label) => label === "bug" || label === "regression")
-    || matchesAny(text, ACTIONABLE_PATTERNS);
+  const concreteReport = matchesAny(text, ACTIONABLE_DETAIL_PATTERNS);
+  const actionable = matchesAny(text, ACTIONABLE_PATTERNS) && concreteReport;
 
   if (actionable) {
     return {
       status: "approved",
-      confidence: 0.82,
-      summary: "Approved for automatic work: actionable bug report with no safety flags.",
+      confidence: CONFIDENCE.high,
+      summary: "Approved for automatic work: the evaluator could not disprove a concrete, surgical issue report and found no safety flags.",
       safetyFlags,
       recommendedLabels: ["ready-for-agent"],
     };
@@ -169,8 +228,8 @@ export function evaluateIssueForAutomation(input: IssueEvaluationInput): IssueEv
 
   return {
     status: "needs_review",
-    confidence: 0.55,
-    summary: "Needs maintainer review because the issue is not clearly actionable yet.",
+    confidence: CONFIDENCE.medium,
+    summary: "Needs maintainer review because the evaluator could not find enough concrete detail to treat the report as proven actionable.",
     safetyFlags,
     recommendedLabels: ["needs-maintainer-review"],
   };
@@ -208,6 +267,8 @@ export function buildIssueEvaluationComment(input: {
     `Issue: [${input.issueTitle}](${input.issueUrl})`,
     "",
     input.decision.summary,
+    "",
+    `Confidence: ${formatIssueEvaluationConfidence(input.decision.confidence)}`,
     "",
     "**Safety flags**",
     flags,


### PR DESCRIPTION
## Summary
- require concrete evidence before issue evaluation applies `ready-for-agent`
- flag broad blast-radius issue requests with `broad-blast-radius` and `large-scope`
- add confidence grades alongside percentages in evaluation comments and the Issues UI

Closes #18

## Validation
- `npm run test -- server/issueEvaluator.test.ts`
- `npm run test:all`
- `npm run check`
- `git diff --check`