### PR TITLE
feat: manage issue labels

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -332,11 +332,16 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasQueryKey(sourceFile, "issue logs query", "/api/logs");
   assertHasApiRequest(sourceFile, "issue work mutation", "POST", "/api/issues/work");
   assertHasApiRequest(sourceFile, "issue evaluation mutation", "POST", "/api/issues/evaluate");
+  assertHasApiRequest(sourceFile, "issue label mutation", "PATCH", "/api/issues/labels");
 
   for (const [label, testId] of [
     ["refresh button", "button-refresh-issues"],
     ["work issue button", "button-work-issue"],
     ["evaluate issue button", "button-evaluate-issue"],
+    ["issue label editor", "issue-label-editor"],
+    ["issue label input", "issue-label-input"],
+    ["add issue label button", "button-add-issue-label"],
+    ["remove issue label button", "button-remove-issue-label"],
     ["repo filter bar", "repo-filter-bar"],
     ["auto eligible filter", "issue-auto-eligible-filter"],
     ["needs evaluation filter", "issue-needs-evaluation-filter"],

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLink, Loader2, RefreshCw, ShieldCheck, Trash2, Wrench } from "lucide-react";
+import { ExternalLink, Loader2, Plus, RefreshCw, ShieldCheck, Trash2, Wrench, X } from "lucide-react";
 import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -382,6 +382,7 @@ export default function Issues() {
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<string>("all");
   const [selectedWorkFilter, setSelectedWorkFilter] = useState<IssueWorkFilter>("all");
+  const [labelInput, setLabelInput] = useState("");
 
   useEffect(() => {
     const filteredIssues = issues
@@ -534,6 +535,30 @@ export default function Issues() {
     },
     onError: (error) => {
       toast({ variant: "destructive", description: `Could not queue issue evaluation: ${error.message}` });
+    },
+  });
+
+  const labelMutation = useMutation({
+    mutationFn: async ({ issue, add, remove }: { issue: Issue; add?: string[]; remove?: string[] }) => {
+      const res = await apiRequest("PATCH", "/api/issues/labels", {
+        repo: issue.repo,
+        number: issue.number,
+        add,
+        remove,
+      });
+      return res.json() as Promise<Issue>;
+    },
+    onSuccess: async (issue) => {
+      setLabelInput("");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] }),
+      ]);
+      toast({ description: `Updated labels for #${issue.number}.` });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Could not update issue labels: ${error.message}` });
     },
   });
 
@@ -862,14 +887,52 @@ export default function Issues() {
                     </button>
                   </div>
                 </div>
-                <div className="flex flex-wrap gap-1">
+                <div data-testid="issue-label-editor" className="flex flex-wrap items-center gap-1">
                   {selectedIssue.labels.length > 0 ? selectedIssue.labels.map((label) => (
-                    <span key={label} className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
-                      {label}
+                    <span key={label} className="inline-flex max-w-full items-center gap-1 border border-border pl-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                      <span className="min-w-0 truncate">{label}</span>
+                      <button
+                        type="button"
+                        onClick={() => labelMutation.mutate({ issue: selectedIssue, remove: [label] })}
+                        disabled={labelMutation.isPending}
+                        title={`Remove ${label}`}
+                        data-testid="button-remove-issue-label"
+                        className="inline-flex h-5 w-5 items-center justify-center text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
                     </span>
                   )) : (
                     <span className="text-[11px] text-muted-foreground">No labels</span>
                   )}
+                  <form
+                    className="ml-1 inline-flex items-center gap-1"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      const label = labelInput.trim();
+                      if (!label || !selectedIssue || selectedIssue.labels.includes(label)) {
+                        return;
+                      }
+                      labelMutation.mutate({ issue: selectedIssue, add: [label] });
+                    }}
+                  >
+                    <input
+                      value={labelInput}
+                      onChange={(event) => setLabelInput(event.target.value)}
+                      placeholder="add label"
+                      data-testid="issue-label-input"
+                      className="h-6 w-44 border border-border bg-background px-2 text-[11px] text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    />
+                    <button
+                      type="submit"
+                      disabled={labelMutation.isPending || !labelInput.trim() || selectedIssue.labels.includes(labelInput.trim())}
+                      title="Add label"
+                      data-testid="button-add-issue-label"
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40"
+                    >
+                      {labelMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+                    </button>
+                  </form>
                 </div>
                 {selectedIssue.workPrUrl && selectedIssue.workPrNumber !== undefined && selectedIssue.workPrNumber !== null && (() => {
                   const readiness = getWorkPrReadiness(selectedIssue);

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -62,6 +62,8 @@ import {
   type MergedPRSummary,
   parsePRUrl,
   parseRepoSlug,
+  addLabelsToIssue,
+  removeLabelsFromIssue,
   resolveNextSemverTag,
 } from "./github";
 
@@ -147,6 +149,7 @@ export type AppRuntime = {
   getReleaseSocialPost(jobId: string): Promise<ReleaseSocialPost>;
   listIssues(): Promise<Issue[]>;
   getIssue(repo: string, number: number): Promise<Issue>;
+  updateIssueLabels(repo: string, number: number, updates: { add?: string[]; remove?: string[] }): Promise<Issue>;
   evaluateIssue(repo: string, number: number): Promise<Issue>;
   workIssue(repo: string, number: number): Promise<Issue>;
   clearIssueWorkFailures(repo: string, number: number): Promise<{ repo: string; number: number; id: string; cleared: number }>;
@@ -1043,6 +1046,50 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     return applyIssueWorkState(issue, { includePrMergeability: true });
   }
 
+  async function updateIssueLabelsInternal(
+    repoInput: string,
+    number: number,
+    updates: { add?: string[]; remove?: string[] },
+  ): Promise<Issue> {
+    const parsedRepo = parseRepoSlug(repoInput);
+    if (!parsedRepo) {
+      throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+    }
+
+    const canonical = formatRepoSlug(parsedRepo);
+    const config = await storage.getConfig();
+    if (!config.watchedRepos.includes(canonical)) {
+      throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
+    }
+
+    const add = Array.from(new Set((updates.add ?? []).map((label) => label.trim()).filter(Boolean)));
+    const remove = Array.from(new Set((updates.remove ?? []).map((label) => label.trim()).filter(Boolean)));
+    if (add.length === 0 && remove.length === 0) {
+      throw new AppRuntimeError(400, "At least one label is required");
+    }
+
+    const octokit = await buildOctokit(config);
+    await Promise.all([
+      addLabelsToIssue(octokit, { ...parsedRepo, number }, add),
+      removeLabelsFromIssue(octokit, { ...parsedRepo, number }, remove),
+    ]);
+
+    const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });
+    const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
+    await storage.addLog(targetId, "info", `Updated labels for ${issue.repoFullName}#${issue.number}`, {
+      metadata: {
+        repo: issue.repoFullName,
+        issueNumber: issue.number,
+        addedLabels: add,
+        removedLabels: remove,
+        stage: "labels_updated",
+      },
+    });
+
+    notifyChange();
+    return applyIssueWorkState(issue, { includePrMergeability: true });
+  }
+
   async function clearIssueWorkFailuresInternal(
     repoInput: string,
     number: number,
@@ -1651,6 +1698,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     async getIssue(repoInput, number) {
       return getIssueInternal(repoInput, number);
+    },
+
+    async updateIssueLabels(repoInput, number, updates) {
+      return updateIssueLabelsInternal(repoInput, number, updates);
     },
 
     async evaluateIssue(repoInput, number) {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { Config, FeedbackItem } from "@shared/schema";
 import {
+  addLabelsToIssue,
   buildGitHubCloneUrl,
   buildOctokit,
   GitHubIntegrationError,
@@ -29,6 +30,7 @@ import {
   resolveNextSemverTag,
   resolveReviewThread,
   selectLatestSemverTag,
+  removeLabelsFromIssue,
   updateStatusReply,
 } from "./github";
 
@@ -790,6 +792,59 @@ test("fetchIssueSummary normalizes direct issue metadata", async () => {
   assert.equal(issue.bodyHtml, null);
   assert.deepEqual(issue.labels, ["bug"]);
   assert.deepEqual(issue.assignees, []);
+});
+
+test("addLabelsToIssue sends label names to GitHub issues", async () => {
+  const calls: unknown[] = [];
+  const octokit = {
+    issues: {
+      addLabels: async (params: unknown) => {
+        calls.push(params);
+        return { data: {} };
+      },
+    },
+  };
+
+  await addLabelsToIssue(octokit as never, { owner: "owner", repo: "repo", number: 17 }, ["blocked"]);
+
+  assert.deepEqual(calls, [{
+    owner: "owner",
+    repo: "repo",
+    issue_number: 17,
+    labels: ["blocked"],
+  }]);
+});
+
+test("removeLabelsFromIssue removes each label from GitHub issues", async () => {
+  const calls: unknown[] = [];
+  const octokit = {
+    issues: {
+      removeLabel: async (params: unknown) => {
+        calls.push(params);
+        return { data: {} };
+      },
+    },
+  };
+
+  await removeLabelsFromIssue(octokit as never, { owner: "owner", repo: "repo", number: 17 }, [
+    "blocked",
+    "blocked-label:needs-maintainer-review",
+  ]);
+
+  assert.deepEqual(calls, [
+    {
+      owner: "owner",
+      repo: "repo",
+      issue_number: 17,
+      name: "blocked",
+    },
+    {
+      owner: "owner",
+      repo: "repo",
+      issue_number: 17,
+      name: "blocked-label:needs-maintainer-review",
+    },
+  ]);
 });
 
 test("fetchFeedbackItemsForPR keeps review bots that are not explicitly ignored", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -1577,6 +1577,27 @@ export async function addLabelsToIssue(
   );
 }
 
+export async function removeLabelsFromIssue(
+  octokit: Octokit,
+  parsed: ParsedRepoSlug & { number: number },
+  labels: string[],
+): Promise<void> {
+  if (labels.length === 0) {
+    return;
+  }
+
+  await Promise.all(labels.map((name) =>
+    withGitHubErrorHandling("issue labels", parsed, () =>
+      octokit.issues.removeLabel({
+        owner: parsed.owner,
+        repo: parsed.repo,
+        issue_number: parsed.number,
+        name,
+      }),
+    )
+  ));
+}
+
 export async function postPRComment(
   octokit: Octokit,
   parsed: ParsedPRUrl,

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1479,6 +1479,7 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
   const workCalls: Array<{ repo: string; number: number }> = [];
   const evaluateCalls: Array<{ repo: string; number: number }> = [];
   const clearFailureCalls: Array<{ repo: string; number: number }> = [];
+  const labelCalls: Array<{ repo: string; number: number; add?: string[]; remove?: string[] }> = [];
   const fakeRuntime = {
     start: async () => undefined,
     stop: () => undefined,
@@ -1496,6 +1497,10 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
     evaluateIssue: async (repo: string, number: number) => {
       evaluateCalls.push({ repo, number });
       return { ...issues[0], evaluationStatus: "approved", evaluationSummary: "Ready for automatic work" };
+    },
+    updateIssueLabels: async (repo: string, number: number, updates: { add?: string[]; remove?: string[] }) => {
+      labelCalls.push({ repo, number, ...updates });
+      return { ...issues[0], repo, number, labels: ["bug", ...(updates.add ?? [])] };
     },
     clearIssueWorkFailures: async (repo: string, number: number) => {
       clearFailureCalls.push({ repo, number });
@@ -1624,6 +1629,20 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
 
     assert.equal(evaluateResponse.status, 201);
     assert.deepEqual(evaluateCalls, [{ repo: "acme/widgets", number: 17 }]);
+
+    const labelResponse = await fetch(`${harness.baseUrl}/api/issues/labels`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repo: "acme/widgets", number: 17, add: ["blocked-label:needs-maintainer-review"], remove: ["bug"] }),
+    });
+
+    assert.equal(labelResponse.status, 200);
+    assert.deepEqual(labelCalls, [{
+      repo: "acme/widgets",
+      number: 17,
+      add: ["blocked-label:needs-maintainer-review"],
+      remove: ["bug"],
+    }]);
 
     const clearResponse = await fetch(`${harness.baseUrl}/api/issues/work/failures`, {
       method: "DELETE",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -436,6 +436,24 @@ export async function registerRoutes(
     }
   });
 
+  app.patch("/api/issues/labels", async (req, res) => {
+    try {
+      const payload = z.object({
+        repo: z.string().min(1),
+        number: z.number().int().positive(),
+        add: z.array(z.string().min(1)).optional(),
+        remove: z.array(z.string().min(1)).optional(),
+      }).parse(req.body);
+
+      res.json(await runtime.updateIssueLabels(payload.repo, payload.number, {
+        add: payload.add,
+        remove: payload.remove,
+      }));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.post("/api/issues/work", async (req, res) => {
     try {
       const payload = z.object({


### PR DESCRIPTION
## Summary
- add a compact label editor to the Issues detail view
- add a manual issue-label mutation endpoint backed by GitHub labels
- cover label add/remove helpers, route proxying, and QA surface wiring

Closes #29

## Validation
- npm run test -- server/routes.test.ts server/github.test.ts
- node --test client/src/lib/fullAppQaSurface.test.ts
- npm run check
- git diff --check
- isolated dev server smoke on PORT=5011 with temporary PATCHDECK_HOME: /issues returned 200 and /api/issues returned []
