### PR TITLE
feat: per-repo Manual/Auto toggle for PR monitoring

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -152,7 +152,7 @@ function AutoModeButton() {
             <span className="flex flex-col">
               <span className="text-[12px] font-medium text-foreground">Pull requests</span>
               <span className="text-[10px] text-muted-foreground">
-                Watcher runs the babysitter on watched PRs.
+                Watcher runs the babysitter on watched PRs. Per-repo overrides in Settings.
               </span>
             </span>
             <Switch

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -39,6 +39,10 @@ function getIssueEvaluateMode(issueAutoEvaluate?: boolean): IssueWorkMode {
   return issueAutoEvaluate ? "auto" : "manual";
 }
 
+function getPrMonitorMode(prAutoMonitor?: boolean): IssueWorkMode {
+  return prAutoMonitor === false ? "manual" : "auto";
+}
+
 function repoTestId(repo: string): string {
   return repo.replace("/", "-");
 }
@@ -213,7 +217,7 @@ export default function Settings() {
   });
 
   const updateRepoSettingsMutation = useMutation({
-    mutationFn: async (updates: { repo: string; autoCreateReleases?: boolean; ownPrsOnly?: boolean; issueAutoEvaluate?: boolean; issueAutoWork?: boolean }) => {
+    mutationFn: async (updates: { repo: string; autoCreateReleases?: boolean; ownPrsOnly?: boolean; issueAutoEvaluate?: boolean; issueAutoWork?: boolean; prAutoMonitor?: boolean }) => {
       const res = await apiRequest("PATCH", "/api/repos/settings", updates);
       return res.json();
     },
@@ -459,7 +463,7 @@ export default function Settings() {
                             {repo.repo}
                           </a>
                           <div className="mt-1 text-[11px] text-muted-foreground">
-                            {repo.ownPrsOnly === false ? "Tracking team PRs" : "Tracking your PRs"} · issue evaluate {repo.issueAutoEvaluate ? "auto" : "manual"} · issue work {repo.issueAutoWork ? "auto" : "manual"}
+                            {repo.ownPrsOnly === false ? "Tracking team PRs" : "Tracking your PRs"} · PR monitoring {repo.prAutoMonitor === false ? "manual" : "auto"} · issue evaluate {repo.issueAutoEvaluate ? "auto" : "manual"} · issue work {repo.issueAutoWork ? "auto" : "manual"}
                           </div>
                         </div>
                         <button
@@ -509,7 +513,7 @@ export default function Settings() {
                           Global Issues auto is off — these per-repo issue controls are paused. Re-enable from the AUTO MODE menu.
                         </div>
                       )}
-                      <div className="mt-4 grid gap-4 md:grid-cols-4">
+                      <div className="mt-4 grid gap-4 md:grid-cols-3">
                         <div>
                           <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
                             Track automatically
@@ -526,6 +530,26 @@ export default function Settings() {
                             name={`tracked-repo-scope-${repo.repo}`}
                             testIdPrefix={`tracked-repo-scope-${repo.repo.replace("/", "-")}`}
                           />
+                        </div>
+                        <div>
+                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                            PR monitoring
+                          </div>
+                          <IssueWorkModeControl
+                            value={getPrMonitorMode(repo.prAutoMonitor)}
+                            onChange={(value) =>
+                              updateRepoSettingsMutation.mutate({
+                                repo: repo.repo,
+                                prAutoMonitor: value === "auto",
+                              })
+                            }
+                            disabled={updateRepoSettingsMutation.isPending}
+                            name={`tracked-repo-pr-monitor-${repo.repo}`}
+                            testIdPrefix={`tracked-repo-pr-monitor-${repo.repo.replace("/", "-")}`}
+                          />
+                          <div className="mt-1 text-[10px] text-muted-foreground">
+                            Manual still syncs PR status; skips auto babysit.
+                          </div>
                         </div>
                         <div>
                           <div className="text-[10px] uppercase tracking-wider text-muted-foreground">

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -2118,6 +2118,21 @@ export class PRBabysitter {
           continue;
         }
 
+        const repoPrAutoMonitor = repoSettingsByRepo.get(repoSlug)?.prAutoMonitor ?? true;
+        if (!repoPrAutoMonitor) {
+          if (!syncedFeedbackPrIds.has(local.id)) {
+            try {
+              await this.syncFeedbackForPR(local.id, { phase: "watcher" });
+              syncedFeedbackPrIds.add(local.id);
+            } catch (error) {
+              await this.storage.addLog(local.id, "warn", `Could not sync GitHub feedback while PR auto-monitor is manual: ${summarizeUnknownError(error)}`, {
+                phase: "watcher",
+              });
+            }
+          }
+          continue;
+        }
+
         await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
           phase: "watcher",
           metadata: { repo: repoSlug },

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -486,6 +486,7 @@ describe("MemStorage", () => {
         ownPrsOnly: true,
         issueAutoEvaluate: false,
         issueAutoWork: false,
+        prAutoMonitor: true,
       }]);
     });
 
@@ -503,6 +504,7 @@ describe("MemStorage", () => {
         ownPrsOnly: false,
         issueAutoEvaluate: true,
         issueAutoWork: true,
+        prAutoMonitor: true,
       });
 
       const config = await storage.getConfig();
@@ -515,6 +517,7 @@ describe("MemStorage", () => {
         ownPrsOnly: false,
         issueAutoEvaluate: true,
         issueAutoWork: true,
+        prAutoMonitor: true,
       });
     });
   });

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -267,6 +267,7 @@ export class MemStorage implements IStorage {
       ownPrsOnly: true,
       issueAutoEvaluate: false,
       issueAutoWork: false,
+      prAutoMonitor: true,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
     this.repoSettings.set(repo, next);
@@ -301,6 +302,7 @@ export class MemStorage implements IStorage {
           ownPrsOnly: true,
           issueAutoEvaluate: false,
           issueAutoWork: false,
+          prAutoMonitor: true,
         });
       }
     }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1173,6 +1173,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       ownPrsOnly: boolean;
       issueAutoEvaluate: boolean;
       issueAutoWork: boolean;
