### PR TITLE
fix: keep Releases syncing during drain mode

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -497,7 +497,8 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
     ["empty release state", "No release activity yet."],
     ["watched repositories sidebar", "Watched repositories"],
   ]);
-  assertHasExpression(releases.sourceFile, "github releases drain guard", /disabled=\{isFetchingGitHub \|\| globalDrainMode \|\| runtimeState === undefined\}/);
+  assertHasExpression(releases.sourceFile, "github releases polling", /refetchInterval:\s*60_000/);
+  assertHasExpression(releases.sourceFile, "github releases sync guard", /disabled=\{isFetchingGitHub \|\| runtimeState === undefined\}/);
 });
 
 test("onboarding panel keeps the QA-tested GitHub setup poll and install actions wired", async () => {

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -329,7 +329,6 @@ export default function Releases() {
     queryKey: ["/api/runtime"],
     refetchInterval: 5000,
   });
-  const globalDrainMode = runtimeState?.drainMode === true;
 
   const {
     data: githubReleasesByRepo = [],
@@ -337,7 +336,8 @@ export default function Releases() {
     error: githubError,
   } = useQuery<RepoGitHubReleases[]>({
     queryKey: ["/api/github-releases"],
-    enabled: runtimeState !== undefined && !globalDrainMode,
+    enabled: runtimeState !== undefined,
+    refetchInterval: 60_000,
   });
 
   const { releaseLookup, orphans } = useMemo(() => {
@@ -423,9 +423,6 @@ export default function Releases() {
   const selectedOrphans = selectedRepo ? orphansByRepo.get(selectedRepo) ?? [] : [];
 
   const handleSyncGitHub = () => {
-    if (globalDrainMode) {
-      return;
-    }
     queryClient.invalidateQueries({ queryKey: ["/api/github-releases"] });
     queryClient.invalidateQueries({ queryKey: ["/api/releases"] });
   };
@@ -468,9 +465,9 @@ export default function Releases() {
             <button
               type="button"
               onClick={handleSyncGitHub}
-              disabled={isFetchingGitHub || globalDrainMode || runtimeState === undefined}
-              title={globalDrainMode ? "Paused by drain mode" : isFetchingGitHub ? "Syncing…" : "Sync from GitHub"}
-              aria-label={globalDrainMode ? "Paused by drain mode" : isFetchingGitHub ? "Syncing from GitHub" : "Sync from GitHub"}
+              disabled={isFetchingGitHub || runtimeState === undefined}
+              title={isFetchingGitHub ? "Syncing…" : "Sync from GitHub"}
+              aria-label={isFetchingGitHub ? "Syncing from GitHub" : "Sync from GitHub"}
               data-testid="button-sync-github-releases"
               className="inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-primary bg-primary text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
             >


### PR DESCRIPTION
## Summary
- let the Releases page fetch GitHub releases even while drain mode is enabled
- keep the manual sync button available during drain mode
- update the QA surface test to match the new behavior

## Verification
- npm run test:all
- npm run check