### PR TITLE
feat: share ActivityMenu, dashboard refresh, GitHub rate-limit backoff

### DIFF
--- a/client/src/components/ActivityMenu.tsx
+++ b/client/src/components/ActivityMenu.tsx
@@ -1,0 +1,203 @@
+import { Activity as ActivityIcon } from "lucide-react";
+import type { ActivityItem, ActivitySnapshot } from "@shared/schema";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import type { QueueStatusView } from "@/lib/activityQueue";
+
+export const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
+  failed: [],
+  inProgress: [],
+  queued: [],
+  warnings: [],
+  generatedAt: "",
+};
+
+export const QUEUED_DRAIN_COPY = "Queued automation is paused until drain mode is disabled.";
+
+function formatClock(timestamp: string | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+  return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
+}
+
+function formatPollLabel(pollIntervalMs?: number): string {
+  const seconds = Math.max(1, Math.round((pollIntervalMs ?? 120000) / 1000));
+  return `${seconds}s`;
+}
+
+function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueStatus: QueueStatusView | null }) {
+  const timeLabel = activity.status === "failed"
+    ? formatClock(activity.updatedAt)
+    : activity.status === "in_progress"
+      ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
+      : formatClock(activity.availableAt) ?? formatClock(activity.queuedAt);
+
+  const content = (
+    <div className="flex min-w-0 items-start gap-2 px-2 py-1.5 text-left">
+      <span
+        className={`mt-1.5 h-1.5 w-1.5 shrink-0 ${
+          activity.status === "failed"
+            ? "bg-destructive"
+            : activity.status === "in_progress"
+              ? "animate-pulse bg-foreground"
+              : "bg-muted-foreground"
+        }`}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
+        {activity.detail && (
+          <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
+        )}
+        <div className="mt-1">
+          <QueueStatusBadge status={queueStatus} />
+        </div>
+        {activity.status === "failed" && activity.lastError && (
+          <span
+            className="block whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
+            title={activity.lastError}
+          >
+            {activity.lastError}
+          </span>
+        )}
+      </span>
+      {timeLabel && (
+        <span className="shrink-0 text-[10px] leading-4 text-muted-foreground">{timeLabel}</span>
+      )}
+    </div>
+  );
+
+  if (activity.targetUrl) {
+    return (
+      <a
+        href={activity.targetUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block outline-none hover:bg-muted focus:bg-muted focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <div>{content}</div>;
+}
+
+function ActivitySection({
+  title,
+  items,
+  emptyLabel,
+  queueStatusById,
+}: {
+  title: string;
+  items: ActivityItem[];
+  emptyLabel: string;
+  queueStatusById: Map<string, QueueStatusView>;
+}) {
+  return (
+    <div className="py-1">
+      <div className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">{title}</div>
+      {items.length > 0 ? (
+        <div className="max-h-52 overflow-y-auto">
+          {items.map((activity) => (
+            <ActivityRow key={activity.id} activity={activity} queueStatus={queueStatusById.get(activity.targetId) ?? null} />
+          ))}
+        </div>
+      ) : (
+        <div className="px-2 pb-2 text-[11px] text-muted-foreground">{emptyLabel}</div>
+      )}
+    </div>
+  );
+}
+
+export function ActivityMenu({
+  activities,
+  onClearFailed,
+  isClearingFailed,
+  globalDrainMode,
+  queueStatusById,
+  pollIntervalMs,
+}: {
+  activities: ActivitySnapshot;
+  onClearFailed: () => void;
+  isClearingFailed: boolean;
+  globalDrainMode: boolean;
+  queueStatusById: Map<string, QueueStatusView>;
+  pollIntervalMs?: number;
+}) {
+  const failedCount = activities.failed.length;
+  const inProgressCount = activities.inProgress.length;
+  const queuedCount = activities.queued.length;
+  const totalCount = failedCount + inProgressCount + queuedCount;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="inline-flex items-center gap-1 border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        aria-label="Open activity menu"
+        data-testid="activity-menu-trigger"
+      >
+        <ActivityIcon className="h-3 w-3" aria-hidden="true" />
+        <span>activity</span>
+        <span className="text-foreground">{totalCount}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-0">
+        <div className="border-b border-border px-2 py-2">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-[12px] font-medium">Activities</div>
+            {failedCount > 0 && (
+              <button
+                type="button"
+                onClick={onClearFailed}
+                disabled={isClearingFailed}
+                className="border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                data-testid="clear-failed-activities"
+              >
+                {isClearingFailed ? "clearing" : "clear failed"}
+              </button>
+            )}
+          </div>
+          <div className="text-[11px] text-muted-foreground">
+            {failedCount} failed / {inProgressCount} in progress / {queuedCount} queued
+          </div>
+        </div>
+        <ActivitySection
+          title="Failed"
+          items={activities.failed}
+          emptyLabel="No failed activities."
+          queueStatusById={queueStatusById}
+        />
+        <div className="border-t border-border" />
+        <ActivitySection
+          title="In progress"
+          items={activities.inProgress}
+          emptyLabel="No activities running right now."
+          queueStatusById={queueStatusById}
+        />
+        <div className="border-t border-border" />
+        <ActivitySection
+          title="Queued"
+          items={activities.queued}
+          emptyLabel="Queue is empty."
+          queueStatusById={queueStatusById}
+        />
+        {globalDrainMode && queuedCount > 0 && (
+          <div
+            className="border-t border-border px-2 py-2 text-[11px] text-muted-foreground"
+            data-testid="activity-drain-note"
+          >
+            {QUEUED_DRAIN_COPY}
+          </div>
+        )}
+        {pollIntervalMs !== undefined && (
+          <div
+            className="border-t border-border px-2 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+            data-testid="activity-poll-footer"
+          >
+            poll <span className="font-mono text-foreground/80">{formatPollLabel(pollIntervalMs)}</span>
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -9,13 +9,24 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 
 type AppHeaderSection = "prs" | "issues" | "releases" | "logs" | "settings";
 
-const NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [
+const PRIMARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [
   { section: "prs", label: "PRs", href: "/" },
   { section: "issues", label: "Issues", href: "/issues" },
   { section: "releases", label: "Releases", href: "/releases" },
+];
+
+const SECONDARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [
   { section: "logs", label: "Logs", href: "/logs" },
   { section: "settings", label: "Settings", href: "/settings" },
 ];
+
+function navLinkClass(selected: boolean) {
+  return `rounded-md border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+    selected
+      ? "border-primary/40 bg-primary/10 text-primary"
+      : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
+  }`;
+}
 
 function PatchdeckMark() {
   return (
@@ -230,18 +241,14 @@ export function AppHeader({
           <span className="text-sm font-semibold tracking-tight">PatchDeck</span>
         </Link>
         <nav aria-label="Primary" className="flex flex-wrap items-center gap-1">
-          {NAV_ITEMS.map((item) => {
+          {PRIMARY_NAV_ITEMS.map((item) => {
             const selected = active === item.section;
             return (
               <Link
                 key={item.section}
                 href={item.href}
                 aria-current={selected ? "page" : undefined}
-                className={`rounded-md border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
-                  selected
-                    ? "border-primary/40 bg-primary/10 text-primary"
-                    : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
-                }`}
+                className={navLinkClass(selected)}
               >
                 {item.label}
               </Link>
@@ -260,6 +267,21 @@ export function AppHeader({
             {actions}
           </div>
         ) : null}
+        <nav aria-label="Secondary" className="flex flex-wrap items-center gap-1">
+          {SECONDARY_NAV_ITEMS.map((item) => {
+            const selected = active === item.section;
+            return (
+              <Link
+                key={item.section}
+                href={item.href}
+                aria-current={selected ? "page" : undefined}
+                className={navLinkClass(selected)}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
         <AutoModeButton />
         <ThemeToggle />
       </div>

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -311,19 +311,17 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasApiRequest(sourceFile, "ask agent mutation", "POST", /`\/api\/prs\/\$\{prId\}\/questions`/);
   assertHasTestId(sourceFile, "dashboard drain banner", "dashboard-drain-banner");
   assertHasTestId(sourceFile, "dashboard drain reason", "dashboard-drain-reason");
-  assertHasTestId(sourceFile, "activity drain note", "activity-drain-note");
   assertHasExpression(sourceFile, "queue status helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "queue status badge", /\bQueueStatusBadge\b/);
   assertHasExpression(sourceFile, "queue status index", /\bqueueStatusById\b/);
   assertHasExpression(sourceFile, "PR number search helper", /\bmatchesNumberSearch\b/);
   assertHasStringValue(sourceFile, "PR number search placeholder", "Search #");
   assertHasExpression(sourceFile, "issue-linked PR index", /\bbuildIssueLinkedPRIndex\b/);
-  assertHasStringValue(sourceFile, "on issues tab label", /On Issues/);
+  assertHasStringValue(sourceFile, "on issues tab label", /Issues \(/);
   assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
   assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");
   assertHasStringValue(sourceFile, "drained PR copy", "Background and manual runs are paused by drain mode.");
   assertHasStringValue(sourceFile, "drained ask copy", "Ask Agent is paused by drain mode.");
-  assertHasStringValue(sourceFile, "queued drain copy", "Queued automation is paused until drain mode is disabled.");
   assertHasStringValue(sourceFile, "dashboard errors heading", "Needs attention");
   assertHasStringValue(sourceFile, "dashboard errors roll-up label", "Roll up");
   assertHasStringValue(sourceFile, "dashboard errors expand label", "Expand");
@@ -489,4 +487,14 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
     ["empty release state", "No release activity yet."],
     ["watched repositories sidebar", "Watched repositories"],
   ]);
+});
+
+test("activity menu keeps the QA-tested trigger, drain note, and poll footer wired", async () => {
+  const { sourceFile } = await parseProjectFile("client/src/components/ActivityMenu.tsx");
+
+  assertHasTestId(sourceFile, "activity menu trigger", "activity-menu-trigger");
+  assertHasTestId(sourceFile, "clear failed activities", "clear-failed-activities");
+  assertHasTestId(sourceFile, "activity drain note", "activity-drain-note");
+  assertHasTestId(sourceFile, "activity poll footer", "activity-poll-footer");
+  assertHasStringValue(sourceFile, "queued drain copy", "Queued automation is paused until drain mode is disabled.");
 });

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,17 +2,13 @@ import { memo, useEffect, useMemo, useRef, useState, type MouseEvent } from "rea
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { Activity as ActivityIcon, AlertTriangle, Bot, ChevronDown, ChevronUp, Trash2 } from "lucide-react";
+import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, RefreshCw, Trash2 } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, LogEntry, OperatorWarning, PR, PRQuestion, RuntimeState, WatchedRepo } from "@shared/schema";
 import { AppHeader } from "@/components/AppHeader";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { toast } from "@/hooks/use-toast";
 import {
@@ -86,11 +82,6 @@ function formatStatusLabel(status: PR["status"]): string {
   return "watching";
 }
 
-function formatPollInterval(pollIntervalMs?: number): string {
-  const seconds = Math.max(1, Math.round((pollIntervalMs ?? 120000) / 1000));
-  return `${seconds}s`;
-}
-
 function latestActivityForTarget(activities: ActivityItem[], targetId: string): ActivityItem | undefined {
   return activities.reduce((latest, activity) => {
     if (activity.targetId !== targetId) {
@@ -130,20 +121,12 @@ function getPRFeedbackFailureReason(pr: PR): string | null {
   return failedItem?.statusReason ?? null;
 }
 
-const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
-  failed: [],
-  inProgress: [],
-  queued: [],
-  warnings: [],
-  generatedAt: "",
-};
 const MAX_VISIBLE_LOGS = 200;
 const DRAIN_PAUSED_LABEL = "Paused";
 const DRAIN_PAUSED_TITLE = "Paused by drain mode";
 const MANUAL_RUNS_BLOCKED_COPY = "Manual runs are blocked while global automation is paused.";
 const GLOBAL_DRAIN_PR_COPY = "Background and manual runs are paused by drain mode.";
 const ASK_DRAIN_COPY = "Ask Agent is paused by drain mode.";
-const QUEUED_DRAIN_COPY = "Queued automation is paused until drain mode is disabled.";
 
 const HEALING_TONE_CLASSES: Record<"neutral" | "info" | "warning" | "success" | "danger", string> = {
   neutral: "border-border text-muted-foreground",
@@ -177,171 +160,6 @@ function WatchPausedIndicator() {
     <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
       watch paused
     </span>
-  );
-}
-
-function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueStatus: QueueStatusView | null }) {
-  const timeLabel = activity.status === "failed"
-    ? formatClock(activity.updatedAt)
-    : activity.status === "in_progress"
-    ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
-    : formatClock(activity.availableAt) ?? formatClock(activity.queuedAt);
-  const content = (
-    <div className="flex min-w-0 items-start gap-2 px-2 py-1.5 text-left">
-      <span
-        className={`mt-1.5 h-1.5 w-1.5 shrink-0 ${
-          activity.status === "failed"
-            ? "bg-destructive"
-            : activity.status === "in_progress"
-              ? "animate-pulse bg-foreground"
-              : "bg-muted-foreground"
-        }`}
-      />
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
-        {activity.detail && (
-          <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
-        )}
-        <div className="mt-1">
-          <QueueStatusBadge status={queueStatus} />
-        </div>
-        {activity.status === "failed" && activity.lastError && (
-          <span
-            className="block whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
-            title={activity.lastError}
-          >
-            {activity.lastError}
-          </span>
-        )}
-      </span>
-      {timeLabel && (
-        <span className="shrink-0 text-[10px] leading-4 text-muted-foreground">{timeLabel}</span>
-      )}
-    </div>
-  );
-
-  if (activity.targetUrl) {
-    return (
-      <a
-        href={activity.targetUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block outline-none hover:bg-muted focus:bg-muted focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-      >
-        {content}
-      </a>
-    );
-  }
-
-  return <div>{content}</div>;
-}
-
-function ActivitySection({
-  title,
-  items,
-  emptyLabel,
-  queueStatusById,
-}: {
-  title: string;
-  items: ActivityItem[];
-  emptyLabel: string;
-  queueStatusById: Map<string, QueueStatusView>;
-}) {
-  return (
-    <div className="py-1">
-      <div className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">{title}</div>
-      {items.length > 0 ? (
-        <div className="max-h-52 overflow-y-auto">
-          {items.map((activity) => (
-            <ActivityRow key={activity.id} activity={activity} queueStatus={queueStatusById.get(activity.targetId) ?? null} />
-          ))}
-        </div>
-      ) : (
-        <div className="px-2 pb-2 text-[11px] text-muted-foreground">{emptyLabel}</div>
-      )}
-    </div>
-  );
-}
-
-function ActivityMenu({
-  activities,
-  onClearFailed,
-  isClearingFailed,
-  globalDrainMode,
-  queueStatusById,
-}: {
-  activities: ActivitySnapshot;
-  onClearFailed: () => void;
-  isClearingFailed: boolean;
-  globalDrainMode: boolean;
-  queueStatusById: Map<string, QueueStatusView>;
-}) {
-  const failedCount = activities.failed.length;
-  const inProgressCount = activities.inProgress.length;
-  const queuedCount = activities.queued.length;
-  const totalCount = failedCount + inProgressCount + queuedCount;
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        className="inline-flex items-center gap-1 border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-        aria-label="Open activity menu"
-        data-testid="activity-menu-trigger"
-      >
-        <ActivityIcon className="h-3 w-3" aria-hidden="true" />
-        <span>activity</span>
-        <span className="text-foreground">{totalCount}</span>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-80 p-0">
-        <div className="border-b border-border px-2 py-2">
-          <div className="flex items-center justify-between gap-2">
-            <div className="text-[12px] font-medium">Activities</div>
-            {failedCount > 0 && (
-              <button
-                type="button"
-                onClick={onClearFailed}
-                disabled={isClearingFailed}
-                className="border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                data-testid="clear-failed-activities"
-              >
-                {isClearingFailed ? "clearing" : "clear failed"}
-              </button>
-            )}
-          </div>
-          <div className="text-[11px] text-muted-foreground">
-            {failedCount} failed / {inProgressCount} in progress / {queuedCount} queued
-          </div>
-        </div>
-        <ActivitySection
-          title="Failed"
-          items={activities.failed}
-          emptyLabel="No failed activities."
-          queueStatusById={queueStatusById}
-        />
-        <div className="border-t border-border" />
-        <ActivitySection
-          title="In progress"
-          items={activities.inProgress}
-          emptyLabel="No activities running right now."
-          queueStatusById={queueStatusById}
-        />
-        <div className="border-t border-border" />
-        <ActivitySection
-          title="Queued"
-          items={activities.queued}
-          emptyLabel="Queue is empty."
-          queueStatusById={queueStatusById}
-        />
-        {globalDrainMode && queuedCount > 0 && (
-          <div
-            className="border-t border-border px-2 py-2 text-[11px] text-muted-foreground"
-            data-testid="activity-drain-note"
-          >
-            {QUEUED_DRAIN_COPY}
-          </div>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }
 
@@ -1287,6 +1105,24 @@ export default function Dashboard() {
   const [viewMode, setViewMode] = useState<"active" | "issues" | "archived">("active");
   const [prNumberSearch, setPrNumberSearch] = useState("");
   const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefreshDashboard = async () => {
+    setIsRefreshing(true);
+    try {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/prs"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/healing-sessions"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/runtime"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] }),
+      ]);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
 
   const { data: prs = [], isLoading } = useQuery<PR[]>({
     queryKey: ["/api/prs"],
@@ -1454,14 +1290,9 @@ export default function Dashboard() {
       <AppHeader
         active="prs"
         status={(
-          <>
-            <span>
-              <span className="font-mono text-foreground">{prs.length}</span> PR{prs.length !== 1 ? "s" : ""} / <span className="font-mono text-foreground">{repos.length}</span> repo{repos.length !== 1 ? "s" : ""}
-            </span>
-            <span>
-              poll <span className="font-mono text-foreground/80">{formatPollInterval(config?.pollIntervalMs)}</span>
-            </span>
-          </>
+          <span>
+            <span className="font-mono text-foreground">{prs.length}</span> PR{prs.length !== 1 ? "s" : ""} / <span className="font-mono text-foreground">{repos.length}</span> repo{repos.length !== 1 ? "s" : ""}
+          </span>
         )}
         actions={(
           <>
@@ -1497,12 +1328,23 @@ export default function Dashboard() {
                 <span className="font-mono">{activeErrorCount}</span>
               </button>
             )}
+            <button
+              type="button"
+              onClick={() => { void handleRefreshDashboard(); }}
+              disabled={isRefreshing}
+              data-testid="button-refresh-dashboard"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+            >
+              {isRefreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              refresh
+            </button>
             <ActivityMenu
               activities={activities}
               onClearFailed={() => clearFailedActivitiesMutation.mutate()}
               isClearingFailed={clearFailedActivitiesMutation.isPending}
               globalDrainMode={globalDrainMode}
               queueStatusById={queueStatusById}
+              pollIntervalMs={config?.pollIntervalMs}
             />
           </>
         )}
@@ -1528,7 +1370,7 @@ export default function Dashboard() {
               type="button"
               onClick={() => setViewMode("active")}
               data-testid="tab-active"
-              className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
                 viewMode === "active"
                   ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
                   : "text-muted-foreground hover:text-foreground"
@@ -1540,19 +1382,19 @@ export default function Dashboard() {
               type="button"
               onClick={() => setViewMode("issues")}
               data-testid="tab-on-issues"
-              className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
                 viewMode === "issues"
                   ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              On Issues ({issueLinkedPRs.length})
+              Issues ({issueLinkedPRs.length})
             </button>
             <button
               type="button"
               onClick={() => setViewMode("archived")}
               data-testid="tab-archived"
-              className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
                 viewMode === "archived"
                   ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
                   : "text-muted-foreground hover:text-foreground"

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -5,10 +5,11 @@ import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
-import type { ActivitySnapshot, Issue, LogEntry, RuntimeState } from "@shared/schema";
+import type { ActivitySnapshot, Config, Issue, LogEntry, RuntimeState } from "@shared/schema";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 
 function formatDateTime(value: string | null | undefined): string {
   if (!value) return "n/a";
@@ -142,14 +143,6 @@ function isStaleIssue(issue: Issue): boolean {
 
   return Date.now() - updatedAt > 7 * 24 * 60 * 60 * 1000;
 }
-
-const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
-  failed: [],
-  inProgress: [],
-  queued: [],
-  warnings: [],
-  generatedAt: "",
-};
 
 function matchesIssueWorkFilter(issue: Issue, filter: IssueWorkFilter): boolean {
   if (filter === "ready") return Boolean(issue.workPrUrl);
@@ -376,7 +369,25 @@ export default function Issues() {
     queryKey: ["/api/activities"],
     refetchInterval: 3000,
   });
+  const { data: config } = useQuery<Config>({ queryKey: ["/api/config"] });
   const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
+
+  const clearFailedActivitiesMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("DELETE", "/api/activities/failed");
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+    },
+    onError: (error) => {
+      toast({
+        title: "Could not clear failed activities",
+        description: error instanceof Error ? error.message : String(error),
+        variant: "destructive",
+      });
+    },
+  });
 
   const { data: issues = [], isLoading, refetch, isFetching } = useQuery<Issue[]>({
     queryKey: ["/api/issues"],
@@ -614,21 +625,31 @@ export default function Issues() {
           </>
         )}
         actions={(
-          <button
-            type="button"
-            onClick={() => {
-              void Promise.all([
-                refetch(),
-                selectedIssueFromList ? refetchSelectedIssueDetail() : Promise.resolve(),
-              ]);
-            }}
-            disabled={isFetching}
-            data-testid="button-refresh-issues"
-            className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
-          >
-            {isFetching ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
-            refresh
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                void Promise.all([
+                  refetch(),
+                  selectedIssueFromList ? refetchSelectedIssueDetail() : Promise.resolve(),
+                ]);
+              }}
+              disabled={isFetching}
+              data-testid="button-refresh-issues"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+            >
+              {isFetching ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              refresh
+            </button>
+            <ActivityMenu
+              activities={activities}
+              onClearFailed={() => clearFailedActivitiesMutation.mutate()}
+              isClearingFailed={clearFailedActivitiesMutation.isPending}
+              globalDrainMode={Boolean(runtime?.drainMode)}
+              queueStatusById={queueStatusById}
+              pollIntervalMs={config?.pollIntervalMs}
+            />
+          </>
         )}
       />
 

--- a/server/github.ts
+++ b/server/github.ts
@@ -740,6 +740,46 @@ class RateLimitGateError extends Error {
   }
 }
 
+const RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS = 15_000;
+
+function parseRetryAfter(value: string | undefined): Date | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return new Date(Date.now() + seconds * 1000);
+    }
+  }
+  const ms = Date.parse(trimmed);
+  return Number.isFinite(ms) ? new Date(ms) : null;
+}
+
+function laterDate(a: Date | null, b: Date | null): Date | null {
+  if (a && b) return a.getTime() >= b.getTime() ? a : b;
+  return a ?? b;
+}
+
+function detectRateLimitFromHeaders(
+  status: number | undefined,
+  headers: Record<string, string>,
+  message: string,
+): { limited: boolean; gateUntil: Date | null } {
+  const remainingRaw = headers["x-ratelimit-remaining"];
+  const retryAfterHeader = headers["retry-after"];
+  const limited = (status === 403 || status === 429)
+    && (remainingRaw === "0" || Boolean(retryAfterHeader) || /rate limit/i.test(message));
+  if (!limited) {
+    return { limited: false, gateUntil: null };
+  }
+  const resetRaw = headers["x-ratelimit-reset"];
+  const resetSeconds = typeof resetRaw === "string" ? Number.parseInt(resetRaw, 10) : Number.NaN;
+  const resetDate = Number.isFinite(resetSeconds) ? new Date(resetSeconds * 1000) : null;
+  const retryDate = parseRetryAfter(retryAfterHeader);
+  return { limited: true, gateUntil: laterDate(resetDate, retryDate) };
+}
+
 function attachRateLimitHook(client: Octokit): void {
   client.hook.wrap("request", async (request, options) => {
     const state = getRateLimitState();
@@ -747,7 +787,7 @@ function attachRateLimitHook(client: Octokit): void {
       throw new RateLimitGateError(state.resetAt);
     }
 
-    try {
+    const dispatch = async (): Promise<ReturnType<typeof request>> => {
       const response = await request(options);
       const remainingRaw = response.headers?.["x-ratelimit-remaining"];
       const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
@@ -755,19 +795,30 @@ function attachRateLimitHook(client: Octokit): void {
         clearRateLimited();
       }
       return response;
-    } catch (error) {
-      const status = (error as { status?: number } | undefined)?.status;
-      const headers = (error as { response?: { headers?: Record<string, string> } } | undefined)?.response?.headers ?? {};
-      const remainingRaw = headers["x-ratelimit-remaining"];
-      const message = error instanceof Error ? error.message.toLowerCase() : "";
-      const looksRateLimited = (status === 403 || status === 429)
-        && (remainingRaw === "0" || /rate limit/i.test(message));
-      if (looksRateLimited) {
-        const resetRaw = headers["x-ratelimit-reset"];
-        const reset = typeof resetRaw === "string" ? Number.parseInt(resetRaw, 10) : Number.NaN;
-        markRateLimited(Number.isFinite(reset) ? reset : undefined);
+    };
+
+    let attempt = 0;
+    while (true) {
+      try {
+        return await dispatch();
+      } catch (error) {
+        const status = (error as { status?: number } | undefined)?.status;
+        const headers = (error as { response?: { headers?: Record<string, string> } } | undefined)?.response?.headers ?? {};
+        const message = error instanceof Error ? error.message.toLowerCase() : "";
+        const { limited, gateUntil } = detectRateLimitFromHeaders(status, headers, message);
+        if (!limited) {
+          throw error;
+        }
+
+        const gateAt = markRateLimited(gateUntil ?? undefined);
+        const waitMs = gateAt.getTime() - Date.now();
+        if (attempt === 0 && waitMs > 0 && waitMs <= RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS) {
+          attempt += 1;
+          await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
+          continue;
+        }
+        throw error;
       }
-      throw error;
     }
   });
 }

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -86,6 +86,70 @@ test("octokit hook short-circuits requests while the gate is active", async () =
   assert.equal(realCalls, 1);
 });
 
+test("octokit hook auto-retries once when Retry-After is within the short-wait threshold", async () => {
+  let callIndex = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        callIndex += 1;
+        if (callIndex === 1) {
+          return new Response(JSON.stringify({ message: "You have exceeded a secondary rate limit" }), {
+            status: 429,
+            headers: {
+              "content-type": "application/json",
+              "retry-after": "1",
+            },
+          });
+        }
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+          },
+        });
+      },
+    },
+  );
+
+  const start = Date.now();
+  const result = await octokit.request("GET /user");
+  const elapsed = Date.now() - start;
+
+  assert.equal(result.data.login, "octo");
+  assert.equal(callIndex, 2);
+  assert.ok(elapsed >= 900, `expected >= ~1s wait, got ${elapsed}ms`);
+  assert.equal(getRateLimitState().limited, false);
+});
+
+test("octokit hook does not auto-retry when the Retry-After wait exceeds the threshold", async () => {
+  let callIndex = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        callIndex += 1;
+        return new Response(JSON.stringify({ message: "You have exceeded a secondary rate limit" }), {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "120",
+          },
+        });
+      },
+    },
+  );
+
+  await assert.rejects(() => octokit.request("GET /user"));
+  assert.equal(callIndex, 1);
+  const state = getRateLimitState();
+  assert.equal(state.limited, true);
+  assert.ok(state.resetAt!.getTime() - Date.now() > 60_000);
+});
+
 test("octokit hook clears the gate on a successful response with remaining > 0", async () => {
   let callIndex = 0;
   const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;


### PR DESCRIPTION
Closes #46.

## Summary

- Extracted `ActivityMenu` into `client/src/components/ActivityMenu.tsx` so PRs and Issues share the same dropdown; folded the `poll Ns` readout into the dropdown footer.
- Reworked `AppHeader` nav: PRs / Issues / Releases on the left, Logs / Settings (plus Activity, Auto Mode, Theme) on the right.
- Kept PR-list tabs on one line and renamed "On Issues" → "Issues" so the column fits the 320 px sidebar.
- Added a dashboard refresh button that invalidates the dashboard query keys with a spinner.
- `server/github.ts`: rate-limit hook now parses `Retry-After` alongside `x-ratelimit-reset` (covering secondary rate limits) and auto-retries once when the wait is ≤ 15 s before propagating.

## Test plan

- [x] `npm run test:all` — 591 / 591 passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open the PRs page, click refresh, confirm spinner + data refresh
- [ ] Manual: open the Issues page, confirm the activity dropdown is present and the refresh button still works
- [ ] Manual: confirm the AppHeader on narrow widths doesn't push into two rows