### PR TITLE
feat: prioritize configured issue authors

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -688,6 +688,7 @@ Partially update the configuration.  Only the provided fields are changed.
   "deploymentCheckPollIntervalMs": 15000,
   "watchedRepos": ["owner/repo"],
   "trustedReviewers": ["alice", "bob"],
+  "priorityIssueAuthors": ["octocat"],
   "ignoredBots": ["dependabot", "codecov"]
 }
 ```
@@ -697,6 +698,12 @@ Partially update the configuration.  Only the provided fields are changed.
 Some configuration is REST-writable but not exposed by the MCP `update_config`
 tool schema today. Use this REST endpoint when changing release automation,
 CI-healing, or deployment-healing keys.
+
+`priorityIssueAuthors` accepts GitHub account logins such as `octocat`; values
+are matched case-insensitively and may include or omit a leading `@`. Issues from
+matching authors are evaluated and worked before the regular issue queue, and
+their evaluation/work jobs use elevated background-job priority. The default is
+an empty array, which leaves issue ordering and job priority unchanged.
 
 ---
 
@@ -1027,6 +1034,7 @@ Install the patchdeck code-review GitHub Actions workflow on a repository.
   deploymentCheckPollIntervalMs: number;
   watchedRepos: string[];
   trustedReviewers: string[];
+  priorityIssueAuthors: string[]; // GitHub logins whose issues receive queue and job priority; empty by default
   ignoredBots: string[];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ PatchDeck reads its config from `~/.patchdeck/state.sqlite`. Override the home d
 Key controls (all editable in Settings):
 
 - **Trusted reviewers** — comments from these GitHub logins skip evaluation and go straight to the agent fix queue
+- **Priority issue authors** — issues from these GitHub logins are evaluated and worked before the regular issue queue
 - **Ignored bots** — bot logins whose comments and reviews are ignored entirely
 - **Auto mode** — global toggles for PR babysitting and issue auto-work; the header chip in the web UI shows current state
 - **Drain mode** — emergency pause across all automation (kept separate from the per-area auto toggles)

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1097,6 +1097,15 @@ export default function Settings() {
               />
 
               <StringListRow
+                label="Priority issue authors"
+                description="GitHub logins whose issues are evaluated and worked before the regular issue queue."
+                placeholder="octocat"
+                values={config?.priorityIssueAuthors ?? []}
+                onChange={(next) => updateConfigMutation.mutate({ priorityIssueAuthors: next })}
+                disabled={!config || updateConfigMutation.isPending}
+              />
+
+              <StringListRow
                 label="Ignored bots"
                 description="Bot logins whose comments and reviews are ignored."
                 placeholder="dependabot[bot]"

--- a/docs/public/_site/configuration.html
+++ b/docs/public/_site/configuration.html
@@ -250,6 +250,7 @@ patchdeck --no-log-file
 <li><strong>Babysitter tuning</strong> — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.</li>
 <li><strong>Runtime drain mode</strong> — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return <code>409</code> instead of queueing new agent work.</li>
 <li><strong>Ignored bots</strong> — Add or remove bot logins whose comments and reviews should be ignored.</li>
+<li><strong>Priority issue authors</strong> — Add GitHub logins whose issues should be evaluated and worked before the regular issue queue.</li>
 <li><strong>PR comment branding</strong> — Customize the app name shown in agent-authored GitHub PR comments, or remove that signature entirely. Toggle whether the signature links back to patchdeck and includes the <code>Posted by patchdeck</code> footer.</li>
 <li><strong>GitHub progress replies</strong> — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.</li>
 <li><strong>CI healing</strong> — Enable autonomous CI repair and tune retry/session limits.</li>
@@ -287,6 +288,9 @@ patchdeck --no-log-file
 </tbody></table>
 <p>New watched repos default to <strong>My PRs only</strong> with automatic release publishing disabled. If you want team-wide tracking for a repository, switch it to <strong>My PRs + teammates</strong> in the dashboard or patch <code>ownPrsOnly: false</code> through <code>/api/repos/settings</code>.</p>
 <p>PRs added directly by URL stay tracked regardless of a repo&#39;s <code>ownPrsOnly</code> setting.</p>
+<h2>Issue Queue Priority</h2>
+<p><code>priorityIssueAuthors</code> is a dashboard and API setting for GitHub issue queue ordering. Add GitHub account logins such as <code>octocat</code>; entries are matched case-insensitively and may include or omit a leading <code>@</code>.</p>
+<p>Issues opened by these authors are evaluated and worked ahead of the regular issue queue. Matching evaluation and work jobs are also queued with elevated background-job priority. The default is an empty list, so issue ordering and job priority are unchanged until logins are configured.</p>
 <h2>Manual Repository Releases</h2>
 <p>Each watched repository row in the dashboard includes a <strong>Release</strong> button. Pressing it queues a manual release run for the latest unreleased merged PR in that repository, using the same release evaluation, version bump, notes, and GitHub publishing flow as automatic release creation.</p>
 <p>Manual release runs are allowed even when <code>autoCreateReleases</code> is disabled, so you can keep automatic publishing off and still publish releases on demand. If the repository has no unreleased merged PRs, the API returns <code>409</code> and no release run is created.</p>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -65,6 +65,7 @@ The settings page in the dashboard provides a UI for:
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
 - **Runtime drain mode** — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.
 - **Ignored bots** — Add or remove bot logins whose comments and reviews should be ignored.
+- **Priority issue authors** — Add GitHub logins whose issues should be evaluated and worked before the regular issue queue.
 - **PR comment branding** — Customize the app name shown in agent-authored GitHub PR comments, or remove that signature entirely. Toggle whether the signature links back to patchdeck and includes the `Posted by patchdeck` footer.
 - **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
@@ -90,6 +91,12 @@ Watched repositories also have repo-level settings exposed in the dashboard's re
 New watched repos default to **My PRs only** with automatic release publishing disabled. If you want team-wide tracking for a repository, switch it to **My PRs + teammates** in the dashboard or patch `ownPrsOnly: false` through `/api/repos/settings`.
 
 PRs added directly by URL stay tracked regardless of a repo's `ownPrsOnly` setting.
+
+## Issue Queue Priority
+
+`priorityIssueAuthors` is a dashboard and API setting for GitHub issue queue ordering. Add GitHub account logins such as `octocat`; entries are matched case-insensitively and may include or omit a leading `@`.
+
+Issues opened by these authors are evaluated and worked ahead of the regular issue queue. Matching evaluation and work jobs are also queued with elevated background-job priority. The default is an empty list, so issue ordering and job priority are unchanged until logins are configured.
 
 ## Manual Repository Releases
 

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -308,6 +308,7 @@ function makePlanIssue(
     id: `${overrides.repo}#${overrides.number}`,
     repo: overrides.repo,
     number: overrides.number,
