### PR TITLE
polish: clarify header pause toggle and tidy GitHub key test panel

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -5,7 +5,9 @@ import { apiRequest } from "@/lib/queryClient";
 import type { ActivitySnapshot, Config, RuntimeState } from "@shared/schema";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
+import { ToastAction } from "@/components/ui/toast";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { toast } from "@/hooks/use-toast";
 
 type AppHeaderSection = "prs" | "issues" | "releases" | "logs" | "settings";
 type GitHubRateLimitState = {
@@ -140,13 +142,38 @@ function AutoModeButton() {
       const res = await apiRequest("POST", "/api/runtime/drain", input);
       return res.json();
     },
+    onSuccess: (_data, variables) => {
+      if (variables.enabled) {
+        toast({
+          description: "Background sync paused. New automation runs are blocked.",
+          action: (
+            <ToastAction
+              altText="Resume background sync"
+              onClick={() => drainMutation.mutate({ enabled: false })}
+            >
+              Undo
+            </ToastAction>
+          ),
+        });
+      } else {
+        toast({ description: "Background sync resumed." });
+      }
+    },
+    onError: (error, variables) => {
+      const message = error instanceof Error ? error.message : String(error);
+      toast({
+        variant: "destructive",
+        description: `Failed to ${variables.enabled ? "pause" : "resume"} background sync: ${message}`,
+      });
+    },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/runtime"] });
       queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
     },
   });
 
-  const pending = updateConfigMutation.isPending || drainMutation.isPending;
+  const switchPending = updateConfigMutation.isPending;
+  const drainPending = drainMutation.isPending;
 
   const tooltip = drainMode
     ? "Automation paused via drain mode. Open to see status."
@@ -198,7 +225,7 @@ function AutoModeButton() {
             <Switch
               id="auto-mode-prs"
               checked={autoPrs}
-              disabled={pending || !config}
+              disabled={switchPending || !config}
               onCheckedChange={(next) => updateConfigMutation.mutate({ autoPrs: next })}
               data-testid="auto-mode-prs-switch"
             />
@@ -216,7 +243,7 @@ function AutoModeButton() {
             <Switch
               id="auto-mode-issues"
               checked={autoIssues}
-              disabled={pending || !config}
+              disabled={switchPending || !config}
               onCheckedChange={(next) => updateConfigMutation.mutate({ autoIssues: next })}
               data-testid="auto-mode-issues-switch"
             />
@@ -224,8 +251,8 @@ function AutoModeButton() {
         </div>
 
         <div className="mt-3 flex items-center justify-between gap-3 border-t border-border pt-2">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
-            Runtime
+          <div className="min-w-0 flex-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+            Background sync
           </div>
           <button
             type="button"
@@ -234,11 +261,11 @@ function AutoModeButton() {
                 ? { enabled: false }
                 : { enabled: true, reason: "Paused from header auto mode menu" },
             )}
-            disabled={pending}
+            disabled={drainPending}
             data-testid="auto-mode-drain-toggle"
-            className="inline-flex items-center rounded-md border border-border px-2 py-1 text-[10px] uppercase tracking-wider text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+            className="inline-flex min-h-[28px] items-center rounded-md border border-border px-2.5 py-1.5 text-[10px] uppercase tracking-wider text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
           >
-            {drainMode ? "Resume" : "Drain"}
+            {drainPending ? "…" : drainMode ? "Resume all" : "Pause all"}
           </button>
         </div>
 
@@ -258,34 +285,46 @@ function GitHubRateLimitNotice() {
     queryKey: ["/api/github-rate-limit"],
     refetchInterval: 30000,
   });
+  const explicitlyLimited = githubRateLimit?.limited === true;
   const { data: activities } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
-    refetchInterval: 5000,
+    refetchInterval: 30000,
+    enabled: !explicitlyLimited,
   });
 
