### PR TITLE
feat: add header drain toggle and github key diagnostics

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { Link } from "wouter";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
-import type { Config, RuntimeState } from "@shared/schema";
+import type { ActivitySnapshot, Config, RuntimeState } from "@shared/schema";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -135,8 +135,18 @@ function AutoModeButton() {
       queryClient.invalidateQueries({ queryKey: ["/api/config"] });
     },
   });
+  const drainMutation = useMutation({
+    mutationFn: async (input: { enabled: boolean; reason?: string }) => {
+      const res = await apiRequest("POST", "/api/runtime/drain", input);
+      return res.json();
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/runtime"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+    },
+  });
 
-  const pending = updateConfigMutation.isPending;
+  const pending = updateConfigMutation.isPending || drainMutation.isPending;
 
   const tooltip = drainMode
     ? "Automation paused via drain mode. Open to see status."
@@ -213,6 +223,25 @@ function AutoModeButton() {
           </div>
         </div>
 
+        <div className="mt-3 flex items-center justify-between gap-3 border-t border-border pt-2">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            Runtime
+          </div>
+          <button
+            type="button"
+            onClick={() => drainMutation.mutate(
+              drainMode
+                ? { enabled: false }
+                : { enabled: true, reason: "Paused from header auto mode menu" },
+            )}
+            disabled={pending}
+            data-testid="auto-mode-drain-toggle"
+            className="inline-flex items-center rounded-md border border-border px-2 py-1 text-[10px] uppercase tracking-wider text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+          >
+            {drainMode ? "Resume" : "Drain"}
+          </button>
+        </div>
+
         <Link
           href="/settings"
           className="mt-3 inline-flex text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
@@ -229,18 +258,34 @@ function GitHubRateLimitNotice() {
     queryKey: ["/api/github-rate-limit"],
     refetchInterval: 30000,
   });
+  const { data: activities } = useQuery<ActivitySnapshot>({
+    queryKey: ["/api/activities"],
+    refetchInterval: 5000,
+  });
 
-  if (!githubRateLimit?.limited || !githubRateLimit.resetAt) {
+  const activityRateLimitMessage = activities
+    ? [...activities.failed, ...activities.warnings]
+      .map((item) => ("lastError" in item ? item.lastError : item.message) ?? "")
+      .find((message) => message.toLowerCase().includes("rate limit")) ?? null
+    : null;
+
+  if (!githubRateLimit?.limited && !activityRateLimitMessage) {
     return null;
   }
 
   return (
     <Link
       href="/settings"
-      title="Open settings for GitHub token configuration"
-      className="hidden max-w-full items-center border border-warning-border bg-warning-muted px-2.5 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:border-warning hover:bg-warning-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background lg:inline-flex"
+      title={
+        githubRateLimit?.limited && githubRateLimit.resetAt
+          ? `GitHub rate limit active until ${new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}. Open settings for token configuration.`
+          : activityRateLimitMessage ?? "GitHub rate limit errors detected in recent activity. Open settings for token configuration."
+      }
+      className="hidden max-w-[320px] items-center truncate whitespace-nowrap rounded-md border border-warning-border bg-warning-muted px-2.5 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:border-warning hover:bg-warning-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background lg:inline-flex"
     >
-      GitHub rate limit active until {new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}
+      {githubRateLimit?.limited && githubRateLimit.resetAt
+        ? `GitHub rate limited until ${new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}`
+        : "GitHub rate limit error (activity)"}
     </Link>
   );
 }

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -69,6 +69,27 @@ type GitHubRateLimitState = {
   resetAt: string | null;
 };
 
+type GitHubTokenTestResult = {
+  index: number;
+  token: string;
+  status: "ok" | "throttled" | "error";
+  login: string | null;
+  remaining: number | null;
+  resetAt: string | null;
+  message: string;
+  repoProbe: string | null;
+};
+
+type GitHubTokenTestResponse = {
+  testedAt: string;
+  results: GitHubTokenTestResult[];
+};
+
+type GitHubTokenTestLog = {
+  timestamp: string;
+  lines: string[];
+};
+
 type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
 type IssueWorkMode = (typeof ISSUE_WORK_MODE_OPTIONS)[number]["value"];
 type RepoAgentOption = (typeof REPO_AGENT_OPTIONS)[number]["value"];
@@ -314,6 +335,7 @@ export default function Settings() {
   const [addUrl, setAddUrl] = useState("");
   const [addRepo, setAddRepo] = useState("");
   const [watchScope, setWatchScope] = useState<WatchScope>("mine");
+  const [tokenTestLogs, setTokenTestLogs] = useState<GitHubTokenTestLog[]>([]);
   const githubTokens = config?.githubTokens ?? (config?.githubToken ? [config.githubToken] : []);
   const githubCommentAppName = config?.githubCommentAppName ?? "patchdeck";
 
@@ -420,6 +442,45 @@ export default function Settings() {
     },
     onError: (error) => {
       toast({ variant: "destructive", description: `Could not update repository settings: ${error.message}` });
+    },
+  });
+
+  const testGitHubTokensMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("POST", "/api/github-tokens/test");
+      return res.json() as Promise<GitHubTokenTestResponse>;
+    },
+    onSuccess: (result) => {
+      const lines = result.results.length === 0
+        ? ["No configured GitHub tokens to test."]
+        : result.results.map((entry) => {
+          const remaining = entry.remaining === null ? "?" : String(entry.remaining);
+          const resetAt = entry.resetAt ? new Date(entry.resetAt).toLocaleTimeString("en-US") : "unknown";
+          const login = entry.login ? `login=${entry.login}` : "login=unknown";
+          const repoProbe = entry.repoProbe ? `probe=${entry.repoProbe}` : "probe=none";
+          return `#${entry.index} ${entry.token} ${entry.status.toUpperCase()} ${login} remaining=${remaining} reset=${resetAt} ${repoProbe} :: ${entry.message}`;
+        });
+
+      setTokenTestLogs((previous) => [
+        {
+          timestamp: result.testedAt,
+          lines,
+        },
+        ...previous,
+      ].slice(0, 12));
+
+      toast({ description: "GitHub key test complete." });
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setTokenTestLogs((previous) => [
+        {
+          timestamp: new Date().toISOString(),
+          lines: [`ERROR ${message}`],
+        },
+        ...previous,
+      ].slice(0, 12));
+      toast({ variant: "destructive", description: `GitHub key test failed: ${message}` });
     },
   });
 