+    author: overrides.author ?? "alice",
     workStatus: overrides.workStatus ?? "idle",
     workPrUrl: overrides.workPrUrl ?? null,
     autoWorkEligible: overrides.autoWorkEligible ?? false,
@@ -344,6 +345,37 @@ test("planAutomaticIssueQueueActions sweeps every unevaluated issue up to the ev
   });
   assert.equal(plan.evaluations.length, 3, "must respect the evaluation cap exactly");
   assert.equal(plan.work.length, 0);
+});
+
+test("planAutomaticIssueQueueActions prioritizes configured issue authors", () => {
+  // Goal: when support-critical users report issues, their work should get the scarce
+  // auto-work slot before newer reports from the regular queue.
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true }],
+    issues: [
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 1,
+        author: "regular-user",
+        autoWorkEligible: true,
+        updatedAt: "2026-05-02T00:00:00.000Z",
+      }),
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 2,
+        author: "Priority-User",
+        autoWorkEligible: true,
+        updatedAt: "2026-05-01T00:00:00.000Z",
+      }),
+    ],
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+    priorityIssueAuthors: ["priority-user"],
+  });
+
+  assert.deepEqual(plan.work.map((action) => action.number), [2]);
 });
 
 test("planAutomaticIssueQueueActions counts already-queued evaluations against the cap", () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -34,6 +34,7 @@ import { generateReleaseSocialPost } from "./releaseSocialPostAgent";
 import { randomUUID } from "node:crypto";
 
 const log = childLogger("runtime");
+const PRIORITY_ISSUE_JOB_PRIORITY = 50;
 import { createBackgroundJobHandlers } from "./backgroundJobHandlers";
 import { BackgroundJobDispatcher } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue, buildBackgroundJobDedupeKey } from "./backgroundJobQueue";
