### PR TITLE
feat: show queue status on PR and issue pages

### DIFF
--- a/client/src/components/QueueStatusBadge.tsx
+++ b/client/src/components/QueueStatusBadge.tsx
@@ -1,0 +1,21 @@
+import type { QueueStatusView } from "@/lib/activityQueue";
+
+export function QueueStatusBadge({ status }: { status: QueueStatusView | null }) {
+  if (!status) {
+    return null;
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 border px-1.5 py-0 text-[10px] uppercase tracking-wider ${status.className}`}
+      data-testid="queue-status-badge"
+    >
+      <span>{status.label}</span>
+      {status.detail && (
+        <span className="normal-case tracking-normal opacity-80">
+          {status.detail}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/client/src/lib/activityQueue.test.ts
+++ b/client/src/lib/activityQueue.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ActivitySnapshot } from "@shared/schema";
+import { buildQueueStatusIndex, getQueueStatusForTarget } from "./activityQueue";
+
+const snapshot: ActivitySnapshot = {
+  failed: [],
+  inProgress: [
+    {
+      id: "run-1",
+      kind: "babysit_pr",
+      status: "in_progress",
+      label: "Babysitting PR #1",
+      detail: null,
+      targetId: "pr-1",
+      targetUrl: null,
+      queuedAt: "2026-05-12T11:56:00.000Z",
+      availableAt: "2026-05-12T11:56:00.000Z",
+      startedAt: "2026-05-12T11:59:00.000Z",
+      updatedAt: "2026-05-12T11:59:10.000Z",
+      attemptCount: 1,
+      lastError: null,
+    },
+  ],
+  queued: [
+    {
+      id: "queued-1",
+      kind: "work_issue",
+      status: "queued",
+      label: "Working issue #7",
+      detail: null,
+      targetId: "issue-7",
+      targetUrl: null,
+      queuedAt: "2026-05-12T11:59:30.000Z",
+      availableAt: "2026-05-12T12:00:00.000Z",
+      startedAt: null,
+      updatedAt: "2026-05-12T11:59:30.000Z",
+      attemptCount: 0,
+      lastError: null,
+    },
+    {
+      id: "queued-2",
+      kind: "evaluate_issue",
+      status: "queued",
+      label: "Evaluating issue #8",
+      detail: null,
+      targetId: "issue-8",
+      targetUrl: null,
+      queuedAt: "2026-05-12T11:59:45.000Z",
+      availableAt: "2026-05-12T12:00:30.000Z",
+      startedAt: null,
+      updatedAt: "2026-05-12T11:59:45.000Z",
+      attemptCount: 0,
+      lastError: null,
+    },
+  ],
+  warnings: [],
+  generatedAt: "2026-05-12T12:00:00.000Z",
+};
+
+test("buildQueueStatusIndex summarizes queued and running activities", () => {
+  const index = buildQueueStatusIndex(snapshot, Date.parse("2026-05-12T12:00:00.000Z"));
+
+  assert.deepEqual(index.get("pr-1"), {
+    label: "running",
+    detail: "~4m remaining",
+    className: "border-primary bg-primary/10 text-primary animate-pulse",
+  });
+  assert.deepEqual(index.get("issue-7"), {
+    label: "up next",
+    detail: "starts in ~4m",
+    className: "border-primary/50 text-primary",
+  });
+  assert.deepEqual(index.get("issue-8"), {
+    label: "#2 in queue",
+    detail: "available in ~30s",
+    className: "border-warning-border bg-warning-muted text-warning-foreground",
+  });
+});
+
+test("getQueueStatusForTarget returns null for missing targets", () => {
+  assert.equal(getQueueStatusForTarget(snapshot, "missing", Date.parse("2026-05-12T12:00:00.000Z")), null);
+});

--- a/client/src/lib/activityQueue.ts
+++ b/client/src/lib/activityQueue.ts
@@ -1,0 +1,122 @@
+import type { ActivityItem, ActivitySnapshot, BackgroundJobKind } from "@shared/schema";
+
+export type QueueStatusView = {
+  label: string;
+  detail: string | null;
+  className: string;
+};
+
+const DEFAULT_JOB_DURATION_MS: Record<BackgroundJobKind, number> = {
+  sync_watched_repos: 45_000,
+  babysit_pr: 5 * 60_000,
+  process_release_run: 2 * 60_000,
+  answer_pr_question: 90_000,
+  evaluate_issue: 90_000,
+  work_issue: 4 * 60_000,
+  generate_social_changelog: 3 * 60_000,
+  heal_deployment: 4 * 60_000,
+};
+
+export function buildQueueStatusIndex(snapshot: ActivitySnapshot, nowMs = Date.now()): Map<string, QueueStatusView> {
+  const statusById = new Map<string, QueueStatusView>();
+  const inProgressBudgetMs = snapshot.inProgress.reduce((total, activity) => {
+    return total + estimateRemainingMs(activity, nowMs);
+  }, 0);
+
+  let queuedBudgetMs = 0;
+  for (let index = 0; index < snapshot.queued.length; index += 1) {
+    const activity = snapshot.queued[index];
+    const position = index + 1;
+    const availableDelayMs = getAvailableDelayMs(activity, nowMs);
+    const waitMs = availableDelayMs + inProgressBudgetMs + queuedBudgetMs;
+
+    statusById.set(activity.targetId, {
+      label: position === 1 ? "up next" : `#${position} in queue`,
+      detail: availableDelayMs > 0
+        ? `available in ~${formatDuration(availableDelayMs)}`
+        : waitMs > 0
+          ? `starts in ~${formatDuration(waitMs)}`
+          : "starting soon",
+      className: availableDelayMs > 0
+        ? "border-warning-border bg-warning-muted text-warning-foreground"
+        : "border-primary/50 text-primary",
+    });
+
+    queuedBudgetMs += estimateDurationMs(activity.kind);
+  }
+
+  for (const activity of snapshot.inProgress) {
+    const elapsedMs = Math.max(0, nowMs - getStartedAtMs(activity, nowMs));
+    const estimateMs = estimateDurationMs(activity.kind);
+    const remainingMs = Math.max(0, estimateMs - elapsedMs);
+
+    statusById.set(activity.targetId, {
+      label: "running",
+      detail: remainingMs > 0
+        ? `~${formatDuration(remainingMs)} remaining`
+        : `running for ~${formatDuration(elapsedMs)}`,
+      className: "border-primary bg-primary/10 text-primary animate-pulse",
+    });
+  }
+
+  return statusById;
+}
+
+export function getQueueStatusForTarget(snapshot: ActivitySnapshot, targetId: string, nowMs = Date.now()): QueueStatusView | null {
+  const statusIndex = buildQueueStatusIndex(snapshot, nowMs);
+  return statusIndex.get(targetId) ?? null;
+}
+
+function estimateDurationMs(kind: BackgroundJobKind): number {
+  return DEFAULT_JOB_DURATION_MS[kind];
+}
+
+function getStartedAtMs(activity: ActivityItem, fallbackNowMs: number): number {
+  const startedAt = activity.startedAt ? Date.parse(activity.startedAt) : Number.NaN;
+  if (Number.isFinite(startedAt)) {
+    return startedAt;
+  }
+
+  const updatedAt = Date.parse(activity.updatedAt);
+  if (Number.isFinite(updatedAt)) {
+    return updatedAt;
+  }
+
+  return fallbackNowMs;
+}
+
+function getAvailableDelayMs(activity: ActivityItem, nowMs: number): number {
+  const availableAt = Date.parse(activity.availableAt);
+  if (!Number.isFinite(availableAt) || availableAt <= nowMs) {
+    return 0;
+  }
+
+  return availableAt - nowMs;
+}
+
+function estimateRemainingMs(activity: ActivityItem, nowMs: number): number {
+  const elapsedMs = Math.max(0, nowMs - getStartedAtMs(activity, nowMs));
+  return Math.max(0, estimateDurationMs(activity.kind) - elapsedMs);
+}
+
+function formatDuration(ms: number): string {
+  const safeMs = Math.max(0, Math.round(ms));
+  const totalSeconds = Math.max(1, Math.round(safeMs / 1000));
+
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+
+  const totalMinutes = Math.round(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
+}

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -307,6 +307,9 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasTestId(sourceFile, "dashboard drain banner", "dashboard-drain-banner");
   assertHasTestId(sourceFile, "dashboard drain reason", "dashboard-drain-reason");
   assertHasTestId(sourceFile, "activity drain note", "activity-drain-note");
+  assertHasExpression(sourceFile, "queue status helper", /\bbuildQueueStatusIndex\b/);
+  assertHasExpression(sourceFile, "queue status badge", /\bQueueStatusBadge\b/);
+  assertHasExpression(sourceFile, "queue status index", /\bqueueStatusById\b/);
   assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
   assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");
   assertHasStringValue(sourceFile, "drained PR copy", "Background and manual runs are paused by drain mode.");
@@ -373,6 +376,8 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "stale issue helper", /\bisStaleIssue\b/);
   assertHasExpression(sourceFile, "issue detail refresh", /\brefetchSelectedIssueDetail\b/);
   assertHasExpression(sourceFile, "issue PR mergeability", /\bworkPrMergeable\b/);