-  const activityRateLimitMessage = activities
+  const activityRateLimitMessage = !explicitlyLimited && activities
     ? [...activities.failed, ...activities.warnings]
       .map((item) => ("lastError" in item ? item.lastError : item.message) ?? "")
       .find((message) => message.toLowerCase().includes("rate limit")) ?? null
     : null;
 
-  if (!githubRateLimit?.limited && !activityRateLimitMessage) {
+  if (!explicitlyLimited && !activityRateLimitMessage) {
     return null;
   }
+
+  const resetTime = githubRateLimit?.resetAt
+    ? new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")
+    : null;
+
+  const label = explicitlyLimited
+    ? resetTime
+      ? `GitHub rate limited until ${resetTime}`
+      : "GitHub rate limited"
+    : "GitHub rate limit hit in recent activity";
+
+  const tooltip = explicitlyLimited
+    ? resetTime
+      ? `GitHub rate limit active until ${resetTime}. Open settings for token configuration.`
+      : "GitHub rate limit active. Open settings for token configuration."
+    : activityRateLimitMessage ?? "GitHub rate limit errors detected in recent activity. Open settings for token configuration.";
 
   return (
     <Link
       href="/settings"
-      title={
-        githubRateLimit?.limited && githubRateLimit.resetAt
-          ? `GitHub rate limit active until ${new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}. Open settings for token configuration.`
-          : activityRateLimitMessage ?? "GitHub rate limit errors detected in recent activity. Open settings for token configuration."
-      }
-      className="hidden max-w-[320px] items-center truncate whitespace-nowrap rounded-md border border-warning-border bg-warning-muted px-2.5 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:border-warning hover:bg-warning-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background lg:inline-flex"
+      title={tooltip}
+      className="inline-flex max-w-[320px] items-center truncate whitespace-nowrap rounded-md border border-warning-border bg-warning-muted px-2.5 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:border-warning hover:bg-warning-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
     >
-      {githubRateLimit?.limited && githubRateLimit.resetAt
-        ? `GitHub rate limited until ${new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}`
-        : "GitHub rate limit error (activity)"}
+      {label}
     </Link>
   );
 }

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -85,9 +85,23 @@ type GitHubTokenTestResponse = {
   results: GitHubTokenTestResult[];
 };
 
+type GitHubTokenTestLogEntry =
+  | { kind: "result"; data: GitHubTokenTestResult }
+  | { kind: "info"; message: string }
+  | { kind: "error"; message: string };
+
 type GitHubTokenTestLog = {
   timestamp: string;
-  lines: string[];
+  tokensTested: number;
+  entries: GitHubTokenTestLogEntry[];
+};
+
+const TOKEN_TEST_LOG_LIMIT = 12;
+
+const TOKEN_TEST_STATUS_CLASS: Record<GitHubTokenTestResult["status"], string> = {
+  ok: "border-success-border bg-success-muted text-success-foreground",
+  throttled: "border-warning-border bg-warning-muted text-warning-foreground",
+  error: "border-destructive/40 bg-destructive/10 text-destructive",
 };
 
 type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
