### PR TITLE
fix: bundle Windows Tauri Node runtime

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -64,6 +64,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Bundle Windows Node runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force vendor/node | Out-Null
+          $nodePath = (Get-Command node).Source
+          Copy-Item $nodePath vendor/node/node.exe
+
       - name: Build Tauri app
         if: github.event_name != 'release'
         uses: tauri-apps/tauri-action@v0

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,16 +21,56 @@ fn version_sort_key(path: &Path) -> Vec<u32> {
 fn node_binary_for_version(version_dir: &Path) -> Option<PathBuf> {
     [
         version_dir.join("bin").join("node"),
+        version_dir.join("bin").join("node.exe"),
         version_dir.join("installation").join("bin").join("node"),
+        version_dir
+            .join("installation")
+            .join("bin")
+            .join("node.exe"),
+        version_dir.join("node.exe"),
     ]
     .into_iter()
     .find(|path| path.exists())
 }
 
+fn home_dir() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return Some(PathBuf::from(home));
+        }
+    }
+
+    if let Ok(profile) = std::env::var("USERPROFILE") {
+        if !profile.is_empty() {
+            return Some(PathBuf::from(profile));
+        }
+    }
+
+    match (std::env::var("HOMEDRIVE"), std::env::var("HOMEPATH")) {
+        (Ok(drive), Ok(path)) if !drive.is_empty() && !path.is_empty() => {
+            Some(PathBuf::from(format!("{}{}", drive, path)))
+        }
+        _ => None,
+    }
+}
+
 /// Find the node binary by checking common install locations.
 /// GUI apps on macOS don't inherit the shell PATH, so `node` alone won't resolve
 /// for nvm, Homebrew, fnm, Volta, or other version managers.
