### PR TITLE
fix(tauri): gate RunEvent::Reopen behind macOS cfg

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,6 +281,7 @@ pub fn run() {
         .run(|app_handle, event| {
             match event {
                 // User clicked the Dock icon while the window was hidden — reveal it.
+                #[cfg(target_os = "macos")]
                 tauri::RunEvent::Reopen {
                     has_visible_windows,
                     ..


### PR DESCRIPTION
## Summary
- `RunEvent::Reopen` is a macOS-only variant (Dock icon click). The unconditional match arm caused `error[E0599]: no variant named 'Reopen' found for enum 'RunEvent'` on Linux and Windows Tauri builds.
- Wrapped the arm in `#[cfg(target_os = "macos")]`. The existing `_ => {}` catch-all keeps the match exhaustive on non-macOS targets.

## Test plan
- [ ] Build Tauri App / build-tauri (ubuntu-22.04, x86_64-unknown-linux-gnu) ✅
- [ ] Build Tauri App / build-tauri (windows-latest, x86_64-pc-windows-msvc) ✅
- [ ] Build Tauri App / build-tauri (macos-*) still green