@@ -459,35 +473,28 @@ export default function Settings() {
       return res.json() as Promise<GitHubTokenTestResponse>;
     },
     onSuccess: (result) => {
-      const lines = result.results.length === 0
-        ? ["No configured GitHub tokens to test."]
-        : result.results.map((entry) => {
-          const remaining = entry.remaining === null ? "?" : String(entry.remaining);
-          const resetAt = entry.resetAt ? new Date(entry.resetAt).toLocaleTimeString("en-US") : "unknown";
-          const login = entry.login ? `login=${entry.login}` : "login=unknown";
-          const repoProbe = entry.repoProbe ? `probe=${entry.repoProbe}` : "probe=none";
-          return `#${entry.index} ${entry.token} ${entry.status.toUpperCase()} ${login} remaining=${remaining} reset=${resetAt} ${repoProbe} :: ${entry.message}`;
-        });
+      const entries: GitHubTokenTestLogEntry[] = result.results.length === 0
+        ? [{ kind: "info", message: "No configured GitHub tokens to test." }]
+        : result.results.map((data) => ({ kind: "result", data }));
 
       setTokenTestLogs((previous) => [
-        {
-          timestamp: result.testedAt,
-          lines,
-        },
+        { timestamp: result.testedAt, tokensTested: result.results.length, entries },
         ...previous,
-      ].slice(0, 12));
+      ].slice(0, TOKEN_TEST_LOG_LIMIT));
 
       toast({ description: "GitHub key test complete." });
     },
     onError: (error) => {
       const message = error instanceof Error ? error.message : String(error);
+      const errorEntries: GitHubTokenTestLogEntry[] = [{ kind: "error", message }];
       setTokenTestLogs((previous) => [
         {
           timestamp: new Date().toISOString(),
-          lines: [`ERROR ${message}`],
+          tokensTested: 0,
+          entries: errorEntries,
         },
         ...previous,
-      ].slice(0, 12));
+      ].slice(0, TOKEN_TEST_LOG_LIMIT));
       toast({ variant: "destructive", description: `GitHub key test failed: ${message}` });
     },
   });