+      prAutoMonitor: boolean;
     }>;
     assert.deepEqual(initial, [{
       repo: "acme/widgets",
@@ -1180,6 +1181,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       ownPrsOnly: true,
       issueAutoEvaluate: false,
       issueAutoWork: false,
+      prAutoMonitor: true,
     }]);
 
     const updateResponse = await fetch(`${harness.baseUrl}/api/repos/settings`, {
@@ -1201,6 +1203,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       ownPrsOnly: boolean;
       issueAutoEvaluate: boolean;
       issueAutoWork: boolean;
+      prAutoMonitor: boolean;
     };
     // Enabling auto-work implicitly enables auto-evaluate — they're dependent settings,
     // not independent flags. Verifies coercion in applyWatchedRepoUpdate.
@@ -1210,6 +1213,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       ownPrsOnly: false,
       issueAutoEvaluate: true,
       issueAutoWork: true,
+      prAutoMonitor: true,
     });
 
     const persisted = await harness.storage.getRepoSettings("acme/widgets");
@@ -1219,6 +1223,7 @@ test("GET/PATCH /api/repos/settings exposes repo-level settings", async () => {
       ownPrsOnly: false,
       issueAutoEvaluate: true,
       issueAutoWork: true,
+      prAutoMonitor: true,
     });
   } finally {
     await harness.close();
@@ -1251,6 +1256,7 @@ test("PATCH /api/repos/settings can update only ownPrsOnly", async () => {
       ownPrsOnly: boolean;
       issueAutoEvaluate: boolean;
       issueAutoWork: boolean;
+      prAutoMonitor: boolean;
     };
     assert.deepEqual(updated, {
       repo: "acme/widgets",
@@ -1258,6 +1264,7 @@ test("PATCH /api/repos/settings can update only ownPrsOnly", async () => {
       ownPrsOnly: false,
       issueAutoEvaluate: false,
       issueAutoWork: false,
+      prAutoMonitor: true,
     });
   } finally {
     await harness.close();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -262,12 +262,14 @@ export async function registerRoutes(
         ownPrsOnly: z.boolean().optional(),
         issueAutoEvaluate: z.boolean().optional(),
         issueAutoWork: z.boolean().optional(),
+        prAutoMonitor: z.boolean().optional(),
       }).refine(
         (value) => (
           value.autoCreateReleases !== undefined
           || value.ownPrsOnly !== undefined
           || value.issueAutoEvaluate !== undefined
           || value.issueAutoWork !== undefined
+          || value.prAutoMonitor !== undefined
         ),
         "At least one repository setting must be provided",
       ).parse(req.body);

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -157,6 +157,7 @@ type WatchedRepoRow = {
   own_prs_only: number;
   issue_auto_evaluate: number;
   issue_auto_work: number;
+  pr_auto_monitor: number;
 };
 
 type FeedbackItemRow = {
@@ -859,6 +860,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("watched_repos", "own_prs_only", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("watched_repos", "issue_auto_work", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("watched_repos", "issue_auto_evaluate", "INTEGER NOT NULL DEFAULT 0");
+    this.ensureColumn("watched_repos", "pr_auto_monitor", "INTEGER NOT NULL DEFAULT 1");
     this.exec("UPDATE watched_repos SET issue_auto_evaluate = 1 WHERE issue_auto_work = 1 AND issue_auto_evaluate = 0");
     this.ensureColumn("config", "max_concurrent_issue_evaluations", "INTEGER NOT NULL DEFAULT 2");
     this.ensureColumn("config", "max_concurrent_issue_work", "INTEGER NOT NULL DEFAULT 1");
@@ -1093,12 +1095,13 @@ export class SqliteStorage implements IStorage {
       for (const repo of config.watchedRepos) {
         const settings = watchedRepoSettings.get(repo);
         this.run(
-          "INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work) VALUES (?, ?, ?, ?, ?)",
+          "INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work, pr_auto_monitor) VALUES (?, ?, ?, ?, ?, ?)",
           repo,
           settings?.auto_create_releases ?? 0,
           settings?.own_prs_only ?? 1,
           settings?.issue_auto_evaluate ?? 0,
           settings?.issue_auto_work ?? 0,
+          settings?.pr_auto_monitor ?? 1,
         );
       }
     });
@@ -1111,12 +1114,13 @@ export class SqliteStorage implements IStorage {
       ownPrsOnly: Boolean(row.own_prs_only ?? 1),
       issueAutoEvaluate: Boolean(row.issue_auto_evaluate ?? 0),
       issueAutoWork: Boolean(row.issue_auto_work ?? 0),
+      prAutoMonitor: Boolean(row.pr_auto_monitor ?? 1),
     };
   }
 
   private getWatchedRepoRows(): WatchedRepoRow[] {
     return this.all<WatchedRepoRow>(
-      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work FROM watched_repos ORDER BY repo ASC",
+      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work, pr_auto_monitor FROM watched_repos ORDER BY repo ASC",
     );
   }
 
@@ -1767,7 +1771,7 @@ export class SqliteStorage implements IStorage {
 
   async getRepoSettings(repo: string): Promise<WatchedRepo | undefined> {
     const row = this.get<WatchedRepoRow>(
-      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work FROM watched_repos WHERE repo = ?",
+      "SELECT repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work, pr_auto_monitor FROM watched_repos WHERE repo = ?",
       repo,
     );
     return row ? this.parseWatchedRepoRow(row) : undefined;
@@ -1783,25 +1787,28 @@ export class SqliteStorage implements IStorage {
       ownPrsOnly: true,
       issueAutoEvaluate: false,
       issueAutoWork: false,
+      prAutoMonitor: true,
     };
     const next = applyWatchedRepoUpdate(existing, updates);
 
     this.withWriteTransaction(() => {
       this.run(
         `
-          INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work)
-          VALUES (?, ?, ?, ?, ?)
+          INSERT INTO watched_repos (repo, auto_create_releases, own_prs_only, issue_auto_evaluate, issue_auto_work, pr_auto_monitor)
+          VALUES (?, ?, ?, ?, ?, ?)
           ON CONFLICT(repo) DO UPDATE SET
             auto_create_releases = excluded.auto_create_releases,
             own_prs_only = excluded.own_prs_only,
             issue_auto_evaluate = excluded.issue_auto_evaluate,
-            issue_auto_work = excluded.issue_auto_work
+            issue_auto_work = excluded.issue_auto_work,
+            pr_auto_monitor = excluded.pr_auto_monitor
         `,
         next.repo,
         Number(next.autoCreateReleases),
         Number(next.ownPrsOnly),
         Number(next.issueAutoEvaluate),
         Number(next.issueAutoWork),
+        Number(next.prAutoMonitor),
       );
     });
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -230,6 +230,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     ownPrsOnly: false,
     issueAutoEvaluate: false,
     issueAutoWork: false,
+    prAutoMonitor: true,
   });
   assert.equal(runtime.drainMode, true);
   assert.equal(runtime.drainRequestedAt, "2026-03-18T10:00:00.000Z");
@@ -489,6 +490,7 @@ test("SqliteStorage updateRepoSettings tracks a previously untracked repo", asyn
       ownPrsOnly: false,
       issueAutoEvaluate: true,
       issueAutoWork: true,
+      prAutoMonitor: true,
     });
 
     const after = await storage.getConfig();
@@ -501,6 +503,7 @@ test("SqliteStorage updateRepoSettings tracks a previously untracked repo", asyn
       ownPrsOnly: false,
       issueAutoEvaluate: true,
       issueAutoWork: true,
+      prAutoMonitor: true,
     });
   } finally {
     storage.close();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -599,6 +599,7 @@ export const watchedRepoSchema = z.object({
   ownPrsOnly: z.boolean(),
   issueAutoEvaluate: z.boolean(),
   issueAutoWork: z.boolean(),
+  prAutoMonitor: z.boolean(),
 });
 export type WatchedRepo = z.infer<typeof watchedRepoSchema>;
 


### PR DESCRIPTION
## Summary
- Add per-repo `prAutoMonitor` setting (default Auto) with a Manual/Auto control on each repo card in Settings, alongside the existing Issue evaluate/work controls.
- When set to Manual, the watcher still syncs the repo's PR list, archives closed PRs, and syncs GitHub feedback — but skips scheduling `babysit_pr` jobs for that repo. The per-PR babysit button continues to work for manual triggers.
- Surface a "Per-repo overrides in Settings." hint under the global Pull-requests switch in the Auto Mode popover.

## Verification
- `npm run check` — clean
- `npm test` — 527/527 passing
- `npx eslint` on touched files — clean
- Manual smoke not run yet; default value preserves existing behavior on existing installs (migration adds column with `DEFAULT 1`).

## Related Issue
- Closes #38
- [#38 Add Manual/Auto toggle for per-repo PR monitoring](https://github.com/jeremymcs/patchdeck/issues/38)

## Repo
- jeremymcs/patchdeck

## Branch
- feat/per-repo-pr-monitor-toggle