### PR TITLE
fix: persist auto mode switches

### DIFF
--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -459,6 +459,8 @@ describe("MemStorage", () => {
         githubCommentAppName: " Review Bot ",
         includeRepositoryLinksInGitHubComments: false,
         postGitHubProgressReplies: true,
+        autoPrs: false,
+        autoIssues: false,
         autoHealCI: true,
         maxHealingAttemptsPerSession: 5,
         maxHealingAttemptsPerFingerprint: 4,
@@ -470,6 +472,8 @@ describe("MemStorage", () => {
       assert.deepEqual(fetched.githubTokens, ["tok_123", "tok_456"]);
       assert.equal(fetched.githubCommentAppName, "Review Bot");
       assert.equal(fetched.postGitHubProgressReplies, true);
+      assert.equal(fetched.autoPrs, false);
+      assert.equal(fetched.autoIssues, false);
     });
   });
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -75,6 +75,8 @@ type ConfigRow = {
   auto_resolve_merge_conflicts: number;
   auto_create_releases: number;
   auto_update_docs: number;
+  auto_prs: number;
+  auto_issues: number;
   include_repository_links_in_github_comments: number;
   github_comment_app_name: string;
   post_github_progress_replies: number;
@@ -531,6 +533,8 @@ export class SqliteStorage implements IStorage {
         auto_resolve_merge_conflicts INTEGER NOT NULL DEFAULT 1,
         auto_create_releases INTEGER NOT NULL DEFAULT 0,
         auto_update_docs INTEGER NOT NULL DEFAULT 1,
+        auto_prs INTEGER NOT NULL DEFAULT 1,
+        auto_issues INTEGER NOT NULL DEFAULT 1,
         include_repository_links_in_github_comments INTEGER NOT NULL DEFAULT 1,
         github_comment_app_name TEXT NOT NULL DEFAULT 'patchdeck',
         post_github_progress_replies INTEGER NOT NULL DEFAULT 0,
@@ -844,6 +848,8 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "auto_resolve_merge_conflicts", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "auto_create_releases", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_update_docs", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "auto_prs", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "auto_issues", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "include_repository_links_in_github_comments", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "github_comment_app_name", "TEXT NOT NULL DEFAULT 'patchdeck'");
     this.ensureColumn("config", "post_github_progress_replies", "INTEGER NOT NULL DEFAULT 0");
@@ -953,8 +959,8 @@ export class SqliteStorage implements IStorage {
       autoResolveMergeConflicts: Boolean(row.auto_resolve_merge_conflicts),
       autoCreateReleases: Boolean(row.auto_create_releases ?? Number(DEFAULT_CONFIG.autoCreateReleases)),
       autoUpdateDocs: Boolean(row.auto_update_docs ?? 1),
-      autoPrs: DEFAULT_CONFIG.autoPrs,
-      autoIssues: DEFAULT_CONFIG.autoIssues,
+      autoPrs: Boolean(row.auto_prs ?? Number(DEFAULT_CONFIG.autoPrs)),
+      autoIssues: Boolean(row.auto_issues ?? Number(DEFAULT_CONFIG.autoIssues)),
       includeRepositoryLinksInGitHubComments: Boolean(
         row.include_repository_links_in_github_comments ?? Number(DEFAULT_CONFIG.includeRepositoryLinksInGitHubComments),
       ),
@@ -1006,6 +1012,8 @@ export class SqliteStorage implements IStorage {
           auto_resolve_merge_conflicts,
           auto_create_releases,
           auto_update_docs,
+          auto_prs,
+          auto_issues,
           include_repository_links_in_github_comments,
           github_comment_app_name,
           post_github_progress_replies,
@@ -1023,7 +1031,7 @@ export class SqliteStorage implements IStorage {
           trusted_reviewers_json,
           priority_issue_authors_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -1039,6 +1047,8 @@ export class SqliteStorage implements IStorage {
           auto_resolve_merge_conflicts = excluded.auto_resolve_merge_conflicts,
           auto_create_releases = excluded.auto_create_releases,
           auto_update_docs = excluded.auto_update_docs,
+          auto_prs = excluded.auto_prs,
+          auto_issues = excluded.auto_issues,
           include_repository_links_in_github_comments = excluded.include_repository_links_in_github_comments,
           github_comment_app_name = excluded.github_comment_app_name,
           post_github_progress_replies = excluded.post_github_progress_replies,
@@ -1072,6 +1082,8 @@ export class SqliteStorage implements IStorage {
         Number(config.autoResolveMergeConflicts),
         Number(config.autoCreateReleases),
         Number(config.autoUpdateDocs),
+        Number(config.autoPrs),
+        Number(config.autoIssues),
         Number(config.includeRepositoryLinksInGitHubComments),
         config.githubCommentAppName,
         Number(config.postGitHubProgressReplies),
@@ -1744,7 +1756,7 @@ export class SqliteStorage implements IStorage {
     const row = this.get<ConfigRow>(`
       SELECT github_token, github_tokens_json, web_username, web_password, coding_agent, fallback_to_next_coding_agent, model, max_turns, batch_window_ms,
              poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_create_releases,
-             auto_update_docs, include_repository_links_in_github_comments, github_comment_app_name,
+             auto_update_docs, auto_prs, auto_issues, include_repository_links_in_github_comments, github_comment_app_name,
              post_github_progress_replies,
              auto_heal_ci, max_healing_attempts_per_session,
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -79,6 +79,8 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     fallbackToNextCodingAgent: true,
     autoCreateReleases: false,
     autoUpdateDocs: false,
+    autoPrs: false,
+    autoIssues: false,
     includeRepositoryLinksInGitHubComments: false,
     githubCommentAppName: "Review Bot",
     postGitHubProgressReplies: true,
@@ -213,6 +215,8 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(config.fallbackToNextCodingAgent, true);
   assert.equal(config.autoCreateReleases, false);
   assert.equal(config.autoUpdateDocs, false);
+  assert.equal(config.autoPrs, false);
+  assert.equal(config.autoIssues, false);
   assert.equal(config.includeRepositoryLinksInGitHubComments, false);
   assert.equal(config.githubCommentAppName, "Review Bot");
   assert.equal(config.postGitHubProgressReplies, true);
@@ -437,6 +441,14 @@ test("SqliteStorage schema defaults automatic release creation off", async () =>
     assert.equal(
       configColumns.find((column) => column.name === "auto_create_releases")?.dflt_value,
       "0",
+    );
+    assert.equal(
+      configColumns.find((column) => column.name === "auto_prs")?.dflt_value,
+      "1",
+    );
+    assert.equal(
+      configColumns.find((column) => column.name === "auto_issues")?.dflt_value,
+      "1",
     );
     assert.equal(
       watchedRepoColumns.find((column) => column.name === "auto_create_releases")?.dflt_value,


### PR DESCRIPTION
## Summary
- persist global `autoPrs` and `autoIssues` in SQLite config storage
- preserve default-on behavior for existing databases through migration columns
- add regression coverage for SQLite reload-from-disk behavior and memory storage config updates

Closes #40

## Verification
- `node --import tsx --test server/storage.test.ts`
- `node --import tsx --test server/memoryStorage.test.ts`
- `npm run check`
- `npm run test`
- `git diff --check`