@@ -1370,26 +1377,90 @@ export default function Settings() {
                     <div className="text-[11px] text-muted-foreground">
                       Run a direct GitHub auth and rate-limit check for each configured token.
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => testGitHubTokensMutation.mutate()}
-                      disabled={testGitHubTokensMutation.isPending}
-                      data-testid="button-test-github-tokens"
-                      className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
-                    >
-                      {testGitHubTokensMutation.isPending ? "Testing..." : "Test keys"}
-                    </button>
+                    <div className="flex items-center gap-2">
+                      {tokenTestLogs.length > 0 ? (
+                        <button
+                          type="button"
+                          onClick={() => setTokenTestLogs([])}
+                          data-testid="button-clear-github-token-tests"
+                          className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                        >
+                          clear
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={() => testGitHubTokensMutation.mutate()}
+                        disabled={testGitHubTokensMutation.isPending}
+                        data-testid="button-test-github-tokens"
+                        className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                      >
+                        {testGitHubTokensMutation.isPending
+                          ? `testing ${githubTokens.length} key${githubTokens.length === 1 ? "" : "s"}…`
+                          : "test keys"}
+                      </button>
+                    </div>
                   </div>
-                  <div className="max-h-52 overflow-y-auto border border-border/80 bg-background/40 p-2 font-mono text-[11px] leading-relaxed">
+                  <div className="min-h-[8rem] max-h-52 overflow-y-auto border border-border/80 bg-background/40 p-2 text-[11px] leading-relaxed">
                     {tokenTestLogs.length === 0 ? (
                       <div className="text-muted-foreground">No key tests run yet.</div>
                     ) : (
-                      tokenTestLogs.map((entry, index) => (
-                        <div key={`${entry.timestamp}-${index}`} className="mb-2 last:mb-0">
-                          <div className="text-muted-foreground">[{new Date(entry.timestamp).toLocaleString()}]</div>
-                          {entry.lines.map((line, lineIndex) => (
-                            <div key={`${entry.timestamp}-${index}-${lineIndex}`}>{line}</div>
-                          ))}
+                      tokenTestLogs.map((log, logIndex) => (
+                        <div
+                          key={`${log.timestamp}-${logIndex}`}
+                          className="mb-3 last:mb-0 border-b border-border/40 pb-2 last:border-b-0 last:pb-0"
+                        >
+                          <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                            {new Date(log.timestamp).toLocaleTimeString("en-US")}
+                            {log.tokensTested > 0
+                              ? ` · ${log.tokensTested} key${log.tokensTested === 1 ? "" : "s"}`
+                              : ""}
+                          </div>
+                          <div className="flex flex-col gap-1.5">
+                            {log.entries.map((item, itemIndex) => {
+                              const key = `${log.timestamp}-${logIndex}-${itemIndex}`;
+                              if (item.kind === "result") {
+                                const { data } = item;
+                                const remaining = data.remaining === null ? "?" : String(data.remaining);
+                                const resetAt = data.resetAt
+                                  ? new Date(data.resetAt).toLocaleTimeString("en-US")
+                                  : "—";
+                                return (
+                                  <div key={key} className="flex flex-col gap-0.5">
+                                    <div className="flex flex-wrap items-center gap-2 font-mono">
+                                      <span className="text-muted-foreground">#{data.index}</span>
+                                      <span
+                                        className={`inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider ${TOKEN_TEST_STATUS_CLASS[data.status]}`}
+                                      >
+                                        {data.status}
+                                      </span>
+                                      <span className="text-foreground">{data.token}</span>
+                                      <span className="text-muted-foreground">
+                                        {data.login ?? "no login"} · remaining {remaining} · reset {resetAt}
+                                        {data.repoProbe ? ` · probe ${data.repoProbe}` : ""}
+                                      </span>
+                                    </div>
+                                    <div className="break-words pl-1 text-muted-foreground">
+                                      {data.message}
+                                    </div>
+                                  </div>
+                                );
+                              }
+                              if (item.kind === "error") {
+                                return (
+                                  <div key={key} className="flex flex-wrap items-center gap-2 font-mono">
+                                    <span className="inline-flex items-center rounded-sm border border-destructive/40 bg-destructive/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-destructive">
+                                      error
+                                    </span>
+                                    <span className="break-words text-destructive">{item.message}</span>
+                                  </div>
+                                );
+                              }
+                              return (
+                                <div key={key} className="text-muted-foreground">{item.message}</div>
+                              );
+                            })}
+                          </div>
                         </div>
                       ))
                     )}


### PR DESCRIPTION
## Summary
Polish pass on the surfaces added in #64 (header drain toggle, settings GitHub key test panel). No behaviour change to the underlying APIs — only UI clarity, safety, and feedback.

### Header auto-mode popover
- Rename `Runtime / Drain | Resume` → `Background sync / Pause all | Resume all` so users without "drain" jargon understand what the control does.
- Add success/error toasts for the pause-all action, plus an **Undo** action on the pause toast so a misclick is recoverable in one tap.
- Split the shared `pending` flag so toggling the PR/Issues switches no longer disables the pause-all button (and vice versa).
- Bump the pause-all tap target (`min-h`, larger padding) and show `…` while the mutation is in flight.

### GitHub rate-limit notice
- Show the badge on mobile (previously hidden below `lg`).
- Drop the `/api/activities` fallback poll from 5s → 30s, and only mount it while the explicit rate-limit endpoint reports clear — the badge no longer holds open a 5s poll in steady state.
- Tighten labels: explicit limit shows the reset time, activity-derived hits read "GitHub rate limit hit in recent activity".

### Settings GitHub key test panel
- Replace the flat string-per-line log with a structured per-result row: index, colored status pill (`ok` / `throttled` / `error`), masked token, login / remaining / reset / probe, and a wrapped message line.
- Reserve a `min-h-[8rem]` on the log container so the first run no longer shifts the page.
- Lower-case the `test keys` / `clear` controls to match neighbouring `add` / `cancel` buttons; include the count while in flight (`testing N keys…`).
- Add a `clear` link that appears once there is at least one log entry; use a compact time-only header per entry (buffer caps at 12 anyway).

## Test plan
- [ ] Open the auto-mode popover and toggle `Pause all` — verify the toast appears with an Undo action and that Undo immediately resumes.
- [ ] Trigger a failure (offline or 500) and confirm a destructive toast surfaces.
- [ ] Toggle the PR/Issues switches while a pause request is in flight — switches should remain interactive, button keeps its own busy state.
- [ ] Force a GitHub rate limit (or use a 403 response) and confirm the badge renders on both mobile and desktop.
- [ ] In Settings, click `test keys` with 0, 1, and N tokens configured — verify counts, colored status pills, and that `clear` empties the log.