### PR TITLE
fix: seal macOS Tauri app bundle

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,10 @@
     "resources": {
       "../dist": "dist/"
     },
-    "externalBin": []
+    "externalBin": [],
+    "macOS": {
+      "signingIdentity": "-"
+    }
   },
   "plugins": {
     "shell": {


### PR DESCRIPTION
## Summary
- configure the macOS Tauri bundle with an ad-hoc signing identity
- make Tauri seal app resources so generated `.app` bundles pass strict code signature verification

Closes #36

## Verification
- `npm run tauri:build`
- `codesign --verify --deep --strict --verbose=2 src-tauri/target/release/bundle/macos/PatchDeck.app`
- `codesign -dv --verbose=4 src-tauri/target/release/bundle/macos/PatchDeck.app`
- launched generated app with temp `PATCHDECK_HOME` and verified `/` plus `/api/config` via curl
- `npm run check`
- `git diff --check`

## Follow-up
This is ad-hoc signing, not notarization. For normal macOS downloaded-app opening without Gatekeeper override, CI still needs Apple Developer ID signing and notarization secrets.