+  assertHasExpression(sourceFile, "issue queue helper", /\bbuildQueueStatusIndex\b/);
+  assertHasExpression(sourceFile, "issue queue badge", /\bQueueStatusBadge\b/);
   assertHasStringValue(sourceFile, "issue body label", "Issue body");
 });
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -26,6 +26,8 @@ import {
   getHealingSessionView,
   selectRelevantHealingSession,
 } from "@/lib/ciHealing";
+import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
+import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 
 function formatClock(timestamp: string | null): string | null {
   if (!timestamp) {
@@ -153,7 +155,7 @@ function WatchPausedIndicator() {
   );
 }
 
-function ActivityRow({ activity }: { activity: ActivityItem }) {
+function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueStatus: QueueStatusView | null }) {
   const timeLabel = activity.status === "failed"
     ? formatClock(activity.updatedAt)
     : activity.status === "in_progress"
@@ -175,6 +177,9 @@ function ActivityRow({ activity }: { activity: ActivityItem }) {
         {activity.detail && (
           <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
         )}
+        <div className="mt-1">
+          <QueueStatusBadge status={queueStatus} />
+        </div>
         {activity.status === "failed" && activity.lastError && (
           <span
             className="block whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
@@ -210,10 +215,12 @@ function ActivitySection({
   title,
   items,
   emptyLabel,
+  queueStatusById,
 }: {
   title: string;
   items: ActivityItem[];
   emptyLabel: string;
+  queueStatusById: Map<string, QueueStatusView>;
 }) {
   return (
     <div className="py-1">
@@ -221,7 +228,7 @@ function ActivitySection({
       {items.length > 0 ? (
         <div className="max-h-52 overflow-y-auto">
           {items.map((activity) => (
-            <ActivityRow key={activity.id} activity={activity} />
+            <ActivityRow key={activity.id} activity={activity} queueStatus={queueStatusById.get(activity.targetId) ?? null} />
           ))}
         </div>
       ) : (
@@ -236,11 +243,13 @@ function ActivityMenu({
   onClearFailed,
   isClearingFailed,
   globalDrainMode,
+  queueStatusById,
 }: {
   activities: ActivitySnapshot;
   onClearFailed: () => void;
   isClearingFailed: boolean;
   globalDrainMode: boolean;
+  queueStatusById: Map<string, QueueStatusView>;
 }) {
   const failedCount = activities.failed.length;
   const inProgressCount = activities.inProgress.length;
@@ -282,18 +291,21 @@ function ActivityMenu({
           title="Failed"
           items={activities.failed}
           emptyLabel="No failed activities."
+          queueStatusById={queueStatusById}
         />
         <div className="border-t border-border" />
         <ActivitySection
           title="In progress"
           items={activities.inProgress}
           emptyLabel="No activities running right now."
+          queueStatusById={queueStatusById}
         />
         <div className="border-t border-border" />
         <ActivitySection
           title="Queued"
           items={activities.queued}
           emptyLabel="Queue is empty."
+          queueStatusById={queueStatusById}
         />
         {globalDrainMode && queuedCount > 0 && (
           <div
@@ -583,11 +595,13 @@ const PRRow = memo(function PRRow({
   isSelected,
   onSelect,
   failureMessage,
+  queueStatus,
 }: {
   pr: PR;
   isSelected: boolean;
   onSelect: (id: string) => void;
   failureMessage?: string | null;
+  queueStatus: QueueStatusView | null;
 }) {
   const checkedAt = formatClock(pr.lastChecked);
   const watchEnabled = isPRWatchEnabled(pr);
@@ -651,6 +665,7 @@ const PRRow = memo(function PRRow({
               {pr.repo}
             </a>
             <span>{formatStatusLabel(pr.status)}</span>
+            <QueueStatusBadge status={queueStatus} />
             {!watchEnabled && <WatchPausedIndicator />}
             {pr.feedbackItems.length > 0 && (() => {
               const counts = countActiveFeedbackStatuses(pr.feedbackItems);
@@ -1243,6 +1258,7 @@ export default function Dashboard() {
     queryKey: ["/api/activities"],
     refetchInterval: 3000,
   });
+  const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
 
   const { data: runtimeState } = useQuery<RuntimeState>({
     queryKey: ["/api/runtime"],
@@ -1273,6 +1289,7 @@ export default function Dashboard() {
   const selectedPR = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
   const selectedPRWatchEnabled = selectedPR ? isPRWatchEnabled(selectedPR) : true;
   const selectedFailedActivity = selectedPR ? latestActivityForTarget(activities.failed, selectedPR.id) : undefined;
+  const selectedPRQueueStatus = selectedPR ? queueStatusById.get(selectedPR.id) ?? null : null;
   const selectedPRErrorMessage = selectedPR?.status === "error"
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
@@ -1413,6 +1430,7 @@ export default function Dashboard() {
               onClearFailed={() => clearFailedActivitiesMutation.mutate()}
               isClearingFailed={clearFailedActivitiesMutation.isPending}
               globalDrainMode={globalDrainMode}
+              queueStatusById={queueStatusById}
             />
           </>
         )}
@@ -1473,6 +1491,7 @@ export default function Dashboard() {
                   pr={pr}
                   isSelected={pr.id === selectedPRId}
                   onSelect={setSelectedPRId}
+                  queueStatus={queueStatusById.get(pr.id) ?? null}
                   failureMessage={
                     pr.status === "error"
                       ? latestActivityForTarget(activities.failed, pr.id)?.lastError ?? getPRFeedbackFailureReason(pr)
@@ -1514,6 +1533,12 @@ export default function Dashboard() {
                       )}
                       <span className="text-border" aria-hidden="true">·</span>
                       <span><span className="font-mono text-foreground">{selectedPR.feedbackItems.length}</span> items</span>
+                      {selectedPRQueueStatus && (
+                        <>
+                          <span className="text-border" aria-hidden="true">·</span>
+                          <QueueStatusBadge status={selectedPRQueueStatus} />
+                        </>
+                      )}
                       {selectedPR.feedbackItems.length > 0 && (() => {
                         const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);
                         return (

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -5,8 +5,10 @@ import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
-import type { Issue, LogEntry, RuntimeState } from "@shared/schema";
+import type { ActivitySnapshot, Issue, LogEntry, RuntimeState } from "@shared/schema";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
+import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 
 function formatDateTime(value: string | null | undefined): string {
   if (!value) return "n/a";
@@ -132,6 +134,14 @@ function isStaleIssue(issue: Issue): boolean {
   return Date.now() - updatedAt > 7 * 24 * 60 * 60 * 1000;
 }
 
+const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
+  failed: [],
+  inProgress: [],
+  queued: [],
+  warnings: [],
+  generatedAt: "",
+};
+
 function matchesIssueWorkFilter(issue: Issue, filter: IssueWorkFilter): boolean {
   if (filter === "ready") return Boolean(issue.workPrUrl);
   if (filter === "auto") return Boolean(issue.autoWorkEligible);
@@ -214,10 +224,12 @@ function IssueRow({
   issue,
   selected,
   onSelect,
+  queueStatus,
 }: {
   issue: Issue;
   selected: boolean;
   onSelect: (issueId: string) => void;
+  queueStatus: QueueStatusView | null;
 }) {
   const showInlineStatusBadge = issue.workStatus !== "queued" && issue.workStatus !== "in_progress";
   const rowAction =
@@ -279,6 +291,7 @@ function IssueRow({
             >
               {formatEvaluationState(issue)}
             </span>
+            <QueueStatusBadge status={queueStatus} />
             {issue.labels.slice(0, 3).map((label) => (
               <span key={label} className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
                 {label}
@@ -350,6 +363,11 @@ export default function Issues() {
     queryKey: ["/api/runtime"],
     refetchInterval: 5000,
   });
+  const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
+    queryKey: ["/api/activities"],
+    refetchInterval: 3000,
+  });
+  const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
 
   const { data: issues = [], isLoading, refetch, isFetching } = useQuery<Issue[]>({
     queryKey: ["/api/issues"],
@@ -417,6 +435,7 @@ export default function Issues() {
   });
   const selectedIssue = selectedIssueDetail ?? selectedIssueFromList;
   const selectedIssueKey = selectedIssue ? issueKey(selectedIssue) : null;
+  const selectedIssueQueueStatus = selectedIssue ? queueStatusById.get(selectedIssue.id) ?? null : null;
   const repoGroups = useMemo(() => {
     const counts = new Map<string, Issue[]>();
     const source = issues
@@ -725,6 +744,7 @@ export default function Issues() {
                         issue={issue}
                         selected={issue.id === selectedIssueId}
                         onSelect={setSelectedIssueId}
+                        queueStatus={queueStatusById.get(issue.id) ?? null}
                       />
                     ))}
                   </div>
@@ -754,6 +774,7 @@ export default function Issues() {
                     </div>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
                       <IssueStatusBadge issue={selectedIssue} />
+                      <QueueStatusBadge status={selectedIssueQueueStatus} />
                       {selectedIssue.workStage && selectedIssue.workStage !== selectedIssue.workStatus && (
                         <span
                           data-testid="issue-work-stage"


### PR DESCRIPTION
Closes #20.\n\nAdds a shared queue summary so PR and Issue rows show up-next/running state with approximate wait times derived from the current activity snapshot. The header activity menu and the list pages now use the same queue view.\n\nVerification:\n- npm run check\n- node --import tsx --test client/src/lib/activityQueue.test.ts client/src/lib/fullAppQaSurface.test.ts\n- Playwright browser pass on the local app with synthetic queued and in-progress activities