### PR TITLE
fix: stop GitHub traffic while paused

### DIFF
--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import type { Config } from "@shared/schema";
+import type { Config, RuntimeState } from "@shared/schema";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { toast } from "@/hooks/use-toast";
 
@@ -190,9 +190,16 @@ export function OnboardingPanel() {
   });
   const [expanded, setExpanded] = useState(true);
 
+  const { data: runtimeState } = useQuery<RuntimeState>({
+    queryKey: ["/api/runtime"],
+    refetchInterval: 5000,
+  });
+  const globalDrainMode = runtimeState?.drainMode === true;
+
   const { data: status, isLoading } = useQuery<OnboardingStatus>({
     queryKey: ["/api/onboarding/status"],
-    refetchInterval: 30000,
+    enabled: runtimeState !== undefined && !globalDrainMode,
+    refetchInterval: globalDrainMode ? false : 30000,
   });
   const { data: config } = useQuery<Config>({
     queryKey: ["/api/config"],
@@ -341,17 +348,17 @@ export function OnboardingPanel() {
                               && installWorkflowMutation.variables?.repo === repoStatus.repo
                               && installWorkflowMutation.variables?.tool === tool;
                             return (
-                              <button
-                                key={`${repoStatus.repo}-${tool}`}
-                                type="button"
-                                onClick={() => installWorkflowMutation.mutate({ repo: repoStatus.repo, tool })}
-                                disabled={installWorkflowMutation.isPending}
-                                className="border border-border px-2 py-1 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-40"
-                              >
-                                {isPending ? "Adding…" : `Add ${REVIEW_TOOL_LABELS[tool]} Action`}
-                              </button>
-                            );
-                          })}
+                            <button
+                              key={`${repoStatus.repo}-${tool}`}
+                              type="button"
+                              onClick={() => installWorkflowMutation.mutate({ repo: repoStatus.repo, tool })}
+                              disabled={installWorkflowMutation.isPending || globalDrainMode}
+                              className="border border-border px-2 py-1 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-40"
+                            >
+                              {globalDrainMode ? "Paused" : isPending ? "Adding…" : `Add ${REVIEW_TOOL_LABELS[tool]} Action`}
+                            </button>
+                          );
+                        })}
                         </div>
                       </div>
                     ))}

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -326,6 +326,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasStringValue(sourceFile, "dashboard errors roll-up label", "Roll up");
   assertHasStringValue(sourceFile, "dashboard errors expand label", "Expand");
   assertHasExpression(sourceFile, "dashboard drain state", /\bglobalDrainMode\b/);
+  assertHasExpression(sourceFile, "dashboard issues drain guard", /enabled: runtimeState !== undefined && !globalDrainMode/);
   assertHasExpression(sourceFile, "dashboard active error count", /\bactiveErrorCount\b/);
   assertHasExpression(sourceFile, "dashboard errors roll-up state", /\bareErrorsRolledUp\b/);
 });
@@ -340,6 +341,8 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasApiRequest(sourceFile, "issue work mutation", "POST", "/api/issues/work");
   assertHasApiRequest(sourceFile, "issue evaluation mutation", "POST", "/api/issues/evaluate");
   assertHasApiRequest(sourceFile, "issue label mutation", "PATCH", "/api/issues/labels");