@@ -225,16 +226,44 @@ function normalizeIssueLabel(label: string): string {
   return label.trim().toLowerCase();
 }
 
+function normalizeGitHubLogin(login: string): string {
+  return login.trim().toLowerCase().replace(/^@/, "");
+}
+
+function isPriorityIssueAuthor(author: string | undefined, priorityIssueAuthors: readonly string[]): boolean {
+  const normalizedAuthor = normalizeGitHubLogin(author ?? "");
+  if (!normalizedAuthor) {
+    return false;
+  }
+
+  return priorityIssueAuthors.some((entry) => normalizeGitHubLogin(entry) === normalizedAuthor);
+}
+
+function compareIssueQueuePriority(
+  a: Pick<Issue, "author" | "updatedAt">,
+  b: Pick<Issue, "author" | "updatedAt">,
+  priorityIssueAuthors: readonly string[],
+): number {
+  const aPriority = isPriorityIssueAuthor(a.author, priorityIssueAuthors);
+  const bPriority = isPriorityIssueAuthor(b.author, priorityIssueAuthors);
+  if (aPriority !== bPriority) {
+    return aPriority ? -1 : 1;
+  }
+
+  return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+}
+
 export type PlanAutomaticIssueQueueInput = {
   repoSettings: Pick<WatchedRepo, "repo" | "issueAutoEvaluate" | "issueAutoWork">[];
   issues: Pick<
     Issue,
-    "id" | "repo" | "number" | "workStatus" | "workPrUrl" | "autoWorkEligible" | "evaluationStatus" | "updatedAt"
+    "id" | "repo" | "number" | "author" | "workStatus" | "workPrUrl" | "autoWorkEligible" | "evaluationStatus" | "updatedAt"
   >[];
   activeEvaluationTargets: Set<string>;
   activeWorkCount: number;
   maxConcurrentIssueEvaluations: number;
   maxConcurrentIssueWork: number;
+  priorityIssueAuthors?: string[];
 };
 
 export type PlanAutomaticIssueQueueActions = {
@@ -258,6 +287,7 @@ export function planAutomaticIssueQueueActions(
   let evaluationBudget = Math.max(0, input.maxConcurrentIssueEvaluations - input.activeEvaluationTargets.size);
   let workBudget = Math.max(0, input.maxConcurrentIssueWork - input.activeWorkCount);
   const claimed = new Set<string>();
+  const priorityIssueAuthors = input.priorityIssueAuthors ?? [];
 
   // Auto-work sweep first: budget is scarcer. Preserve per-repo single-flight semantics —
   // at most one work job per repo at a time, regardless of global budget.
@@ -269,7 +299,7 @@ export function planAutomaticIssueQueueActions(
     }
     const candidate = repoIssues
       .filter((issue) => issue.workStatus === "idle" && !issue.workPrUrl && issue.autoWorkEligible)
-      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+      .sort((a, b) => compareIssueQueuePriority(a, b, priorityIssueAuthors))[0];
     if (!candidate) continue;
     result.work.push({ repo: candidate.repo, number: candidate.number, id: candidate.id });
     claimed.add(candidate.id);
@@ -289,7 +319,7 @@ export function planAutomaticIssueQueueActions(
           && !input.activeEvaluationTargets.has(issue.id)
           && !claimed.has(issue.id),
         )
-        .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+        .sort((a, b) => compareIssueQueuePriority(a, b, priorityIssueAuthors));
       if (pending.length > 0) {
         repoQueues.set(repo, pending);
       }
@@ -788,6 +818,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     const octokit = await buildOctokit(config);
     const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });
     const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
+    const priority = isPriorityIssueAuthor(issue.author, config.priorityIssueAuthors)
+      ? PRIORITY_ISSUE_JOB_PRIORITY
+      : undefined;
     const job = await scheduleBackgroundJob(
       "evaluate_issue",
       targetId,
@@ -803,6 +836,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           targetUrl: issue.url,
         }),
       },
