### PR TITLE
feat: throttle issue sync with paged lazy loading and SWR cache

### DIFF
--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -5,7 +5,7 @@ import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
-import type { ActivitySnapshot, Config, Issue, LogEntry, RuntimeState } from "@shared/schema";
+import type { ActivitySnapshot, Config, Issue, IssueListPage, LogEntry, RuntimeState } from "@shared/schema";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
@@ -13,26 +13,27 @@ import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu
 
 const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v1";
 const ISSUES_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
+const ISSUES_PAGE_SIZE = 20;
 
-function readCachedIssues(): { data: Issue[]; updatedAt: number } | null {
+function readCachedIssues(): { data: IssueListPage; updatedAt: number } | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.localStorage.getItem(ISSUES_CACHE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as { data?: unknown; updatedAt?: unknown };
-    if (!Array.isArray(parsed.data) || typeof parsed.updatedAt !== "number" || !Number.isFinite(parsed.updatedAt)) {
+    if (!parsed.data || typeof parsed.updatedAt !== "number" || !Number.isFinite(parsed.updatedAt)) {
       return null;
     }
     if (Date.now() - parsed.updatedAt > ISSUES_CACHE_MAX_AGE_MS) {
       return null;
     }
-    return { data: parsed.data as Issue[], updatedAt: parsed.updatedAt };
+    return { data: parsed.data as IssueListPage, updatedAt: parsed.updatedAt };
   } catch {
     return null;
   }
 }
 
-function writeCachedIssues(data: Issue[]): void {
+function writeCachedIssues(data: IssueListPage): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(ISSUES_CACHE_KEY, JSON.stringify({
@@ -70,6 +71,10 @@ function issueKey(issue: Issue): string {
 function issueDetailUrl(issue: Issue): string {
   const [owner, repo] = issue.repo.split("/");
   return `/api/issues/${encodeURIComponent(owner ?? "")}/${encodeURIComponent(repo ?? "")}/${issue.number}`;
+}
+
+function issueListUrl(limit: number, offset: number): string {
+  return `/api/issues?limit=${limit}&offset=${offset}`;
 }
 
 function isActiveWorkStatus(status: Issue["workStatus"]): boolean {
@@ -440,8 +445,9 @@ export default function Issues() {
     },
   });
 
-  const issuesQuery = useQuery<Issue[]>({
-    queryKey: ["/api/issues"],
+  const issuesQuery = useQuery<IssueListPage>({
+    queryKey: ["/api/issues", ISSUES_PAGE_SIZE, 0],
+    queryFn: async () => fetchJson<IssueListPage>(issueListUrl(ISSUES_PAGE_SIZE, 0)),
     enabled: runtime !== undefined && !globalDrainMode,
     initialData: cachedIssues?.data,
     initialDataUpdatedAt: cachedIssues?.updatedAt,
@@ -451,18 +457,49 @@ export default function Issues() {
       if (globalDrainMode) {
         return false;
       }
-      const data = query.state.data;
+      const data = query.state.data?.items;
       return Array.isArray(data) && data.some((issue) => isActiveWorkStatus(issue.workStatus))
         ? 5000
         : false;
     },
   });
-  const { data: issues = [], isLoading, refetch, isFetching } = issuesQuery;
+  const { data: issuesPage, isLoading, refetch, isFetching } = issuesQuery;
+  const [extraPages, setExtraPages] = useState<IssueListPage[]>([]);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
   useEffect(() => {
     if (issuesQuery.status === "success") {
       writeCachedIssues(issuesQuery.data);
     }
   }, [issuesQuery.status, issuesQuery.data]);
+  useEffect(() => {
+    setExtraPages([]);
+  }, [issuesPage?.fetchedAt]);
+
+  const issues = useMemo(() => {
+    const all = [issuesPage, ...extraPages].flatMap((page) => page?.items ?? []);
+    const deduped = new Map<string, Issue>();
+    for (const issue of all) deduped.set(issue.id, issue);
+    return Array.from(deduped.values()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  }, [issuesPage, extraPages]);
+  const latestPage = extraPages[extraPages.length - 1] ?? issuesPage ?? null;
+  const canLoadMore = Boolean(latestPage?.hasMore);
+  const nextOffset = latestPage?.nextOffset ?? null;
+
+  const loadMoreIssues = async (): Promise<void> => {
+    if (!canLoadMore || nextOffset === null || globalDrainMode || isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const nextPage = await fetchJson<IssueListPage>(issueListUrl(ISSUES_PAGE_SIZE, nextOffset));
+      setExtraPages((current) => [...current, nextPage]);
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        description: `Could not load more issues: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
 
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<string>("all");
@@ -716,7 +753,7 @@ export default function Issues() {
               type="button"
               onClick={() => {
                 void Promise.all([
-                  refetch(),
+                  refetch().then(() => setExtraPages([])),
                   selectedIssueFromList ? refetchSelectedIssueDetail() : Promise.resolve(),
                 ]);
               }}
@@ -892,22 +929,37 @@ export default function Issues() {
                     : "No open issues found in watched repositories."}
                 </div>
               ) : (
-                repoGroups.map((group) => (
-                  <div key={group.repo} className="border-b border-border/60 last:border-b-0">
-                    <div className="sticky top-0 z-10 border-b border-border bg-background px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                      {group.repo} <span className="font-mono text-foreground/70">({group.issues.length})</span>
+                <>
+                  {repoGroups.map((group) => (
+                    <div key={group.repo} className="border-b border-border/60 last:border-b-0">
+                      <div className="sticky top-0 z-10 border-b border-border bg-background px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                        {group.repo} <span className="font-mono text-foreground/70">({group.issues.length})</span>
+                      </div>
+                      {group.issues.map((issue) => (
+                        <IssueRow
+                          key={issue.id}
+                          issue={issue}
+                          selected={issue.id === selectedIssueId}
+                          onSelect={setSelectedIssueId}
+                          queueStatus={queueStatusById.get(issue.id) ?? null}
+                        />
+                      ))}
                     </div>
-                    {group.issues.map((issue) => (
-                      <IssueRow
-                        key={issue.id}
-                        issue={issue}
-                        selected={issue.id === selectedIssueId}
-                        onSelect={setSelectedIssueId}
-                        queueStatus={queueStatusById.get(issue.id) ?? null}
-                      />
-                    ))}
-                  </div>
-                ))
+                  ))}
+                  {canLoadMore && (
+                    <div className="border-t border-border/60 px-4 py-2">
+                      <button
+                        type="button"
+                        onClick={() => void loadMoreIssues()}
+                        disabled={isLoadingMore || globalDrainMode}
+                        className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:opacity-50"
+                      >
+                        {isLoadingMore ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+                        load more
+                      </button>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundJob,
   Config,
   Issue,
+  IssueListPage,
   IssueEvaluation,
   DeploymentHealingSession,
   HealingSession,
@@ -61,6 +62,7 @@ import {
   listOpenLinkedPullRequestsForIssue,
   listReleasesForRepo,
   listUnreleasedMergedPulls,
+  type GitHubIssueSummary,
   type MergedPRSummary,
   parsePRUrl,
   parseRepoSlug,
@@ -149,7 +151,7 @@ export type AppRuntime = {
   listGitHubReleases(): Promise<RepoGitHubReleases[]>;
   startReleaseSocialPost(request: StartReleaseSocialPostRequest): Promise<ReleaseSocialPost>;
   getReleaseSocialPost(jobId: string): Promise<ReleaseSocialPost>;
-  listIssues(): Promise<Issue[]>;
+  listIssues(input?: { limit?: number; offset?: number }): Promise<IssueListPage>;
   getIssue(repo: string, number: number): Promise<Issue>;
   updateIssueLabels(repo: string, number: number, updates: { add?: string[]; remove?: string[] }): Promise<Issue>;
   evaluateIssue(repo: string, number: number): Promise<Issue>;
@@ -215,6 +217,11 @@ const AUTO_WORK_READY_LABELS = new Set([
   "agent-ready",
   "ready",
 ]);
+const DEFAULT_ISSUES_PAGE_SIZE = 20;
+const MAX_ISSUES_PAGE_SIZE = 100;
+const ISSUES_PAGE_CACHE_TTL_HOT_MS = 60 * 1000;
+const ISSUES_PAGE_CACHE_TTL_WARM_MS = 10 * 60 * 1000;
+const ISSUES_PAGE_CACHE_TTL_COLD_MS = 30 * 60 * 1000;
 const AUTO_WORK_BLOCKED_LABELS = new Set([
   "blocked",
   "question",
@@ -809,6 +816,24 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     lastSyncSucceededAt: string | null;
     lastSyncError: string | null;
   }>();
+  const issuePageCache = new Map<string, {
+    items: GitHubIssueSummary[];
+    hasMore: boolean;
+    fetchedAt: string;
+    staleAt: string;
+    expiresAtMs: number;
+  }>();
+  const issuePageRefreshes = new Map<string, Promise<void>>();
+
+  function issuePageCacheKey(repo: string, limit: number, offset: number): string {
+    return `${repo}|${limit}|${offset}`;
+  }
+
+  function issuePageCacheTtlMs(offset: number): number {
+    if (offset <= 0) return ISSUES_PAGE_CACHE_TTL_HOT_MS;
+    if (offset < 100) return ISSUES_PAGE_CACHE_TTL_WARM_MS;
+    return ISSUES_PAGE_CACHE_TTL_COLD_MS;
+  }
 
   function markIssueSyncAttempt(targetId: string): string {
     const now = new Date().toISOString();
@@ -1072,21 +1097,93 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     };
   }
 
-  async function listIssuesInternal(): Promise<Issue[]> {
+  async function listIssuesInternal(input?: { limit?: number; offset?: number }): Promise<IssueListPage> {
+    const limit = Math.min(Math.max(1, input?.limit ?? DEFAULT_ISSUES_PAGE_SIZE), MAX_ISSUES_PAGE_SIZE);
+    const offset = Math.max(0, input?.offset ?? 0);
     const config = await storage.getConfig();
+    const nowMs = Date.now();
     if (config.watchedRepos.length === 0) {
-      return [];
+      const ttlMs = issuePageCacheTtlMs(offset);
+      return {
+        items: [],
+        limit,
+        offset,
+        nextOffset: null,
+        hasMore: false,
+        fetchedAt: new Date(nowMs).toISOString(),
+        staleAt: new Date(nowMs + ttlMs).toISOString(),
+      };
     }
 
     const octokit = await buildOctokit(config);
-    const perRepoIssues = await Promise.all(
+    const refreshIssuePageCache = async (parsed: ReturnType<typeof parseRepoSlug>, limitValue: number, offsetValue: number): Promise<void> => {
+      if (!parsed) return;
+      const canonicalRepo = formatRepoSlug(parsed);
+      const cacheKey = issuePageCacheKey(canonicalRepo, limitValue, offsetValue);
+      const existing = issuePageRefreshes.get(cacheKey);
+      if (existing) {
+        await existing;
+        return;
+      }
+
+      const refreshPromise = (async () => {
+        const fetched = await listOpenIssuesForRepo(octokit, parsed, { limit: limitValue, offset: offsetValue });
+        const now = Date.now();
+        const ttlMs = issuePageCacheTtlMs(offsetValue);
+        issuePageCache.set(cacheKey, {
+          items: fetched.items,
+          hasMore: fetched.hasMore,
+          fetchedAt: new Date(now).toISOString(),
+          staleAt: new Date(now + ttlMs).toISOString(),
+          expiresAtMs: now + ttlMs,
+        });
+      })();
+
+      issuePageRefreshes.set(cacheKey, refreshPromise);
+      try {
+        await refreshPromise;
+      } finally {
+        issuePageRefreshes.delete(cacheKey);
+      }
+    };
+
+    const perRepoPages = await Promise.all(
       config.watchedRepos.map(async (repoSlug) => {
+        const ttlMs = issuePageCacheTtlMs(offset);
+        const fetchedAt = new Date(nowMs).toISOString();
+        const staleAt = new Date(nowMs + ttlMs).toISOString();
         const parsed = parseRepoSlug(repoSlug);
         if (!parsed) {
-          return [];
+          return { items: [], hasMore: false, fetchedAt, staleAt };
+        }
+        const canonicalRepo = formatRepoSlug(parsed);
+        const cacheKey = issuePageCacheKey(canonicalRepo, limit, offset);
+        const cached = issuePageCache.get(cacheKey);
+        if (cached) {
+          if (cached.expiresAtMs <= nowMs) {
+            void refreshIssuePageCache(parsed, limit, offset).catch((error) => {
+              log.warn(
+                {
+                  err: error instanceof Error ? error.message : String(error),
+                  repo: canonicalRepo,
+                  limit,
+                  offset,
+                },
+                "Issue page cache refresh failed",
+              );
+            });
+          }
+          return { items: cached.items, hasMore: cached.hasMore, fetchedAt: cached.fetchedAt, staleAt: cached.staleAt };
         }
 
-        return listOpenIssuesForRepo(octokit, parsed);
+        await refreshIssuePageCache(parsed, limit, offset);
+        const refreshed = issuePageCache.get(cacheKey);
+        return {
+          items: refreshed?.items ?? [],
+          hasMore: refreshed?.hasMore ?? false,
+          fetchedAt: refreshed?.fetchedAt ?? fetchedAt,
+          staleAt: refreshed?.staleAt ?? staleAt,
+        };
       }),
     );
     const workJobs = await storage.listBackgroundJobs({ kind: "work_issue" });
@@ -1098,15 +1195,27 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       workJobsByTarget.set(job.targetId, existing);
     }
 
-    const issuesWithWorkLinks = await Promise.all(perRepoIssues.flat().map((issue) => {
+    const issuesWithWorkLinks = await Promise.all(perRepoPages.flatMap((repoPage) => repoPage.items).map((issue) => {
       const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
       const attemptedAt = markIssueSyncAttempt(targetId);
       markIssueSyncSuccess(targetId, attemptedAt);
       return applyIssueWorkState(issue, { issueJobs: workJobsByTarget.get(targetId) ?? [], octokit });
     }));
 
-    return issuesWithWorkLinks
+    const sortedItems = issuesWithWorkLinks
       .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    const hasMore = perRepoPages.some((repoPage) => repoPage.hasMore);
+    const fetchedAtMs = Math.min(...perRepoPages.map((repoPage) => new Date(repoPage.fetchedAt).getTime()));
+    const staleAtMs = Math.min(...perRepoPages.map((repoPage) => new Date(repoPage.staleAt).getTime()));
+    return {
+      items: sortedItems,
+      limit,
+      offset,
+      nextOffset: hasMore ? offset + limit : null,
+      hasMore,
+      fetchedAt: new Date(fetchedAtMs).toISOString(),
+      staleAt: new Date(staleAtMs).toISOString(),
+    };
   }
 
   async function getIssueInternal(repoInput: string, number: number): Promise<Issue> {
@@ -1236,12 +1345,13 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       return;
     }
 
-    const [repoSettings, issues, evaluationJobs, workJobs] = await Promise.all([
+    const [repoSettings, issuesPage, evaluationJobs, workJobs] = await Promise.all([
       storage.listRepoSettings(),
-      listIssuesInternal(),
+      listIssuesInternal({ limit: MAX_ISSUES_PAGE_SIZE, offset: 0 }),
       storage.listBackgroundJobs({ kind: "evaluate_issue" }),
       storage.listBackgroundJobs({ kind: "work_issue" }),
     ]);
+    const issues = issuesPage.items;
 
     const isJobActive = (status: string) => status === "queued" || status === "leased";
     const activeEvaluationTargets = new Set(
@@ -1788,8 +1898,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       return release;
     },
 
-    async listIssues() {
-      return listIssuesInternal();
+    async listIssues(input) {
+      return listIssuesInternal(input);
     },
 
     async getIssue(repoInput, number) {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -809,14 +809,14 @@ test("listOpenIssuesForRepo filters pull requests and normalizes issue metadata"
     },
   };
 
-  const issues = await listOpenIssuesForRepo(octokit as never, { owner: "owner", repo: "repo" });
+  const page = await listOpenIssuesForRepo(octokit as never, { owner: "owner", repo: "repo" });
 
-  assert.equal(issues.length, 1);
-  assert.equal(issues[0]?.number, 17);
-  assert.deepEqual(issues[0]?.labels, ["bug", "ui"]);
-  assert.deepEqual(issues[0]?.assignees, ["octocat"]);
-  assert.equal(issues[0]?.repoFullName, "owner/repo");
-  assert.match(issues[0]?.bodyHtml ?? "", /<p>The toggle is stuck<\/p>/);
+  assert.equal(page.items.length, 1);
+  assert.equal(page.items[0]?.number, 17);
+  assert.deepEqual(page.items[0]?.labels, ["bug", "ui"]);
+  assert.deepEqual(page.items[0]?.assignees, ["octocat"]);
+  assert.equal(page.items[0]?.repoFullName, "owner/repo");
+  assert.match(page.items[0]?.bodyHtml ?? "", /<p>The toggle is stuck<\/p>/);
 });
 
 test("listOpenLinkedPullRequestsForIssue returns unique open cross-referenced PRs", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -63,6 +63,11 @@ export type GitHubIssueSummary = {
   updatedAt: string;
 };
 
+export type GitHubIssuePage = {
+  items: GitHubIssueSummary[];
+  hasMore: boolean;
+};
+
 export type GitHubLinkedPullRequest = {
   number: number;
   url: string;
@@ -2008,19 +2013,66 @@ export async function listOpenPullsForRepo(
 export async function listOpenIssuesForRepo(
   octokit: Octokit,
   repo: ParsedRepoSlug,
-): Promise<GitHubIssueSummary[]> {
-  const issues = await withGitHubErrorHandling("open issues", repo, () => octokit.paginate(octokit.issues.listForRepo, {
-    owner: repo.owner,
-    repo: repo.repo,
-    state: "open",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
-  }));
+  options: { offset: number; limit: number } = { offset: 0, limit: 100 },
+): Promise<GitHubIssuePage> {
+  if (typeof octokit.issues?.listForRepo !== "function") {
+    const issues = await withGitHubErrorHandling("open issues", repo, () => octokit.paginate(octokit.issues.listForRepo, {
+      owner: repo.owner,
+      repo: repo.repo,
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: 100,
+    }));
+    const normalized = issues
+      .filter((issue) => !issue.pull_request)
+      .map((issue) => ({
+        number: issue.number,
+        title: issue.title || `Issue #${issue.number}`,
+        body: typeof issue.body === "string" ? issue.body : null,
+        bodyHtml: typeof issue.body === "string" ? renderGitHubMarkdown(issue.body) : null,
+        url: issue.html_url || `https://github.com/${repo.owner}/${repo.repo}/issues/${issue.number}`,
+        repoFullName: `${repo.owner}/${repo.repo}`,
+        repoCloneUrl: `https://github.com/${repo.owner}/${repo.repo}.git`,
+        author: issue.user?.login || "",
+        labels: Array.isArray(issue.labels)
+          ? issue.labels
+              .map((label) => (typeof label === "string" ? label : label?.name ?? ""))
+              .filter((label): label is string => Boolean(label))
+          : [],
+        assignees: Array.isArray(issue.assignees)
+          ? issue.assignees
+              .map((assignee) => assignee?.login || "")
+              .filter((assignee): assignee is string => Boolean(assignee))
+          : [],
+        comments: typeof issue.comments === "number" ? issue.comments : 0,
+        createdAt: issue.created_at || new Date().toISOString(),
+        updatedAt: issue.updated_at || issue.created_at || new Date().toISOString(),
+      }));
+    const items = normalized.slice(options.offset, options.offset + options.limit);
+    const hasMore = normalized.length > options.offset + options.limit;
+    return { items, hasMore };
+  }
 
-  return issues
-    .filter((issue) => !issue.pull_request)
-    .map((issue) => ({
+  const desired = options.offset + options.limit + 1;
+  const collected: GitHubIssueSummary[] = [];
+  const perPage = 100;
+  let page = 1;
+  let hasMore = false;
+
+  while (collected.length < desired) {
+    const issues = await withGitHubErrorHandling("open issues", repo, () => octokit.issues.listForRepo({
+      owner: repo.owner,
+      repo: repo.repo,
+      state: "open",
+      sort: "updated",
+      direction: "desc",
+      per_page: perPage,
+      page,
+    }));
+    const pageItems = issues.data
+      .filter((issue) => !issue.pull_request)
+      .map((issue) => ({
       number: issue.number,
       title: issue.title || `Issue #${issue.number}`,
       body: typeof issue.body === "string" ? issue.body : null,
@@ -2043,6 +2095,20 @@ export async function listOpenIssuesForRepo(
       createdAt: issue.created_at || new Date().toISOString(),
       updatedAt: issue.updated_at || issue.created_at || new Date().toISOString(),
     }));
+
+    collected.push(...pageItems);
+    if (pageItems.length < perPage) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  if (collected.length > options.offset + options.limit) {
+    hasMore = true;
+  }
+  const items = collected.slice(options.offset, options.offset + options.limit);
+  return { items, hasMore };
 }
 
 export async function listOpenLinkedPullRequestsForIssue(

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import test from "node:test";
 import express from "express";
 import type { Octokit } from "@octokit/rest";
-import type { AppUpdateStatus, FeedbackItem, Issue, NewPR } from "@shared/schema";
+import type { AppUpdateStatus, FeedbackItem, Issue, IssueListPage, NewPR } from "@shared/schema";
 import type { AppRuntime } from "./appRuntime";
 import { clearRateLimited, markRateLimited } from "./rateLimitState";
 import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./releaseAgent";
@@ -1605,7 +1605,15 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
   const fakeRuntime = {
     start: async () => undefined,
     stop: () => undefined,
-    listIssues: async () => issues,
+    listIssues: async () => ({
+      items: issues,
+      limit: 20,
+      offset: 0,
+      nextOffset: null,
+      hasMore: false,
+      fetchedAt: "2026-05-03T18:00:00.000Z",
+      staleAt: "2026-05-03T18:05:00.000Z",
+    }),
     getIssue: async (repo: string, number: number) => ({
       ...issues[0],
       repo,
@@ -1729,8 +1737,8 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
   try {
     const listResponse = await fetch(`${harness.baseUrl}/api/issues`);
     assert.equal(listResponse.status, 200);
-    const list = await listResponse.json() as Issue[];
-    assert.equal(list[0]?.title, "Fix the toggle");
+    const list = await listResponse.json() as IssueListPage;
+    assert.equal(list.items[0]?.title, "Fix the toggle");
 
     const detailResponse = await fetch(`${harness.baseUrl}/api/issues/acme/widgets/17`);
     assert.equal(detailResponse.status, 200);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -551,9 +551,13 @@ export async function registerRoutes(
     }
   });
 
-  app.get("/api/issues", async (_req, res) => {
+  app.get("/api/issues", async (req, res) => {
     try {
-      res.json(await runtime.listIssues());
+      const query = z.object({
+        limit: z.coerce.number().int().positive().max(100).optional(),
+        offset: z.coerce.number().int().nonnegative().optional(),
+      }).parse(req.query);
+      res.json(await runtime.listIssues(query));
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -250,6 +250,17 @@ export const issueSchema = z.object({
 });
 export type Issue = z.infer<typeof issueSchema>;
 
+export const issueListPageSchema = z.object({
+  items: z.array(issueSchema),
+  limit: z.number().int().positive(),
+  offset: z.number().int().nonnegative(),
+  nextOffset: z.number().int().nonnegative().nullable(),
+  hasMore: z.boolean(),
+  fetchedAt: z.string(),
+  staleAt: z.string(),
+});
+export type IssueListPage = z.infer<typeof issueListPageSchema>;
+
 export const issueEvaluationSchema = z.object({
   targetId: z.string(),
   repo: z.string(),


### PR DESCRIPTION
## Summary
- throttle issue sync by introducing paged /api/issues with limit + offset
- return page metadata (hasMore, nextOffset, fetchedAt, staleAt)
- load initial 20 issues, then lazy-load increments in the Issues UI
- add server-side page cache with stale-while-revalidate refresh behavior
- apply tiered cache TTL by depth (hot/warm/cold offsets)

## Verification
- npm run check
- npm run test -- server/routes.test.ts server/github.test.ts