+  assertHasExpression(sourceFile, "issues drain guard", /enabled: runtime !== undefined && !globalDrainMode/);
+  assertHasExpression(sourceFile, "issue detail drain guard", /enabled: Boolean\(selectedIssueFromList\) && !globalDrainMode/);
 
   for (const [label, testId] of [
     ["refresh button", "button-refresh-issues"],
@@ -457,6 +460,7 @@ test("settings keeps the QA-tested configuration, token, and runtime controls wi
     /testIdPrefix=\{`tracked-repo-issue-work-mode-\$\{repo\.repo\.replace\(\s*["']\/["']\s*,\s*["']-["']\s*\)\}`\}/,
   );
   assertHasExpression(sourceFile, "ordered GitHub tokens", /\bgithubTokens\b/);
+  assertHasExpression(sourceFile, "repo sync drain guard", /disabled=\{syncReposMutation\.isPending \|\| globalDrainMode\}/);
 });
 
 test("logs route keeps the QA-tested filtering, streaming, copy, and download surface wired", async () => {
@@ -477,6 +481,7 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
 
   assertHasQueryKey(releases.sourceFile, "release route query", "/api/releases");
   assertHasQueryKey(releases.sourceFile, "github releases query", "/api/github-releases");
+  assertHasQueryKey(releases.sourceFile, "runtime query", "/api/runtime");
   assertHasApiRequest(releases.sourceFile, "release retry mutation", "POST", /`\/api\/releases\/\$\{id\}\/retry`/);
   assertHasJsxTag(releases.sourceFile, "release notes copy", "CopyButton");
   assertHasJsxTag(releases.sourceFile, "orphan github release card", "GitHubReleaseCard");
@@ -487,6 +492,17 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
     ["empty release state", "No release activity yet."],
     ["watched repositories sidebar", "Watched repositories"],
   ]);
+  assertHasExpression(releases.sourceFile, "github releases drain guard", /disabled=\{isFetchingGitHub \|\| globalDrainMode \|\| runtimeState === undefined\}/);
+});
+
+test("onboarding panel keeps the QA-tested GitHub setup poll and install actions wired", async () => {
+  const { sourceFile } = await parseProjectFile("client/src/components/OnboardingPanel.tsx");
+
+  assertHasQueryKey(sourceFile, "onboarding status query", "/api/onboarding/status");
+  assertHasQueryKey(sourceFile, "runtime query", "/api/runtime");
+  assertHasApiRequest(sourceFile, "install review mutation", "POST", "/api/onboarding/install-review");
+  assertHasExpression(sourceFile, "onboarding drain guard", /enabled: runtimeState !== undefined && !globalDrainMode/);
+  assertHasExpression(sourceFile, "onboarding install disable", /disabled=\{installWorkflowMutation\.isPending \|\| globalDrainMode\}/);
 });
 
 test("activity menu keeps the QA-tested trigger, drain note, and poll footer wired", async () => {

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1134,8 +1134,15 @@ export default function Dashboard() {
     refetchInterval: 10000,
   });
 
+  const { data: runtimeState } = useQuery<RuntimeState>({
+    queryKey: ["/api/runtime"],
+    refetchInterval: 3000,
+  });
+  const globalDrainMode = runtimeState?.drainMode === true;
+
   const { data: issues = [], isLoading: isLoadingIssues } = useQuery<Issue[]>({
     queryKey: ["/api/issues"],
+    enabled: runtimeState !== undefined && !globalDrainMode,
     refetchInterval: 30000,
   });
 
@@ -1155,11 +1162,6 @@ export default function Dashboard() {
     refetchInterval: 3000,
   });
   const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
