### PR TITLE
fix: surface github rate-limit resets

### DIFF
--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -292,10 +292,10 @@ export function OnboardingPanel() {
                     )}
                     <div className="space-y-1.5 text-[12px] text-muted-foreground">
                       <Step number={1}>
-                        Run <InlineCode>gh auth login</InlineCode> on this machine, or set <InlineCode>GITHUB_TOKEN</InlineCode> before starting the app.
+                        Run <InlineCode>gh auth login</InlineCode> on this machine, set <InlineCode>GITHUB_TOKEN</InlineCode>, or add a saved token in <Link href="/settings" className="underline underline-offset-2">settings</Link>.
                       </Step>
                       <Step number={2}>
-                        Prefer the built-in token list if you want the app to remember it. Open <Link href="/settings" className="underline underline-offset-2">settings</Link> to paste a Personal Access Token.
+                        Prefer the built-in token list if you want the app to remember it. For fine-grained PATs, give the watched repos the GitHub permissions PatchDeck uses: Metadata read, Contents read/write if you push, Issues read/write, Pull requests read/write, and Checks read.
                       </Step>
                     </div>
                   </div>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -64,6 +64,11 @@ const CLAUDE_EFFORT_OPTIONS = [
 const DRAIN_PAUSED_LABEL = "Paused";
 const DRAIN_PAUSED_TITLE = "Paused by drain mode";
 
+type GitHubRateLimitState = {
+  limited: boolean;
+  resetAt: string | null;
+};
+
 type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
 type IssueWorkMode = (typeof ISSUE_WORK_MODE_OPTIONS)[number]["value"];
 type RepoAgentOption = (typeof REPO_AGENT_OPTIONS)[number]["value"];
@@ -340,6 +345,10 @@ export default function Settings() {
   const { data: runtimeState, isError: runtimeStateIsError } = useQuery<RuntimeState>({
     queryKey: ["/api/runtime"],
     refetchInterval: 5000,
+  });
+  const { data: githubRateLimit } = useQuery<GitHubRateLimitState>({
+    queryKey: ["/api/github-rate-limit"],
+    refetchInterval: 30000,
   });
   const drainStatusView = getDrainStatusView(runtimeState, runtimeStateIsError);
   const globalDrainMode = runtimeState?.drainMode === true;
@@ -1189,7 +1198,9 @@ export default function Settings() {
                   <div>
                     <div className="text-sm">Tokens</div>
                     <div className="text-[11px] text-muted-foreground">
-                      Tried in order before GITHUB_TOKEN and gh auth.
+                      Tried in order before GITHUB_TOKEN and gh auth. For fine-grained PATs, give the watched repos
+                      Metadata: read, Contents: read/write if you push, Issues: read/write, Pull requests: read/write,
+                      and Checks: read. Tokens from the same GitHub account share the same rate-limit bucket.
                     </div>
                   </div>
                   {!showTokenInput && (
@@ -1247,6 +1258,11 @@ export default function Settings() {
                 ) : (
                   <div className="text-[11px] text-muted-foreground">none configured</div>
                 )}
+                {githubRateLimit?.limited && githubRateLimit.resetAt ? (
+                  <div className="border-l-2 border-warning bg-muted/30 px-3 py-2 text-[11px]">
+                    GitHub rate limit active until {new Date(githubRateLimit.resetAt).toLocaleString()}.
+                  </div>
+                ) : null}
                 {showTokenInput ? (
                   <div className="flex items-center gap-2">
                     <input

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -61,6 +61,7 @@ The dashboard also exposes a server log viewer at `/logs`. It shows recent struc
 The settings page in the dashboard provides a UI for:
 
 - **GitHub token management** — Add, remove, and reorder saved tokens before falling back to `GITHUB_TOKEN` or `gh auth`.
+- **GitHub token permissions** — For fine-grained PATs, grant the watched repos `Metadata: read`, `Contents: read/write` if PatchDeck will push commits, `Issues: read/write`, `Pull requests: read/write`, and `Checks: read`. Tokens from the same GitHub account still share one rate-limit bucket.
 - **Agent selection** — Choose whether autonomous runs use Claude Code or OpenAI Codex. If the default run fails and a code-owner fallback is launched, the fallback uses the same resolved agent; enabling **Fallback to next coding agent** lets patchdeck resolve that fallback to the other local CLI when needed.
 - **Babysitter tuning** — Control polling, batching, merge-conflict handling, release automation, and automatic docs assessment.
 - **Runtime drain mode** — Pause new background automation and manual agent-triggering actions while allowing in-flight work to finish. During drain mode, the dashboard disables Run now/apply, feedback retry, Ask Agent, manual Release, and release retry actions; matching API calls return `409` instead of queueing new agent work.

--- a/server/github.ts
+++ b/server/github.ts
@@ -749,6 +749,18 @@ type GitHubRequestOptions = {
   method?: string;
 };
 
+type GitHubRateLimitResourceSnapshot = {
+  limit?: number | null;
+  remaining?: number | null;
+  reset?: number | null;
+  used?: number | null;
+};
+
+type GitHubRateLimitResponse = {
+  resources?: Record<string, GitHubRateLimitResourceSnapshot | undefined>;
+  rate?: GitHubRateLimitResourceSnapshot | null;
+};
+
 type QueuedGitHubRequest<T> = {
   options: GitHubRequestOptions;
   run: () => Promise<T>;
@@ -838,22 +850,56 @@ function detectRateLimitFromHeaders(
   status: number | undefined,
   headers: Record<string, string>,
   message: string,
-): { limited: boolean; gateUntil: Date | null } {
+): { limited: boolean; gateUntil: Date | null; resource: string | null } {
   const remainingRaw = headers["x-ratelimit-remaining"];
   const retryAfterHeader = headers["retry-after"];
   const limited = (status === 403 || status === 429)
     && (remainingRaw === "0" || Boolean(retryAfterHeader) || /rate limit/i.test(message));
   if (!limited) {
-    return { limited: false, gateUntil: null };
+    return { limited: false, gateUntil: null, resource: null };
   }
   const resetRaw = headers["x-ratelimit-reset"];
   const resetSeconds = typeof resetRaw === "string" ? Number.parseInt(resetRaw, 10) : Number.NaN;
   const resetDate = Number.isFinite(resetSeconds) ? new Date(resetSeconds * 1000) : null;
   const retryDate = parseRetryAfter(retryAfterHeader);
-  return { limited: true, gateUntil: laterDate(resetDate, retryDate) };
+  return {
+    limited: true,
+    gateUntil: laterDate(resetDate, retryDate),
+    resource: headers["x-ratelimit-resource"]?.trim().toLowerCase() || null,
+  };
 }
 
-function attachRateLimitHook(client: Octokit): void {
+function readRateLimitReset(
+  payload: GitHubRateLimitResponse,
+  resourceHint: string | null,
+): Date | null {
+  const resources = payload.resources ?? {};
+  const resourceKey = resourceHint ?? "core";
+  const resource = resources[resourceKey] ?? payload.rate ?? null;
+  const reset = resource?.reset;
+  if (typeof reset !== "number" || !Number.isFinite(reset) || reset <= 0) {
+    return null;
+  }
+
+  return new Date(reset * 1000);
+}
+
+async function fetchRateLimitResetAt(
+  client: Octokit,
+  resourceHint: string | null,
+): Promise<Date | null> {
+  try {
+    const response = await client.request("GET /rate_limit");
+    return readRateLimitReset(response.data as GitHubRateLimitResponse, resourceHint);
+  } catch {
+    return null;
+  }
+}
+
+function attachRateLimitHook(
+  client: Octokit,
+  resolveRateLimitResetAt?: (resourceHint: string | null) => Promise<Date | null>,
+): void {
   client.hook.wrap("request", async (request, options) => {
     const state = getRateLimitState();
     if (state.limited && state.resetAt) {
@@ -878,12 +924,13 @@ function attachRateLimitHook(client: Octokit): void {
         const status = (error as { status?: number } | undefined)?.status;
         const headers = (error as { response?: { headers?: Record<string, string> } } | undefined)?.response?.headers ?? {};
         const message = error instanceof Error ? error.message.toLowerCase() : "";
-        const { limited, gateUntil } = detectRateLimitFromHeaders(status, headers, message);
+        const { limited, gateUntil, resource } = detectRateLimitFromHeaders(status, headers, message);
         if (!limited) {
           throw error;
         }
 
-        const gateAt = markRateLimited(gateUntil ?? undefined);
+        const exactResetAt = resolveRateLimitResetAt ? await resolveRateLimitResetAt(resource) : null;
+        const gateAt = markRateLimited(exactResetAt ?? gateUntil ?? undefined);
         const waitMs = gateAt.getTime() - Date.now();
         if (attempt === 0 && waitMs > 0 && waitMs <= RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS) {
           attempt += 1;
@@ -902,7 +949,7 @@ export async function buildOctokit(
 ): Promise<Octokit> {
   const envToken = process.env.GITHUB_TOKEN?.trim();
   const configuredToken = resolveConfiguredGitHubToken(config);
-  const buildClient = (authToken?: string) => {
+  const buildClient = (authToken?: string, attachHooks = true) => {
     const client = new Octokit({
       auth: authToken,
       log: octokitLogger,
@@ -913,7 +960,9 @@ export async function buildOctokit(
         },
       },
     });
-    attachRateLimitHook(client);
+    if (attachHooks) {
+      attachRateLimitHook(client, async (resourceHint) => fetchRateLimitResetAt(buildClient(authToken, false), resourceHint));
+    }
     return client;
   };
 

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -88,6 +88,52 @@ test("octokit hook records rate-limit reset from 403 response headers", async ()
   assert.equal(state.resetAt!.getTime(), resetUnixSeconds * 1000);
 });
 
+test("octokit hook refreshes the reset time from /rate_limit when the response omits it", async () => {
+  const resetUnixSeconds = Math.floor(Date.now() / 1000) + 900;
+  const requestedPaths: string[] = [];
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async (input) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        requestedPaths.push(new URL(url).pathname);
+
+        if (url.includes("/rate_limit")) {
+          return new Response(JSON.stringify({
+            resources: {
+              core: {
+                limit: 5000,
+                remaining: 0,
+                reset: resetUnixSeconds,
+                used: 5000,
+              },
+            },
+          }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+
+        return new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+          status: 403,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-resource": "core",
+          },
+        });
+      },
+    },
+  );
+
+  await assert.rejects(() => octokit.request("GET /user"));
+  const state = getRateLimitState();
+  assert.equal(state.limited, true);
+  assert.equal(state.resetAt!.getTime(), resetUnixSeconds * 1000);
+  assert.deepEqual(requestedPaths, ["/user", "/rate_limit"]);
+});
+
 test("octokit hook short-circuits requests while the gate is active", async () => {
   const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
   let realCalls = 0;
@@ -110,11 +156,11 @@ test("octokit hook short-circuits requests while the gate is active", async () =
   );
 
   await assert.rejects(() => octokit.request("GET /user"));
-  assert.equal(realCalls, 1);
+  assert.equal(realCalls, 2);
 
   // Second call must be short-circuited by the gate.
   await assert.rejects(() => octokit.request("GET /repos/foo/bar"));
-  assert.equal(realCalls, 1);
+  assert.equal(realCalls, 2);
 });
 
 test("octokit hook auto-retries once when Retry-After is within the short-wait threshold", async () => {
@@ -150,7 +196,7 @@ test("octokit hook auto-retries once when Retry-After is within the short-wait t
   const elapsed = Date.now() - start;
 
   assert.equal(result.data.login, "octo");
-  assert.equal(callIndex, 2);
+  assert.equal(callIndex, 3);
   assert.ok(elapsed >= 900, `expected >= ~1s wait, got ${elapsed}ms`);
   assert.equal(getRateLimitState().limited, false);
 });
@@ -175,7 +221,7 @@ test("octokit hook does not auto-retry when the Retry-After wait exceeds the thr
   );
 
   await assert.rejects(() => octokit.request("GET /user"));
-  assert.equal(callIndex, 1);
+  assert.equal(callIndex, 2);
   const state = getRateLimitState();
   assert.equal(state.limited, true);
   assert.ok(state.resetAt!.getTime() - Date.now() > 60_000);

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -5,6 +5,7 @@ import express from "express";
 import type { Octokit } from "@octokit/rest";
 import type { AppUpdateStatus, FeedbackItem, Issue, NewPR } from "@shared/schema";
 import type { AppRuntime } from "./appRuntime";
+import { clearRateLimited, markRateLimited } from "./rateLimitState";
 import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./releaseAgent";
 import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
 import { MemStorage } from "./memoryStorage";
@@ -214,6 +215,25 @@ test("PATCH /api/config accepts legacy single githubToken updates", async () => 
     const stored = await harness.storage.getConfig();
     assert.deepEqual(stored.githubTokens, ["ghs_legacy9999"]);
   } finally {
+    await harness.close();
+  }
+});
+
+test("GET /api/github-rate-limit reports the current reset time", async () => {
+  const resetAt = new Date(Date.now() + 600_000);
+  markRateLimited(resetAt);
+
+  const harness = await createHarness();
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/github-rate-limit`);
+    assert.equal(response.status, 200);
+
+    const body = await response.json() as { limited: boolean; resetAt: string | null };
+    assert.equal(body.limited, true);
+    assert.equal(body.resetAt, resetAt.toISOString());
+  } finally {
+    clearRateLimited();
     await harness.close();
   }
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,7 @@ import {
   type LogLevel,
   type LogRecord,
 } from "./logger";
+import { getRateLimitState } from "./rateLimitState";
 
 const VALID_LEVELS: LogLevel[] = ["trace", "debug", "info", "warn", "error", "fatal"];
 
@@ -144,6 +145,14 @@ export async function registerRoutes(
 
   app.get("/api/runtime", async (_req, res) => {
     res.json(await runtime.getRuntimeSnapshot());
+  });
+
+  app.get("/api/github-rate-limit", async (_req, res) => {
+    const state = getRateLimitState();
+    res.json({
+      limited: state.limited,
+      resetAt: state.resetAt ? state.resetAt.toISOString() : null,
+    });
   });
 
   app.get("/api/server-logs", (req, res) => {


### PR DESCRIPTION
## Summary

- Probe `GET /rate_limit` after a GitHub rate-limit response so PatchDeck can capture an exact reset timestamp when GitHub provides one.
- Expose the current reset time through `/api/github-rate-limit` and show it in Settings.
- Tighten the GitHub token guidance for fine-grained PAT permissions and same-account rate limits.

Closes #51

## Verification

- [x] `node --import tsx --test server/rateLimitHook.test.ts server/routes.test.ts`
- [x] `npm run check`
