### PR TITLE
ui(dashboard): slim "Ready to merge" badge to one line

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -641,11 +641,9 @@ const PRRow = memo(function PRRow({
               href={pr.url}
               testId={`ready-to-merge-${pr.id}`}
               label="Ready to merge"
-              hint="— click to open PR"
               onClick={(event) => event.stopPropagation()}
-              className="mt-1.5 ml-[3.75rem] gap-1.5 px-2 py-0.5 text-[11px] tracking-wider"
+              className="mt-1.5 ml-[3.75rem] gap-1.5 whitespace-nowrap px-2 py-0.5 text-[10px] tracking-wider"
               dotClassName="h-1.5 w-1.5"
-              hintClassName="text-[10px] normal-case tracking-normal text-success-foreground/75"
             />
           )}
           {pr.status === "error" && failureMessage && (


### PR DESCRIPTION
## Summary
- The compact `Ready to merge` badge in the active PR list wrapped to two lines because the row column is narrow and the badge carried both an uppercase label and a `— click to open PR` hint.
- Drop the hint on the row variant, add `whitespace-nowrap`, and bump the row badge to `text-[10px]` so it renders as a single slim pill.
- Detail panel variant (`All comments resolved — ready to merge` + `Open PR on GitHub →`) is left untouched — it has room for the full content.

Closes #22

## Test plan
- [ ] Run the dashboard locally and confirm a PR with all comments resolved shows a single-line green pill under the PR title in the active list.
- [ ] Confirm the detail panel still shows the full "All comments resolved — ready to merge / Open PR on GitHub →" badge unchanged.
- [ ] Verify clicking the badge still opens the PR in a new tab and does not toggle row selection.