-fn find_node() -> Option<PathBuf> {
+fn bundled_node(resource_dir: &Path) -> Option<PathBuf> {
+    [
+        resource_dir.join("vendor").join("node").join("node.exe"),
+        resource_dir.join("vendor").join("node").join("node"),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+fn find_node(resource_dir: &Path) -> Option<PathBuf> {
+    if let Some(node) = bundled_node(resource_dir) {
+        return Some(node);
+    }
+
     // First, try the bare command (works if node is in the system PATH)
     if Command::new("node")
         .arg("--version")
@@ -40,24 +80,53 @@ fn find_node() -> Option<PathBuf> {
         return Some(PathBuf::from("node"));
     }
 
-    let home = std::env::var("HOME").ok()?;
-    let candidates = [
-        // nvm (most common on macOS)
-        format!("{}/.nvm/versions/node", home),
-        // fnm
-        format!("{}/.local/share/fnm/node-versions", home),
-        format!("{}/Library/Application Support/fnm/node-versions", home),
-        // Volta
-        format!("{}/.volta/tools/image/node", home),
-    ];
+    let home = home_dir();
+    let mut candidates: Vec<PathBuf> = Vec::new();
 
-    for base in &candidates {
-        let base_path = PathBuf::from(base);
+    if let Some(home) = &home {
+        // nvm (most common on macOS)
+        candidates.push(home.join(".nvm").join("versions").join("node"));
+        // fnm
+        candidates.push(
+            home.join(".local")
+                .join("share")
+                .join("fnm")
+                .join("node-versions"),
+        );
+        candidates.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("fnm")
+                .join("node-versions"),
+        );
+        // Volta
+        candidates.push(home.join(".volta").join("tools").join("image").join("node"));
+    }
+
+    if cfg!(target_os = "windows") {
+        if let Ok(app_data) = std::env::var("APPDATA") {
+            candidates.push(PathBuf::from(app_data).join("nvm"));
+        }
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            let local_app_data = PathBuf::from(local_app_data);
+            candidates.push(
+                local_app_data
+                    .clone()
+                    .join("Volta")
+                    .join("tools")
+                    .join("image")
+                    .join("node"),
+            );
+            candidates.push(local_app_data.join("fnm_multishells"));
+        }
+    }
+
+    for base_path in &candidates {
         if !base_path.is_dir() {
             continue;
         }
         // Pick the highest semver directory
-        if let Ok(entries) = std::fs::read_dir(&base_path) {
+        if let Ok(entries) = std::fs::read_dir(base_path) {
             let mut versions: Vec<PathBuf> = entries
                 .filter_map(|e| e.ok())
                 .map(|e| e.path())
@@ -74,12 +143,13 @@ fn find_node() -> Option<PathBuf> {
         }
     }
 
-    // Homebrew paths
-    let brew_paths = [
+    let fixed_paths = [
         "/opt/homebrew/bin/node", // Apple Silicon
         "/usr/local/bin/node",    // Intel Mac / Linux Homebrew
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\Program Files (x86)\\nodejs\\node.exe",
     ];
-    for path in &brew_paths {
+    for path in &fixed_paths {
         let p = PathBuf::from(path);
         if p.exists() {
             return Some(p);
@@ -89,20 +159,32 @@ fn find_node() -> Option<PathBuf> {
     None
 }
 
+fn push_existing_path(entries: &mut Vec<PathBuf>, path: impl Into<PathBuf>) {
+    let path = path.into();
+    if path.exists() {
+        entries.push(path);
+    }
+}
+
+fn joined_path(entries: Vec<PathBuf>) -> String {
+    std::env::join_paths(entries)
+        .map(|paths| paths.to_string_lossy().to_string())
+        .unwrap_or_default()
+}
+
 /// Build a PATH that includes the user's shell-managed binary locations.
 /// macOS GUI apps don't inherit the shell PATH, so `gh`, `git`, codex/claude CLIs
 /// won't resolve unless we extend it ourselves.
 fn build_subprocess_path() -> String {
-    let mut entries: Vec<String> = Vec::new();
+    let mut entries: Vec<PathBuf> = Vec::new();
 
     if let Ok(existing) = std::env::var("PATH") {
         if !existing.is_empty() {
-            entries.push(existing);
+            entries.extend(std::env::split_paths(&existing));
         }
     }
 
-    let home = std::env::var("HOME").unwrap_or_default();
-    let candidates = [
+    let unix_candidates = [
         "/opt/homebrew/bin",
         "/opt/homebrew/sbin",
         "/usr/local/bin",
@@ -112,27 +194,47 @@ fn build_subprocess_path() -> String {
         "/usr/sbin",
         "/sbin",
     ];
-    for path in candidates {
-        if PathBuf::from(path).exists() {
-            entries.push(path.to_string());
-        }
+    for path in unix_candidates {
+        push_existing_path(&mut entries, path);
     }
 
-    if !home.is_empty() {
+    if let Some(home) = home_dir() {
         for suffix in [".local/bin", ".cargo/bin", ".npm-global/bin", "bin"] {
-            let p = PathBuf::from(&home).join(suffix);
-            if p.exists() {
-                entries.push(p.display().to_string());
+            push_existing_path(&mut entries, home.join(suffix));
+        }
+
+        push_existing_path(&mut entries, home.join("scoop").join("shims"));
+        push_existing_path(
+            &mut entries,
+            home.join("AppData").join("Roaming").join("npm"),
+        );
+    }
+
+    if cfg!(target_os = "windows") {
+        for key in ["ProgramFiles", "ProgramFiles(x86)"] {
+            if let Ok(program_files) = std::env::var(key) {
+                push_existing_path(&mut entries, PathBuf::from(program_files).join("nodejs"));
             }
         }
+
+        if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+            push_existing_path(
+                &mut entries,
+                PathBuf::from(local_app_data)
+                    .join("Programs")
+                    .join("Git")
+                    .join("cmd"),
+            );
+        }
     }
 
-    entries.join(":")
+    joined_path(entries)
 }
 
 /// Best-effort: launch the user's login shell to capture env vars they set in
 /// `~/.zshrc`, `~/.zshenv`, `~/.bash_profile`, etc. The Tauri process itself
 /// doesn't see these when launched from Finder.
+#[cfg(not(target_os = "windows"))]
 fn read_login_shell_env() -> Vec<(String, String)> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     // -l: login shell, -i: interactive (loads .zshrc / .bashrc), -c: command
@@ -140,7 +242,9 @@ fn read_login_shell_env() -> Vec<(String, String)> {
         .args(["-l", "-i", "-c", "env -0"])
         .output();
 
-    let Ok(output) = output else { return Vec::new() };
+    let Ok(output) = output else {
+        return Vec::new();
+    };
     if !output.status.success() {
         return Vec::new();
     }
@@ -158,6 +262,11 @@ fn read_login_shell_env() -> Vec<(String, String)> {
     pairs
 }
 
+#[cfg(target_os = "windows")]
+fn read_login_shell_env() -> Vec<(String, String)> {
+    Vec::new()
+}
+
 fn start_server(resource_dir: PathBuf, port: u16) -> Result<Child, String> {
     let server_script = resource_dir.join("dist").join("index.cjs");
 
@@ -168,7 +277,7 @@ fn start_server(resource_dir: PathBuf, port: u16) -> Result<Child, String> {
         ));
     }
 
-    let node = find_node().ok_or_else(|| {
+    let node = find_node(&resource_dir).ok_or_else(|| {
         "Node.js not found. Please install Node.js (https://nodejs.org) and restart the app."
             .to_string()
     })?;
@@ -197,6 +306,68 @@ fn start_server(resource_dir: PathBuf, port: u16) -> Result<Child, String> {
     command
         .spawn()
         .map_err(|e| format!("Failed to start server with {}: {}", node.display(), e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("patchdeck-tauri-{}-{}", name, std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn node_binary_for_version_accepts_windows_node_exe_layout() {
+        let dir = temp_dir("node-exe");
+        let node = dir.join("node.exe");
+        File::create(&node).expect("create node.exe");
+
+        assert_eq!(node_binary_for_version(&dir), Some(node));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn find_node_prefers_bundled_runtime() {
+        let dir = temp_dir("bundled-node");
+        let bundled_dir = dir.join("vendor").join("node");
+        fs::create_dir_all(&bundled_dir).expect("create bundled node dir");
+        let node = bundled_dir.join("node.exe");
+        File::create(&node).expect("create bundled node.exe");
+
+        assert_eq!(find_node(&dir), Some(node));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn joined_path_uses_platform_path_separator() {
+        let first = PathBuf::from("first");
+        let second = PathBuf::from("second");
+        let path = joined_path(vec![first.clone(), second.clone()]);
+        let parsed: Vec<PathBuf> = std::env::split_paths(&path).collect();
+
+        assert_eq!(parsed, vec![first, second]);
+    }
+
+    #[test]
+    fn build_subprocess_path_is_parseable_by_current_platform() {
+        let path = build_subprocess_path();
+
+        assert!(
+            !path.is_empty(),
+            "subprocess PATH should include the existing process PATH"
+        );
+        assert!(
+            std::env::split_paths(&path).next().is_some(),
+            "subprocess PATH should use the current platform separator"
+        );
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,7 +38,8 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "../dist": "dist/"
+      "../dist": "dist/",
+      "../vendor/node": "vendor/node/"
     },
     "externalBin": [],
     "macOS": {

--- a/vendor/node/.gitkeep
+++ b/vendor/node/.gitkeep
@@ -1,0 +1,1 @@
+Windows release builds copy node.exe into this directory before Tauri bundles resources.


### PR DESCRIPTION
## Summary

- bundle the Windows runner's node.exe into Tauri resources for Windows release builds
- make the Tauri launcher prefer the bundled Node runtime before falling back to local installs
- make Node discovery and subprocess PATH construction platform-aware for Windows

Fixes #44

## Validation

- npm run check
- npm run build
- npm run test:all — 587 passed, 0 skipped
- cargo test --manifest-path src-tauri/Cargo.toml — 6 passed
- npm run tauri:build
