### PR TITLE
perf: cache releases queries and remove polling

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -497,7 +497,7 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
     ["empty release state", "No release activity yet."],
     ["watched repositories sidebar", "Watched repositories"],
   ]);
-  assertHasExpression(releases.sourceFile, "github releases polling", /refetchInterval:\s*60_000/);
+  assertHasExpression(releases.sourceFile, "github releases cache window", /staleTime:\s*5\s*\*\s*60\s*\*\s*1000/);
   assertHasExpression(releases.sourceFile, "github releases sync guard", /disabled=\{isFetchingGitHub \|\| runtimeState === undefined\}/);
 });
 

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -26,10 +26,6 @@ function isTerminalStatus(status: ReleaseRunStatus): boolean {
   return status === "published" || status === "skipped" || status === "error";
 }
 
-function hasReleaseRunStatus(value: unknown): value is { status: ReleaseRunStatus } {
-  return typeof value === "object" && value !== null && "status" in value && typeof value.status === "string";
-}
-
 function formatDateTime(value: string | null | undefined): string {
   if (!value) return "n/a";
   const date = new Date(value);
@@ -317,12 +313,7 @@ function RepoListButton({
 export default function Releases() {
   const { data: releases = [], isLoading } = useQuery<ReleaseRun[]>({
     queryKey: ["/api/releases"],
-    refetchInterval: (query) => {
-      const data = query.state.data;
-      return Array.isArray(data) && data.some((run) => hasReleaseRunStatus(run) && isActiveStatus(run.status))
-        ? 5000
-        : false;
-    },
+    staleTime: 5 * 60 * 1000,
   });
 
   const { data: runtimeState } = useQuery<RuntimeState>({
@@ -337,7 +328,7 @@ export default function Releases() {
   } = useQuery<RepoGitHubReleases[]>({
     queryKey: ["/api/github-releases"],
     enabled: runtimeState !== undefined,
-    refetchInterval: 60_000,
+    staleTime: 5 * 60 * 1000,
   });
 
   const { releaseLookup, orphans } = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove polling from Releases page queries
- cache `/api/releases` and `/api/github-releases` responses with a 5-minute stale window
- keep manual sync/invalidation behavior for explicit refreshes
- update release QA surface assertion to check cache window instead of polling

## Why
Releases do not change frequently enough to justify background polling.

## Verification
- npm run check
- Note: targeted full-app QA test invocation in this worktree hit a local `typescript` module resolution issue (`ERR_MODULE_NOT_FOUND`), unrelated to these query changes.