+      priority === undefined ? undefined : { priority },
     );
 
     await storage.addLog(targetId, "info", `${source === "automatic" ? "Queued automatic issue evaluation" : "Queued manual issue evaluation"} for ${issue.repoFullName}#${issue.number}`, {
@@ -846,6 +880,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });
     const baseBranch = await getDefaultBranchForRepo(octokit, parsedRepo);
     const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
+    const priority = isPriorityIssueAuthor(issue.author, config.priorityIssueAuthors)
+      ? PRIORITY_ISSUE_JOB_PRIORITY
+      : undefined;
 
     const job = await scheduleBackgroundJob(
       "work_issue",
@@ -863,6 +900,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           targetUrl: issue.url,
         }),
       },
+      priority === undefined ? undefined : { priority },
     );
 
     await storage.addLog(targetId, "info", `${source === "automatic" ? "Queued automatic issue work" : "Queued manual issue work"} for ${issue.repoFullName}#${issue.number}`, {
@@ -1080,6 +1118,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       activeWorkCount,
       maxConcurrentIssueEvaluations: config.maxConcurrentIssueEvaluations,
       maxConcurrentIssueWork: config.maxConcurrentIssueWork,
+      priorityIssueAuthors: config.priorityIssueAuthors,
     });
 
     for (const action of plan.work) {

--- a/server/defaultConfig.test.ts
+++ b/server/defaultConfig.test.ts
@@ -46,6 +46,7 @@ describe("DEFAULT_CONFIG", () => {
       "maxConcurrentIssueWork",
       "watchedRepos",
       "trustedReviewers",
+      "priorityIssueAuthors",
       "ignoredBots",
     ] as const;
 
@@ -77,11 +78,13 @@ describe("DEFAULT_CONFIG", () => {
     }
   });
 
-  it("has empty arrays for watchedRepos and trustedReviewers", () => {
+  it("has empty arrays for watchedRepos, trustedReviewers, and priorityIssueAuthors", () => {
     assert.ok(Array.isArray(DEFAULT_CONFIG.watchedRepos), "watchedRepos should be an array");
     assert.ok(Array.isArray(DEFAULT_CONFIG.trustedReviewers), "trustedReviewers should be an array");
+    assert.ok(Array.isArray(DEFAULT_CONFIG.priorityIssueAuthors), "priorityIssueAuthors should be an array");
     assert.equal(DEFAULT_CONFIG.watchedRepos.length, 0, "watchedRepos should be empty by default");
     assert.equal(DEFAULT_CONFIG.trustedReviewers.length, 0, "trustedReviewers should be empty by default");
+    assert.equal(DEFAULT_CONFIG.priorityIssueAuthors.length, 0, "priorityIssueAuthors should be empty by default");
   });
 
   it("has empty array as default githubTokens", () => {

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -31,5 +31,6 @@ export const DEFAULT_CONFIG: Config = {
   maxConcurrentIssueWork: 1,
   watchedRepos: [],
   trustedReviewers: [],
+  priorityIssueAuthors: [],
   ignoredBots: ["dependabot[bot]", "codecov[bot]", "github-actions[bot]"],
 };

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -90,6 +90,7 @@ type ConfigRow = {
   max_concurrent_issue_evaluations: number;
   max_concurrent_issue_work: number;
   trusted_reviewers_json: string;
+  priority_issue_authors_json: string;
   ignored_bots_json: string;
 };
 
@@ -538,6 +539,7 @@ export class SqliteStorage implements IStorage {
         max_concurrent_healing_runs INTEGER NOT NULL DEFAULT 1,
         healing_cooldown_ms INTEGER NOT NULL DEFAULT 300000,
         trusted_reviewers_json TEXT NOT NULL,
+        priority_issue_authors_json TEXT NOT NULL DEFAULT '[]',
         ignored_bots_json TEXT NOT NULL
       );
 
@@ -860,6 +862,7 @@ export class SqliteStorage implements IStorage {
     this.exec("UPDATE watched_repos SET issue_auto_evaluate = 1 WHERE issue_auto_work = 1 AND issue_auto_evaluate = 0");
     this.ensureColumn("config", "max_concurrent_issue_evaluations", "INTEGER NOT NULL DEFAULT 2");
     this.ensureColumn("config", "max_concurrent_issue_work", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "priority_issue_authors_json", "TEXT NOT NULL DEFAULT '[]'");
     this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
@@ -970,6 +973,7 @@ export class SqliteStorage implements IStorage {
       maxConcurrentIssueWork: row.max_concurrent_issue_work ?? DEFAULT_CONFIG.maxConcurrentIssueWork,
       watchedRepos,
       trustedReviewers: JSON.parse(row.trusted_reviewers_json),
+      priorityIssueAuthors: parseStringArrayJson(row.priority_issue_authors_json),
       ignoredBots: JSON.parse(row.ignored_bots_json),
     };
   }
@@ -1015,8 +1019,9 @@ export class SqliteStorage implements IStorage {
           max_concurrent_issue_evaluations,
           max_concurrent_issue_work,
           trusted_reviewers_json,
+          priority_issue_authors_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -1047,7 +1052,8 @@ export class SqliteStorage implements IStorage {
           max_concurrent_issue_evaluations = excluded.max_concurrent_issue_evaluations,
           max_concurrent_issue_work = excluded.max_concurrent_issue_work,
           trusted_reviewers_json = excluded.trusted_reviewers_json,
-        ignored_bots_json = excluded.ignored_bots_json
+          priority_issue_authors_json = excluded.priority_issue_authors_json,
+          ignored_bots_json = excluded.ignored_bots_json
       `,
         1,
         config.githubTokens[0] ?? "",
@@ -1079,6 +1085,7 @@ export class SqliteStorage implements IStorage {
         config.maxConcurrentIssueEvaluations,
         config.maxConcurrentIssueWork,
         JSON.stringify(config.trustedReviewers),
+        JSON.stringify(config.priorityIssueAuthors),
         JSON.stringify(config.ignoredBots),
       );
 
@@ -1739,7 +1746,7 @@ export class SqliteStorage implements IStorage {
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,
              auto_heal_deployments, deployment_check_delay_ms, deployment_check_timeout_ms,
              deployment_check_poll_interval_ms, max_concurrent_issue_evaluations, max_concurrent_issue_work,
-             trusted_reviewers_json, ignored_bots_json
+             trusted_reviewers_json, priority_issue_authors_json, ignored_bots_json
       FROM config
       WHERE id = 1
     `);

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -87,6 +87,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     maxHealingAttemptsPerFingerprint: 4,
     maxConcurrentHealingRuns: 2,
     healingCooldownMs: 123456,
+    priorityIssueAuthors: ["priority-user"],
     watchedRepos: ["alex-morgan-o/lolodex"],
   });
   await first.updateRepoSettings("alex-morgan-o/lolodex", {
@@ -221,6 +222,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(config.maxConcurrentHealingRuns, 2);
   assert.equal(config.healingCooldownMs, 123456);
   assert.deepEqual(config.githubTokens, ["ghs_first", "ghs_second"]);
+  assert.deepEqual(config.priorityIssueAuthors, ["priority-user"]);
   assert.deepEqual(config.watchedRepos, ["alex-morgan-o/lolodex"]);
   assert.deepEqual(repoSettings, {
     repo: "alex-morgan-o/lolodex",

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -389,6 +389,7 @@ export function applyConfigUpdate(existing: Config, updates: Partial<Config>): C
     webUsername,
     watchedRepos: updates.watchedRepos ?? existing.watchedRepos,
     trustedReviewers: updates.trustedReviewers ?? existing.trustedReviewers,
+    priorityIssueAuthors: updates.priorityIssueAuthors ?? existing.priorityIssueAuthors,
     ignoredBots: updates.ignoredBots ?? existing.ignoredBots,
   });
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -588,6 +588,7 @@ export const configSchema = z.object({
   maxConcurrentIssueWork: z.number().int().positive().default(1),
   watchedRepos: z.array(z.string()),
   trustedReviewers: z.array(z.string()),
+  priorityIssueAuthors: z.array(z.string()),
   ignoredBots: z.array(z.string()),
 });
 export type Config = z.infer<typeof configSchema>;


### PR DESCRIPTION
## Summary
- add a priority issue authors setting for GitHub logins
- prefer matching authors when automatic issue evaluation/work chooses the next issue
- persist the setting in SQLite and cover queue/default/storage behavior with tests

Closes #25

## Verification
- npm run check
- npm run test
- npm run test:all
- npm run build