### PR TITLE
[codex] expose failed activity clear action

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -278,6 +278,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["ask submit", "button-ask"],
     ["dashboard error pill", "dashboard-error-pill"],
     ["dashboard errors panel", "dashboard-errors-panel"],
+    ["dashboard clear failed activities", "dashboard-clear-failed-activities"],
     ["dashboard clear issue failure", "dashboard-clear-issue-failure"],
     ["dashboard errors roll-up toggle", "dashboard-errors-rollup-toggle"],
     ["dashboard errors roll-up summary", "dashboard-errors-rollup-summary"],

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -401,12 +401,16 @@ function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
 
 function DashboardErrorsPanel({
   activities,
+  onClearFailed,
+  isClearingFailed,
   onClearIssueFailure,
   isClearingIssueFailure,
   rolledUp,
   onToggleRolledUp,
 }: {
   activities: ActivitySnapshot;
+  onClearFailed: () => void;
+  isClearingFailed: boolean;
   onClearIssueFailure: (activity: ActivityItem) => void;
   isClearingIssueFailure: boolean;
   rolledUp: boolean;
@@ -434,6 +438,22 @@ function DashboardErrorsPanel({
           <div className="text-[11px] text-muted-foreground">
             Failed jobs stay here until retried or cleared from activity.
           </div>
+          <button
+            type="button"
+            onClick={onClearFailed}
+            disabled={isClearingFailed}
+            data-testid="dashboard-clear-failed-activities"
+            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            {isClearingFailed ? (
+              "Clearing"
+            ) : (
+              <>
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+                Clear failed
+              </>
+            )}
+          </button>
           <button
             type="button"
             onClick={onToggleRolledUp}
@@ -1438,6 +1458,8 @@ export default function Dashboard() {
       <OperatorWarningsBanner warnings={activities.warnings} />
       <DashboardErrorsPanel
         activities={activities}
+        onClearFailed={() => clearFailedActivitiesMutation.mutate()}
+        isClearingFailed={clearFailedActivitiesMutation.isPending}
         onClearIssueFailure={(activity) => clearIssueFailureMutation.mutate(activity)}
         isClearingIssueFailure={clearIssueFailureMutation.isPending}
         rolledUp={areErrorsRolledUp}


### PR DESCRIPTION
## Summary
- Add a direct Clear failed action to the Needs attention banner.
- Reuse the existing failed-activity clear mutation and endpoint.
- Cover the new dashboard control in the QA surface test.

Closes #27

## Verification
- npm run test -- client/src/lib/fullAppQaSurface.test.ts
- npm run check

## Notes
- /simplify was attempted before commit but produced no output and hung; it was stopped after waiting.