### PR TITLE
feat: search PRs and issues by number

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -269,6 +269,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   for (const [label, testId] of [
     ["active tab", "tab-active"],
     ["archived tab", "tab-archived"],
+    ["PR number search", "pr-number-search"],
     ["run-now action", "button-apply"],
     ["pause-resume watch action", "button-toggle-watch"],
     ["CI healing panel", "panel-ci-healing"],
@@ -310,6 +311,8 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasExpression(sourceFile, "queue status helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "queue status badge", /\bQueueStatusBadge\b/);
   assertHasExpression(sourceFile, "queue status index", /\bqueueStatusById\b/);
+  assertHasExpression(sourceFile, "PR number search helper", /\bmatchesNumberSearch\b/);
+  assertHasStringValue(sourceFile, "PR number search placeholder", "Search #");
   assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
   assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");
   assertHasStringValue(sourceFile, "drained PR copy", "Background and manual runs are paused by drain mode.");
@@ -335,6 +338,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
 
   for (const [label, testId] of [
     ["refresh button", "button-refresh-issues"],
+    ["issue number search", "issue-number-search"],
     ["work issue button", "button-work-issue"],
     ["evaluate issue button", "button-evaluate-issue"],
     ["repo filter bar", "repo-filter-bar"],
@@ -378,6 +382,8 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue PR mergeability", /\bworkPrMergeable\b/);
   assertHasExpression(sourceFile, "issue queue helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "issue queue badge", /\bQueueStatusBadge\b/);
+  assertHasExpression(sourceFile, "issue filtered list", /\bfilteredIssues\b/);
+  assertHasStringValue(sourceFile, "issue number search placeholder", "Search #");
   assertHasStringValue(sourceFile, "issue body label", "Issue body");
 });
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -41,6 +41,15 @@ function isPRWatchEnabled(pr: PR): boolean {
   return pr.watchEnabled;
 }
 
+function normalizeNumberSearch(value: string): string {
+  return value.trim().replace(/^#/, "").trim();
+}
+
+function matchesNumberSearch(number: number, search: string): boolean {
+  const normalized = normalizeNumberSearch(search);
+  return normalized === "" || String(number).includes(normalized);
+}
+
 function formatStatusLabel(status: PR["status"]): string {
   if (status === "processing") {
     return "autonomous run active";
@@ -1229,6 +1238,7 @@ function showMutationError(title: string, error: unknown) {
 export default function Dashboard() {
   const [selectedPRId, setSelectedPRId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"active" | "archived">("active");
+  const [prNumberSearch, setPrNumberSearch] = useState("");
   const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
 
   const { data: prs = [], isLoading } = useQuery<PR[]>({
@@ -1268,8 +1278,10 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
 
-  const displayedPRs = viewMode === "active" ? prs : archivedPRs;
+  const displayedPRs = (viewMode === "active" ? prs : archivedPRs)
+    .filter((pr) => matchesNumberSearch(pr.number, prNumberSearch));
   const isArchived = viewMode === "archived";
+  const normalizedPrNumberSearch = normalizeNumberSearch(prNumberSearch);
 
   useEffect(() => {
     if (displayedPRs.length === 0) {
@@ -1473,13 +1485,26 @@ export default function Dashboard() {
               Archived ({archivedPRs.length})
             </button>
           </div>
+          <div className="border-b border-border px-3 py-2">
+            <label htmlFor="pr-number-search" className="sr-only">Search PR number</label>
+            <input
+              id="pr-number-search"
+              value={prNumberSearch}
+              onChange={(event) => setPrNumberSearch(event.target.value)}
+              placeholder="Search #"
+              data-testid="pr-number-search"
+              className="h-7 w-full rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
           <div className="flex-1">
             {(isArchived ? isLoadingArchived : isLoading) ? (
               <div className="p-4 text-[12px] text-muted-foreground">Loading...</div>
             ) : displayedPRs.length === 0 ? (
               <div className="p-4 text-[12px] text-muted-foreground">
-                {isArchived
-                  ? "No archived PRs. Closed PRs are archived automatically."
+                {normalizedPrNumberSearch
+                  ? `No PRs match #${normalizedPrNumberSearch}.`
+                  : isArchived
+                    ? "No archived PRs. Closed PRs are archived automatically."
                   : "No PRs tracked yet. Add a repository or PR from Settings."}
               </div>
             ) : (

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -42,6 +42,15 @@ function isActiveWorkStatus(status: Issue["workStatus"]): boolean {
   return status === "queued" || status === "in_progress";
 }
 
+function normalizeNumberSearch(value: string): string {
+  return value.trim().replace(/^#/, "").trim();
+}
+
+function matchesNumberSearch(number: number, search: string): boolean {
+  const normalized = normalizeNumberSearch(search);
+  return normalized === "" || String(number).includes(normalized);
+}
+
 function getWorkPrReadiness(issue: Issue): { label: string; detail: string; tone: "success" | "warning" | "neutral" } {
   if (issue.workPrMergeable === true) {
     return {
@@ -382,14 +391,23 @@ export default function Issues() {
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<string>("all");
   const [selectedWorkFilter, setSelectedWorkFilter] = useState<IssueWorkFilter>("all");
+  const [issueNumberSearch, setIssueNumberSearch] = useState("");
+  const normalizedIssueNumberSearch = normalizeNumberSearch(issueNumberSearch);
+  const filteredIssues = useMemo(
+    () => issues
+      .filter((issue) => selectedRepo === "all" || issue.repo === selectedRepo)
+      .filter((issue) => matchesIssueWorkFilter(issue, selectedWorkFilter))
+      .filter((issue) => matchesNumberSearch(issue.number, issueNumberSearch)),
+    [issues, selectedRepo, selectedWorkFilter, issueNumberSearch],
+  );
 
   useEffect(() => {
-    const filteredIssues = issues
-      .filter((issue) => selectedRepo === "all" || issue.repo === selectedRepo)
-      .filter((issue) => matchesIssueWorkFilter(issue, selectedWorkFilter));
     const nextIssue = filteredIssues[0];
 
     if (!nextIssue) {
+      if (selectedIssueId !== null) {
+        setSelectedIssueId(null);
+      }
       return;
     }
 
@@ -402,7 +420,7 @@ export default function Issues() {
     if (!selected) {
       setSelectedIssueId(nextIssue.id);
     }
-  }, [issues, selectedIssueId, selectedRepo, selectedWorkFilter]);
+  }, [filteredIssues, selectedIssueId]);
 
   const selectedIssueFromList = useMemo(
     () => {
@@ -411,15 +429,13 @@ export default function Issues() {
         baseIssue
         && (selectedRepo === "all" || baseIssue.repo === selectedRepo)
         && matchesIssueWorkFilter(baseIssue, selectedWorkFilter)
+        && matchesNumberSearch(baseIssue.number, issueNumberSearch)
       ) {
         return baseIssue;
       }
-      return issues.find((issue) =>
-        (selectedRepo === "all" || issue.repo === selectedRepo)
-        && matchesIssueWorkFilter(issue, selectedWorkFilter)
-      ) ?? null;
+      return filteredIssues[0] ?? null;
     },
-    [issues, selectedIssueId, selectedRepo, selectedWorkFilter],
+    [filteredIssues, issueNumberSearch, issues, selectedIssueId, selectedRepo, selectedWorkFilter],
   );
   const { data: selectedIssueDetail, refetch: refetchSelectedIssueDetail } = useQuery<Issue>({
     queryKey: ["/api/issues/detail", selectedIssueFromList?.repo ?? "", selectedIssueFromList?.number ?? 0],
@@ -438,10 +454,7 @@ export default function Issues() {
   const selectedIssueQueueStatus = selectedIssue ? queueStatusById.get(selectedIssue.id) ?? null : null;
   const repoGroups = useMemo(() => {
     const counts = new Map<string, Issue[]>();
-    const source = issues
-      .filter((issue) => selectedRepo === "all" || issue.repo === selectedRepo)
-      .filter((issue) => matchesIssueWorkFilter(issue, selectedWorkFilter));
-    for (const issue of source) {
+    for (const issue of filteredIssues) {
       const current = counts.get(issue.repo) ?? [];
       current.push(issue);
       counts.set(issue.repo, current);
@@ -450,7 +463,7 @@ export default function Issues() {
       repo,
       issues: repoIssues,
     }));
-  }, [issues, selectedRepo, selectedWorkFilter]);
+  }, [filteredIssues]);
   const repoCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const issue of issues) {
@@ -538,9 +551,7 @@ export default function Issues() {
   });
 
   const activeIssueCount = issues.filter((issue) => isActiveWorkStatus(issue.workStatus)).length;
-  const visibleIssues = issues
-    .filter((issue) => selectedRepo === "all" || issue.repo === selectedRepo)
-    .filter((issue) => matchesIssueWorkFilter(issue, selectedWorkFilter));
+  const visibleIssues = filteredIssues;
   const readyIssueCount = issues.filter((issue) =>
     (selectedRepo === "all" || issue.repo === selectedRepo) && Boolean(issue.workPrUrl)
   ).length;
@@ -602,6 +613,20 @@ export default function Issues() {
             Watched issues
           </div>
           <div data-testid="repo-filter-bar" className="flex flex-col gap-2 border-b border-border px-4 py-2.5">
+            <div className="flex flex-wrap items-start gap-2">
+              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Search
+              </span>
+              <label htmlFor="issue-number-search" className="sr-only">Search issue number</label>
+              <input
+                id="issue-number-search"
+                value={issueNumberSearch}
+                onChange={(event) => setIssueNumberSearch(event.target.value)}
+                placeholder="Search #"
+                data-testid="issue-number-search"
+                className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
             <div className="flex flex-wrap items-start gap-2">
               <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                 Repo
@@ -730,7 +755,9 @@ export default function Issues() {
                 <div className="p-4 text-[12px] text-muted-foreground">Loading...</div>
               ) : visibleIssues.length === 0 ? (
                 <div className="p-4 text-[12px] text-muted-foreground">
-                  No open issues found in watched repositories.
+                  {normalizedIssueNumberSearch
+                    ? `No issues match #${normalizedIssueNumberSearch}.`
+                    : "No open issues found in watched repositories."}
                 </div>
               ) : (
                 repoGroups.map((group) => (


### PR DESCRIPTION
## Summary
- add PR number search to the dashboard list
- add issue number search to the Issues list
- keep number search composed with existing list filters

Closes #33

## Validation
- node --test client/src/lib/fullAppQaSurface.test.ts
- npm run check
- git diff --check
- isolated dev server smoke on PORT=5013 with temporary PATCHDECK_HOME: /, /issues, /api/prs, and /api/issues responded
