### PR TITLE
fix: disable background sync while global manual mode is active

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -214,6 +214,27 @@ test("runtime updateConfig persists updates and exposes them through getConfig",
   assert.equal(config.postGitHubProgressReplies, true);
 });
 
+test("watcher tick does not enqueue sync jobs while global manual mode is on", async () => {
+  const storage = new MemStorage();
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+  });
+
+  await runtime.updateConfig({
+    autoPrs: false,
+    autoIssues: false,
+  });
+
+  await runtime.syncRepos();
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "sync_watched_repos",
+  });
+  assert.equal(jobs.length, 0);
+});
+
 test("runtime release adapter skips merged PRs without a merge commit SHA", () => {
   const summaries = mapMergedPullsToReleaseSummaries([
     {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -763,6 +763,11 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         return;
       }
 
+      const config = await storage.getConfig();
+      if (config.autoPrs === false && config.autoIssues === false) {
+        return;
+      }
+
       const rateLimit = getRateLimitState();
       if (rateLimit.limited && rateLimit.resetAt) {
         log.info(


### PR DESCRIPTION
## Summary
- stop watcher ticks from queuing sync_watched_repos jobs when global manual mode is active (autoPrs=false and autoIssues=false)
- keep manual actions available while preventing automatic background refreshes
- add regression coverage for manual mode watcher behavior

## Verification
- npm run test -- server/appRuntime.test.ts
- npm run check