-
-  const { data: runtimeState } = useQuery<RuntimeState>({
-    queryKey: ["/api/runtime"],
-    refetchInterval: 3000,
-  });
 
   const { data: repos = [] } = useQuery<WatchedRepo[]>({
     queryKey: ["/api/repos/settings"],
@@ -1201,7 +1203,6 @@ export default function Dashboard() {
   const selectedPRErrorMessage = selectedPR?.status === "error"
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
-  const globalDrainMode = runtimeState?.drainMode === true;
   const activeErrorCount = activities.failed.length + activities.warnings.length;
 
   const applyMutation = useMutation({

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -365,6 +365,7 @@ export default function Issues() {
     queryKey: ["/api/runtime"],
     refetchInterval: 5000,
   });
+  const globalDrainMode = runtime?.drainMode === true;
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
     refetchInterval: 3000,
@@ -391,7 +392,11 @@ export default function Issues() {
 
   const { data: issues = [], isLoading, refetch, isFetching } = useQuery<Issue[]>({
     queryKey: ["/api/issues"],
+    enabled: runtime !== undefined && !globalDrainMode,
     refetchInterval: (query) => {
+      if (globalDrainMode) {
+        return false;
+      }
       const data = query.state.data;
       return Array.isArray(data) && data.some((issue) => isActiveWorkStatus(issue.workStatus))
         ? 5000
@@ -458,8 +463,8 @@ export default function Issues() {
 
       return fetchJson<Issue>(issueDetailUrl(selectedIssueFromList));
     },
-    enabled: Boolean(selectedIssueFromList),
-    refetchInterval: selectedIssueFromList && isActiveWorkStatus(selectedIssueFromList.workStatus) ? 5000 : false,
+    enabled: Boolean(selectedIssueFromList) && !globalDrainMode,
+    refetchInterval: selectedIssueFromList && isActiveWorkStatus(selectedIssueFromList.workStatus) && !globalDrainMode ? 5000 : false,
   });
   const selectedIssue = selectedIssueDetail ?? selectedIssueFromList;
   const selectedIssueKey = selectedIssue ? issueKey(selectedIssue) : null;
@@ -634,12 +639,12 @@ export default function Issues() {
                   selectedIssueFromList ? refetchSelectedIssueDetail() : Promise.resolve(),
                 ]);
               }}
-              disabled={isFetching}
+              disabled={isFetching || globalDrainMode}
               data-testid="button-refresh-issues"
               className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
             >
-              {isFetching ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
-              refresh
+              {globalDrainMode ? <span className="h-3.5 w-3.5" /> : isFetching ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              {globalDrainMode ? "paused" : "refresh"}
             </button>
             <ActivityMenu
               activities={activities}

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -7,7 +7,7 @@ import { GitHubReleaseCard } from "@/components/GitHubReleaseCard";
 import { SocialPostGenerator } from "@/components/SocialPostGenerator";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
-import type { GitHubRelease, ReleaseRun, RepoGitHubReleases } from "@shared/schema";
+import type { GitHubRelease, ReleaseRun, RepoGitHubReleases, RuntimeState } from "@shared/schema";
 
 type ReleaseRunStatus = ReleaseRun["status"];
 
@@ -325,12 +325,19 @@ export default function Releases() {
     },
   });
 
+  const { data: runtimeState } = useQuery<RuntimeState>({
+    queryKey: ["/api/runtime"],
+    refetchInterval: 5000,
+  });
+  const globalDrainMode = runtimeState?.drainMode === true;
+
   const {
     data: githubReleasesByRepo = [],
     isFetching: isFetchingGitHub,
     error: githubError,
   } = useQuery<RepoGitHubReleases[]>({
     queryKey: ["/api/github-releases"],
+    enabled: runtimeState !== undefined && !globalDrainMode,
   });
 
   const { releaseLookup, orphans } = useMemo(() => {
@@ -416,6 +423,9 @@ export default function Releases() {
   const selectedOrphans = selectedRepo ? orphansByRepo.get(selectedRepo) ?? [] : [];
 
   const handleSyncGitHub = () => {
+    if (globalDrainMode) {
+      return;
+    }
     queryClient.invalidateQueries({ queryKey: ["/api/github-releases"] });
     queryClient.invalidateQueries({ queryKey: ["/api/releases"] });
   };
@@ -458,9 +468,9 @@ export default function Releases() {
             <button
               type="button"
               onClick={handleSyncGitHub}
-              disabled={isFetchingGitHub}
-              title={isFetchingGitHub ? "Syncing…" : "Sync from GitHub"}
-              aria-label={isFetchingGitHub ? "Syncing from GitHub" : "Sync from GitHub"}
+              disabled={isFetchingGitHub || globalDrainMode || runtimeState === undefined}
+              title={globalDrainMode ? "Paused by drain mode" : isFetchingGitHub ? "Syncing…" : "Sync from GitHub"}
+              aria-label={globalDrainMode ? "Paused by drain mode" : isFetchingGitHub ? "Syncing from GitHub" : "Sync from GitHub"}
               data-testid="button-sync-github-releases"
               className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-primary bg-primary text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
             >

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -610,11 +610,12 @@ export default function Settings() {
                     <button
                       type="button"
                       onClick={() => syncReposMutation.mutate()}
-                      disabled={syncReposMutation.isPending}
+                      disabled={syncReposMutation.isPending || globalDrainMode}
+                      title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Fetch watched repos from GitHub"}
                       data-testid="button-sync-repos"
                       className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-xs font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
-                      {syncReposMutation.isPending ? "Fetching..." : "Fetch"}
+                      {globalDrainMode ? DRAIN_PAUSED_LABEL : syncReposMutation.isPending ? "Fetching..." : "Fetch"}
                     </button>
                   }
                 >

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -756,6 +756,11 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   let logsRetentionJob: RetentionJobHandle | null = null;
   const watcherScheduler = dependencies.watcherScheduler ?? createWatcherScheduler(
     async () => {
+      const runtimeState = await storage.getRuntimeState();
+      if (runtimeState.drainMode) {
+        return;
+      }
+
       const rateLimit = getRateLimitState();
       if (rateLimit.limited && rateLimit.resetAt) {
         log.info(
@@ -1136,13 +1141,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   }
 
   async function queueAutomaticIssueWorkInternal(): Promise<void> {
-    const [runtimeState, config, repoSettings, issues, evaluationJobs, workJobs] = await Promise.all([
+    const [runtimeState, config] = await Promise.all([
       storage.getRuntimeState(),
       storage.getConfig(),
-      storage.listRepoSettings(),
-      listIssuesInternal(),
-      storage.listBackgroundJobs({ kind: "evaluate_issue" }),
-      storage.listBackgroundJobs({ kind: "work_issue" }),
     ]);
 
     if (runtimeState.drainMode) {
@@ -1152,6 +1153,13 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     if (config.autoIssues === false) {
       return;
     }
+
+    const [repoSettings, issues, evaluationJobs, workJobs] = await Promise.all([
+      storage.listRepoSettings(),
+      listIssuesInternal(),
+      storage.listBackgroundJobs({ kind: "evaluate_issue" }),
+      storage.listBackgroundJobs({ kind: "work_issue" }),
+    ]);
 
     const isJobActive = (status: string) => status === "queued" || status === "leased";
     const activeEvaluationTargets = new Set(

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -582,6 +582,7 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
 test("syncAndBabysitTrackedRepos refreshes repository status during drain without queueing babysits", async () => {
   const storage = new MemStorage();
   const backgroundJobQueue = new BackgroundJobQueue(storage);
+  let listOpenPullsCalls = 0;
   await storage.updateRuntimeState({
     drainMode: true,
     drainRequestedAt: "2026-05-02T10:00:00.000Z",
@@ -608,11 +609,16 @@ test("syncAndBabysitTrackedRepos refreshes repository status during drain withou
 
   const babysitter = new PRBabysitter(
     storage,
-    makeWatcherGitHubService(),
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        listOpenPullsCalls += 1;
+        return [];
+      },
+    }),
     {
       resolveAgent: async () => "codex",
       checkAgentHealth: async () => {
-        throw new Error("drained status refresh should not check agent health");
+        throw new Error("drained sync should not check agent health");
       },
       ciPollIntervalMs: 0,
       evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
@@ -626,20 +632,19 @@ test("syncAndBabysitTrackedRepos refreshes repository status during drain withou
   await babysitter.syncAndBabysitTrackedRepos();
 
   const updated = await storage.getPR(pr.id);
-  const logs = await storage.getLogs(pr.id);
   const jobs = await storage.listBackgroundJobs({
     kind: "babysit_pr",
     targetId: pr.id,
   });
-  assert.equal(updated?.status, "archived");
+  assert.equal(updated?.status, "watching");
   assert.equal(jobs.length, 0);
-  assert.ok(logs.some((log) => log.message.includes("archived")));
+  assert.equal(listOpenPullsCalls, 0);
 });
 
 test("syncAndBabysitTrackedRepos syncs feedback during drain without queueing babysits", async () => {
   const storage = new MemStorage();
   const backgroundJobQueue = new BackgroundJobQueue(storage);
-  const incomingItem = makeFeedbackItem();
+  let feedbackFetches = 0;
   await storage.updateRuntimeState({
     drainMode: true,
     drainRequestedAt: "2026-05-04T12:42:38.857Z",
@@ -667,22 +672,15 @@ test("syncAndBabysitTrackedRepos syncs feedback during drain without queueing ba
   const babysitter = new PRBabysitter(
     storage,
     makeWatcherGitHubService({
-      fetchFeedbackItemsForPR: async () => [incomingItem],
-      listOpenPullsForRepo: async () => [{
-        number: 42,
-        title: "Example PR",
-        branch: "feature/example",
-        author: "octocat",
-        url: "https://github.com/octo/example/pull/42",
-        headSha: "head123",
-        baseRef: "main",
-        baseSha: "base123",
-      }],
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetches += 1;
+        return [makeFeedbackItem()];
+      },
     }),
     {
       resolveAgent: async () => "codex",
       checkAgentHealth: async () => {
-        throw new Error("drained feedback sync should not check agent health");
+        throw new Error("drained sync should not check agent health");
       },
       ciPollIntervalMs: 0,
       evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
@@ -696,16 +694,14 @@ test("syncAndBabysitTrackedRepos syncs feedback during drain without queueing ba
   await babysitter.syncAndBabysitTrackedRepos();
 
   const updated = await storage.getPR(pr.id);
-  const logs = await storage.getLogs(pr.id);
   const jobs = await storage.listBackgroundJobs({
     kind: "babysit_pr",
     targetId: pr.id,
   });
-  assert.equal(updated?.feedbackItems.length, 1);
-  assert.equal(updated?.feedbackItems[0]?.id, incomingItem.id);
-  assert.equal(updated?.lastChecked !== null, true);
+  assert.equal(updated?.feedbackItems.length, 0);
+  assert.equal(updated?.lastChecked, null);
   assert.equal(jobs.length, 0);
-  assert.ok(logs.some((log) => log.message === "GitHub sync complete: 1 feedback item (1 new)"));
+  assert.equal(feedbackFetches, 0);
 });
 
 test("syncAndBabysitTrackedRepos does not duplicate drain sync after metadata repair", async () => {
@@ -748,21 +744,11 @@ test("syncAndBabysitTrackedRepos does not duplicate drain sync after metadata re
         feedbackFetches += 1;
         return [makeFeedbackItem({ threadId: "THREAD_node_1", threadResolved: false })];
       },
-      listOpenPullsForRepo: async () => [{
-        number: 42,
-        title: "Example PR",
-        branch: "feature/example",
-        author: "octocat",
-        url: "https://github.com/octo/example/pull/42",
-        headSha: "head123",
-        baseRef: "main",
-        baseSha: "base123",
-      }],
     }),
     {
       resolveAgent: async () => "codex",
       checkAgentHealth: async () => {
-        throw new Error("drained feedback sync should not check agent health");
+        throw new Error("drained sync should not check agent health");
       },
       ciPollIntervalMs: 0,
       evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
@@ -780,9 +766,9 @@ test("syncAndBabysitTrackedRepos does not duplicate drain sync after metadata re
     kind: "babysit_pr",
     targetId: pr.id,
   });
-  assert.equal(feedbackFetches, 1);
-  assert.equal(updated?.feedbackItems[0]?.threadId, "THREAD_node_1");
-  assert.equal(updated?.feedbackItems[0]?.threadResolved, false);
+  assert.equal(feedbackFetches, 0);
+  assert.equal(updated?.feedbackItems[0]?.threadId, null);
+  assert.equal(updated?.feedbackItems[0]?.threadResolved, null);
   assert.equal(jobs.length, 0);
 });
 
@@ -1317,6 +1303,67 @@ test("syncAndBabysitTrackedRepos skips automatic babysits when pr watch is pause
   assert.equal(updated?.watchEnabled, false);
   assert.deepEqual(babysitCalls, []);
   assert.ok(!logs.some((log) => log.message.includes("Watcher queued autonomous babysitter run")));
+});
+
+test("syncAndBabysitTrackedRepos returns early while drain mode is enabled", async () => {
+  const storage = new MemStorage();
+  let listOpenPullsCalls = 0;
+  let fetchFeedbackCalls = 0;
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Example PR",
+    repo: "octo/example",
+    branch: "feature/example",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  await storage.updateRuntimeState({
+    drainMode: true,
+    drainRequestedAt: "2026-03-18T10:00:00.000Z",
+    drainReason: "planned update",
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchFeedbackItemsForPR: async () => {
+        fetchFeedbackCalls += 1;
+        return [];
+      },
+      listOpenPullsForRepo: async () => {
+        listOpenPullsCalls += 1;
+        return [{
+          number: 42,
+          title: "Example PR",
+          branch: "feature/example",
+          author: "octocat",
+          url: "https://github.com/octo/example/pull/42",
+        }];
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const updated = await storage.getPR(pr.id);
+  assert.equal(updated?.watchEnabled, true);
+  assert.equal(listOpenPullsCalls, 0);
+  assert.equal(fetchFeedbackCalls, 0);
 });
 
 test("syncAndBabysitTrackedRepos resumes automatic babysits when pr watch is re-enabled", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1779,7 +1779,11 @@ export class PRBabysitter {
       this.storage.getRuntimeState(),
       this.storage.getConfig(),
     ]);
-    const automationBlocked = runtimeState.drainMode || configEarly.autoPrs === false;
+    if (runtimeState.drainMode) {
+      return;
+    }
+
+    const automationBlocked = configEarly.autoPrs === false;
 
     const repairCandidates = [
       ...(await this.storage.getPRs()),

--- a/server/github.ts
+++ b/server/github.ts
@@ -150,6 +150,9 @@ const SEMVER_TAG_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
 
 const GITHUB_API_VERSION = "2022-11-28";
 const GH_AUTH_CACHE_TTL_MS = 15000;
+const GITHUB_MAX_CONCURRENT_REQUESTS = 20;
+const GITHUB_REST_POINT_INTERVAL_MS = 67;
+const GITHUB_CONTENT_REQUEST_INTERVAL_MS = 750;
 const REVIEW_THREADS_QUERY = `
   query CodeFactoryReviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -742,6 +745,76 @@ class RateLimitGateError extends Error {
 
 const RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS = 15_000;
 
+type GitHubRequestOptions = {
+  method?: string;
+};
+
+type QueuedGitHubRequest<T> = {
+  options: GitHubRequestOptions;
+  run: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+class GitHubRequestThrottle {
+  private active = 0;
+  private pointReadyAt = 0;
+  private contentReadyAt = 0;
+  private readonly queue: Array<QueuedGitHubRequest<unknown>> = [];
+
+  schedule<T>(options: GitHubRequestOptions, run: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        options,
+        run: run as () => Promise<unknown>,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      this.drain();
+    });
+  }
+
+  private drain(): void {
+    while (this.active < GITHUB_MAX_CONCURRENT_REQUESTS && this.queue.length > 0) {
+      const item = this.queue.shift();
+      if (!item) return;
+
+      this.active += 1;
+      const delayMs = this.reserveDelay(item.options);
+      setTimeout(() => {
+        item.run()
+          .then(item.resolve)
+          .catch(item.reject)
+          .finally(() => {
+            this.active -= 1;
+            this.drain();
+          });
+      }, delayMs);
+    }
+  }
+
+  private reserveDelay(options: GitHubRequestOptions): number {
+    const now = Date.now();
+    const method = options.method?.toUpperCase() ?? "GET";
+    const isContentRequest = method === "POST" || method === "PATCH" || method === "PUT" || method === "DELETE";
+    const pointCost = isContentRequest ? 5 : 1;
+    const startAt = Math.max(
+      now,
+      this.pointReadyAt,
+      isContentRequest ? this.contentReadyAt : 0,
+    );
+
+    this.pointReadyAt = startAt + (pointCost * GITHUB_REST_POINT_INTERVAL_MS);
+    if (isContentRequest) {
+      this.contentReadyAt = startAt + GITHUB_CONTENT_REQUEST_INTERVAL_MS;
+    }
+
+    return Math.max(0, startAt - now);
+  }
+}
+
+const githubRequestThrottle = new GitHubRequestThrottle();
+
 function parseRetryAfter(value: string | undefined): Date | null {
   if (!value) return null;
   const trimmed = value.trim();
@@ -800,7 +873,7 @@ function attachRateLimitHook(client: Octokit): void {
     let attempt = 0;
     while (true) {
       try {
-        return await dispatch();
+        return await githubRequestThrottle.schedule(options, dispatch);
       } catch (error) {
         const status = (error as { status?: number } | undefined)?.status;
         const headers = (error as { response?: { headers?: Record<string, string> } } | undefined)?.response?.headers ?? {};

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -33,6 +33,37 @@ const config: Config = {
 
 test.beforeEach(() => clearRateLimited());
 
+test("octokit hook spaces concurrent REST requests under GitHub secondary limits", async () => {
+  const requestStartedAt: number[] = [];
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        requestStartedAt.push(Date.now());
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+          },
+        });
+      },
+    },
+  );
+
+  await Promise.all([
+    octokit.request("GET /user"),
+    octokit.request("GET /user"),
+  ]);
+
+  assert.equal(requestStartedAt.length, 2);
+  assert.ok(
+    requestStartedAt[1] - requestStartedAt[0] >= 50,
+    `expected REST requests to be spaced, got ${requestStartedAt[1] - requestStartedAt[0]}ms`,
+  );
+});
+
 test("octokit hook records rate-limit reset from 403 response headers", async () => {
   const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
   const octokit = await buildOctokit(

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -452,7 +452,7 @@ test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () 
   }
 });
 
-test("POST /api/repos/sync enqueues sync_watched_repos while drain mode is enabled", async () => {
+test("POST /api/repos/sync is a no-op while drain mode is enabled", async () => {
   const harness = await createHarness();
   await harness.storage.updateRuntimeState({
     drainMode: true,
@@ -473,9 +473,7 @@ test("POST /api/repos/sync enqueues sync_watched_repos while drain mode is enabl
       kind: "sync_watched_repos",
       status: "queued",
     });
-    assert.equal(jobs.length, 1);
-    assert.equal(jobs[0].targetId, "runtime:1");
-    assert.equal(jobs[0].dedupeKey, "sync_watched_repos");
+    assert.equal(jobs.length, 0);
   } finally {
     await harness.close();
   }


### PR DESCRIPTION
## Summary

- Block the remaining GitHub polling and sync paths while drain mode is enabled.
- Throttle shared GitHub REST requests more defensively.

Closes #48

## Verification

- [x] `npm run check`
- [x] `node --import tsx --test server/babysitter.test.ts client/src/lib/fullAppQaSurface.test.ts`
- [x] Manual verification against `http://127.0.0.1:5001/api/runtime` and the octokit server logs while drain mode was enabled.