@@ -1295,6 +1356,37 @@ export default function Settings() {
                     </button>
                   </div>
                 ) : null}
+
+                <div className="mt-1 flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-[11px] text-muted-foreground">
+                      Run a direct GitHub auth and rate-limit check for each configured token.
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => testGitHubTokensMutation.mutate()}
+                      disabled={testGitHubTokensMutation.isPending}
+                      data-testid="button-test-github-tokens"
+                      className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                    >
+                      {testGitHubTokensMutation.isPending ? "Testing..." : "Test keys"}
+                    </button>
+                  </div>
+                  <div className="max-h-52 overflow-y-auto border border-border/80 bg-background/40 p-2 font-mono text-[11px] leading-relaxed">
+                    {tokenTestLogs.length === 0 ? (
+                      <div className="text-muted-foreground">No key tests run yet.</div>
+                    ) : (
+                      tokenTestLogs.map((entry, index) => (
+                        <div key={`${entry.timestamp}-${index}`} className="mb-2 last:mb-0">
+                          <div className="text-muted-foreground">[{new Date(entry.timestamp).toLocaleString()}]</div>
+                          {entry.lines.map((line, lineIndex) => (
+                            <div key={`${entry.timestamp}-${index}-${lineIndex}`}>{line}</div>
+                          ))}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
               </div>
 
               <div className="flex flex-col gap-2">

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -238,6 +238,62 @@ test("GET /api/github-rate-limit reports the current reset time", async () => {
   }
 });
 
+test("POST /api/github-tokens/test returns per-token diagnostics", async () => {
+  const harness = await createHarness(new MemStorage(), {
+    testGitHubTokensFn: async () => ({
+      testedAt: "2026-05-14T23:55:00.000Z",
+      results: [
+        {
+          index: 1,
+          token: "***1234",
+          status: "ok",
+          login: "octocat",
+          remaining: 4999,
+          resetAt: "2026-05-15T00:55:00.000Z",
+          message: "Authenticated and can access acme/widgets",
+          repoProbe: "acme/widgets",
+        },
+        {
+          index: 2,
+          token: "***9999",
+          status: "throttled",
+          login: null,
+          remaining: 0,
+          resetAt: "2026-05-15T00:01:00.000Z",
+          message: "GitHub returned 403: API rate limit exceeded",
+          repoProbe: "acme/widgets",
+        },
+      ],
+    }),
+  });
+
+  try {
+    await harness.storage.updateConfig({
+      githubTokens: ["ghs_alpha1234", "ghs_beta9999"],
+    });
+    await harness.storage.updateRepoSettings("acme/widgets", { ownPrsOnly: true });
+
+    const response = await fetch(`${harness.baseUrl}/api/github-tokens/test`, {
+      method: "POST",
+    });
+
+    assert.equal(response.status, 200);
+    const body = await response.json() as {
+      testedAt: string;
+      results: Array<{ token: string; status: string; remaining: number | null }>;
+    };
+
+    assert.equal(body.testedAt, "2026-05-14T23:55:00.000Z");
+    assert.equal(body.results.length, 2);
+    assert.equal(body.results[0]?.token, "***1234");
+    assert.equal(body.results[0]?.status, "ok");
+    assert.equal(body.results[1]?.token, "***9999");
+    assert.equal(body.results[1]?.status, "throttled");
+  } finally {
+    await harness.close();
+  }
+});
+
 test("GET/PATCH /api/config masks and preserves remote access password", async () => {
   const harness = await createHarness();
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,6 @@
 import type { Express, Response } from "express";
 import type { Server } from "http";
+import { Octokit } from "@octokit/rest";
 import { z } from "zod";
 import { claudeEffortSchema, codexReasoningEffortSchema, codingAgentSchema, configSchema, startReleaseSocialPostSchema } from "@shared/schema";
 import type { Config } from "@shared/schema";
@@ -37,6 +38,7 @@ function parsePositiveInt(value: unknown): number | undefined {
 
 const TOKEN_MASK_PREFIX = "***";
 const WEB_PASSWORD_MASK = "********";
+const GITHUB_API_VERSION = "2022-11-28";
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -128,7 +130,110 @@ function maskConfig(config: Config): Config {
 export type RouteDependencies = AppRuntimeDependencies & {
   runtime?: AppRuntime;
   appUpdateChecker?: AppUpdateChecker;
+  testGitHubTokensFn?: (config: Config, watchedRepos: string[]) => Promise<GitHubTokenTestResponse>;
 };
+
+type GitHubTokenTestStatus = "ok" | "throttled" | "error";
+
+type GitHubTokenTestResult = {
+  index: number;
+  token: string;
+  status: GitHubTokenTestStatus;
+  login: string | null;
+  remaining: number | null;
+  resetAt: string | null;
+  message: string;
+  repoProbe: string | null;
+};
+
+type GitHubTokenTestResponse = {
+  testedAt: string;
+  results: GitHubTokenTestResult[];
+};
+
+function parseRateLimitInfo(headers: Record<string, string | string[] | undefined>): { remaining: number | null; resetAt: string | null } {
+  const remainingRaw = headers["x-ratelimit-remaining"];
+  const resetRaw = headers["x-ratelimit-reset"];
+  const remainingText = Array.isArray(remainingRaw) ? remainingRaw[0] : remainingRaw;
+  const resetText = Array.isArray(resetRaw) ? resetRaw[0] : resetRaw;
+  const remaining = typeof remainingText === "string" ? Number.parseInt(remainingText, 10) : Number.NaN;
+  const resetEpoch = typeof resetText === "string" ? Number.parseInt(resetText, 10) : Number.NaN;
+  return {
+    remaining: Number.isFinite(remaining) ? remaining : null,
+    resetAt: Number.isFinite(resetEpoch) ? new Date(resetEpoch * 1000).toISOString() : null,
+  };
+}
+
+async function testGitHubTokens(config: Config, watchedRepos: string[]): Promise<GitHubTokenTestResponse> {
+  const tokens = (config.githubTokens ?? []).map((token) => token.trim()).filter(Boolean);
+  const firstWatchedRepo = watchedRepos[0] ?? null;
+  const results: GitHubTokenTestResult[] = [];
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const client = new Octokit({
+      auth: token,
+      request: {
+        headers: {
+          "X-GitHub-Api-Version": GITHUB_API_VERSION,
+        },
+      },
+    });
+
+    try {
+      const user = await client.request("GET /user");
+      const { remaining, resetAt } = parseRateLimitInfo(user.headers as Record<string, string>);
+      let message = "Authenticated successfully";
+
+      if (firstWatchedRepo) {
+        const [owner, repo] = firstWatchedRepo.split("/");
+        if (owner && repo) {
+          try {
+            await client.request("GET /repos/{owner}/{repo}", { owner, repo });
+            message = `Authenticated and can access ${firstWatchedRepo}`;
+          } catch (error) {
+            const status = (error as { status?: number } | undefined)?.status;
+            const detail = error instanceof Error ? error.message : String(error);
+            message = status
+              ? `Authenticated, but repo probe ${firstWatchedRepo} returned ${status}: ${detail}`
+              : `Authenticated, but repo probe ${firstWatchedRepo} failed: ${detail}`;
+          }
+        }
+      }
+
+      results.push({
+        index: index + 1,
+        token: maskToken(token),
+        status: remaining === 0 ? "throttled" : "ok",
+        login: typeof user.data?.login === "string" ? user.data.login : null,
+        remaining,
+        resetAt,
+        message,
+        repoProbe: firstWatchedRepo,
+      });
+    } catch (error) {
+      const status = (error as { status?: number; response?: { headers?: Record<string, string> } } | undefined)?.status;
+      const headers = (error as { response?: { headers?: Record<string, string> } } | undefined)?.response?.headers ?? {};
+      const { remaining, resetAt } = parseRateLimitInfo(headers);
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        index: index + 1,
+        token: maskToken(token),
+        status: status === 403 && remaining === 0 ? "throttled" : "error",
+        login: null,
+        remaining,
+        resetAt,
+        message: status ? `GitHub returned ${status}: ${message}` : message,
+        repoProbe: firstWatchedRepo,
+      });
+    }
+  }
+
+  return {
+    testedAt: new Date().toISOString(),
+    results,
+  };
+}
 
 export async function registerRoutes(
   httpServer: Server,
@@ -137,6 +242,7 @@ export async function registerRoutes(
 ): Promise<Server> {
   const runtime = dependencies.runtime ?? createAppRuntime(dependencies);
   const appUpdateChecker = dependencies.appUpdateChecker ?? createAppUpdateChecker();
+  const testGitHubTokensFn = dependencies.testGitHubTokensFn ?? testGitHubTokens;
   await runtime.start();
 
   httpServer.on("close", () => {
@@ -153,6 +259,16 @@ export async function registerRoutes(
       limited: state.limited,
       resetAt: state.resetAt ? state.resetAt.toISOString() : null,
     });
+  });
+
+  app.post("/api/github-tokens/test", async (_req, res) => {
+    try {
+      const config = await runtime.getConfig();
+      const watchedRepos = (await runtime.listRepoSettings()).map((repo) => repo.repo);
+      res.json(await testGitHubTokensFn(config, watchedRepos));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
   });
 
   app.get("/api/server-logs", (req, res) => {


### PR DESCRIPTION
## Summary
- add drain/resume toggle in header auto-mode menu
- add activity-aware GitHub rate-limit banner fallback text in header
- add Settings "Test keys" action for GitHub tokens with result logs
- add API route and tests for per-token GitHub diagnostics

## Files
- client/src/components/AppHeader.tsx
- client/src/pages/settings.tsx
- server/routes.ts
- server/routes.test.ts
