### PR TITLE
feat: improve sync scheduling and cache architecture

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -13,6 +13,8 @@ type AppHeaderSection = "prs" | "issues" | "releases" | "logs" | "settings";
 type GitHubRateLimitState = {
   limited: boolean;
   resetAt: string | null;
+  recentlyLimited: boolean;
+  lastLimitedAt: string | null;
 };
 
 const PRIMARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [
@@ -286,6 +288,7 @@ function GitHubRateLimitNotice() {
     refetchInterval: 30000,
   });
   const explicitlyLimited = githubRateLimit?.limited === true;
+  const recentlyLimited = githubRateLimit?.recentlyLimited === true;
   const { data: activities } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
     refetchInterval: 30000,
@@ -298,7 +301,7 @@ function GitHubRateLimitNotice() {
       .find((message) => message.toLowerCase().includes("rate limit")) ?? null
     : null;
 
-  if (!explicitlyLimited && !activityRateLimitMessage) {
+  if (!explicitlyLimited && !recentlyLimited && !activityRateLimitMessage) {
     return null;
   }
 
@@ -310,6 +313,8 @@ function GitHubRateLimitNotice() {
     ? resetTime
       ? `GitHub rate limited until ${resetTime}`
       : "GitHub rate limited"
+    : recentlyLimited
+      ? "GitHub rate limit hit recently"
     : "GitHub rate limit hit in recent activity";
 
   const tooltip = explicitlyLimited

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -42,6 +42,8 @@ type OnboardingStatus = {
 type GitHubRateLimitState = {
   limited: boolean;
   resetAt: string | null;
+  recentlyLimited: boolean;
+  lastLimitedAt: string | null;
 };
 
 type CodeReviewPresence = {
@@ -272,7 +274,7 @@ export function OnboardingPanel() {
   if (isLoading || !status) return null;
 
   const effectiveGithubError = status.githubError
-    ?? (githubRateLimit?.limited ? "rate limit gate active" : undefined);
+    ?? ((githubRateLimit?.limited || githubRateLimit?.recentlyLimited) ? "rate limit gate active" : undefined);
   const transientGithubWarning = isTransientGitHubWarning(effectiveGithubError);
   const hasCurrentReviewer = status.repos.some((repo) => hasDetectedCodeReviewWorkflow(repo.codeReviews));
   const shouldUseCachedRepoStatus = transientGithubWarning && status.repos.length === 0 && lastHasTrackedRepo;

--- a/client/src/lib/activityQueue.ts
+++ b/client/src/lib/activityQueue.ts
@@ -12,6 +12,7 @@ const DEFAULT_JOB_DURATION_MS: Record<BackgroundJobKind, number> = {
   process_release_run: 2 * 60_000,
   answer_pr_question: 90_000,
   evaluate_issue: 90_000,
+  verify_issue: 90_000,
   work_issue: 4 * 60_000,
   generate_social_changelog: 3 * 60_000,
   heal_deployment: 4 * 60_000,

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, RefreshCw, Trash2 } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
-import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, LogEntry, OperatorWarning, PR, PRQuestion, RuntimeState, WatchedRepo } from "@shared/schema";
+import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, RuntimeState, WatchedRepo } from "@shared/schema";
 import { AppHeader } from "@/components/AppHeader";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -24,6 +24,7 @@ import {
 } from "@/lib/ciHealing";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import { Skeleton } from "@/components/ui/skeleton";
 
 function formatClock(timestamp: string | null): string | null {
   if (!timestamp) {
@@ -33,7 +34,7 @@ function formatClock(timestamp: string | null): string | null {
   return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
 }
 
-function isPRWatchEnabled(pr: PR): boolean {
+function isPRWatchEnabled(pr: Pick<PRSummary, "watchEnabled">): boolean {
   return pr.watchEnabled;
 }
 
@@ -113,7 +114,11 @@ function scrollToDashboardErrors() {
   document.getElementById("dashboard-errors")?.scrollIntoView({ block: "start" });
 }
 
-function getPRFeedbackFailureReason(pr: PR): string | null {
+function getPRFeedbackFailureReason(pr: PR | PRSummary | null): string | null {
+  if (!pr || !("feedbackItems" in pr)) {
+    return null;
+  }
+
   const failedItem = pr.feedbackItems.find((item) =>
     (item.status === "failed" || item.status === "warning") && Boolean(item.statusReason),
   );
@@ -421,17 +426,12 @@ function ReadyToMergeIndicator({
   );
 }
 
-function AgentIndicator({ pr }: { pr: PR }) {
-  const agentCount = countActiveFeedbackStatuses(pr.feedbackItems).inProgress;
+function AgentIndicator({ pr }: { pr: PRSummary }) {
   const isProcessing = pr.status === "processing";
 
-  if (!isProcessing && agentCount === 0) {
+  if (!isProcessing) {
     return null;
   }
-
-  const label = agentCount > 0
-    ? `${agentCount} agent${agentCount !== 1 ? "s" : ""} running on this PR`
-    : "Agent run active on this PR";
 
   return (
     <Tooltip>
@@ -441,15 +441,33 @@ function AgentIndicator({ pr }: { pr: PR }) {
           data-testid={`agent-indicator-${pr.id}`}
         >
           <Bot className="h-3.5 w-3.5 animate-pulse" aria-hidden="true" />
-          {agentCount > 0 && (
-            <span className="font-mono text-[10px] text-muted-foreground">{agentCount}</span>
-          )}
         </span>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <p className="text-xs">{label}</p>
+        <p className="text-xs">Agent run active on this PR</p>
       </TooltipContent>
     </Tooltip>
+  );
+}
+
+function PRRowSkeleton() {
+  return (
+    <div className="border-b border-l-2 border-l-transparent border-border px-4 py-3">
+      <div className="flex items-start gap-3">
+        <Skeleton className="mt-1.5 h-2 w-2 rounded-full" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-3 w-10" />
+            <Skeleton className="h-3.5 w-2/3" />
+          </div>
+          <div className="mt-2 ml-[3.75rem] flex items-center gap-3">
+            <Skeleton className="h-2.5 w-24" />
+            <Skeleton className="h-2.5 w-16" />
+            <Skeleton className="h-2.5 w-14" />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -461,7 +479,7 @@ const PRRow = memo(function PRRow({
   queueStatus,
   issueLink,
 }: {
-  pr: PR;
+  pr: PRSummary;
   isSelected: boolean;
   onSelect: (id: string) => void;
   failureMessage?: string | null;
@@ -470,9 +488,6 @@ const PRRow = memo(function PRRow({
 }) {
   const checkedAt = formatClock(pr.lastChecked);
   const watchEnabled = isPRWatchEnabled(pr);
-  const agentActive = pr.status === "processing" || countActiveFeedbackStatuses(pr.feedbackItems).inProgress > 0;
-  const readyToMerge = !agentActive && isPRReadyToMerge(pr.feedbackItems);
-
   return (
     <div
       onClick={() => onSelect(pr.id)}
@@ -510,16 +525,6 @@ const PRRow = memo(function PRRow({
               </span>
             )}
           </div>
-          {readyToMerge && (
-            <ReadyToMergeIndicator
-              href={pr.url}
-              testId={`ready-to-merge-${pr.id}`}
-              label="Ready to merge"
-              onClick={(event) => event.stopPropagation()}
-              className="mt-1.5 ml-[3.75rem] gap-1.5 whitespace-nowrap px-2 py-0.5 text-[10px] tracking-wider"
-              dotClassName="h-1.5 w-1.5"
-            />
-          )}
           {pr.status === "error" && failureMessage && (
             <div className="mt-2 ml-[3.75rem] border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
               <span className="font-medium uppercase tracking-wider">Error:</span>{" "}
@@ -539,16 +544,7 @@ const PRRow = memo(function PRRow({
             <span>{formatStatusLabel(pr.status)}</span>
             <QueueStatusBadge status={queueStatus} />
             {!watchEnabled && <WatchPausedIndicator />}
-            {pr.feedbackItems.length > 0 && (() => {
-              const counts = countActiveFeedbackStatuses(pr.feedbackItems);
-              const parts: string[] = [];
-              if (counts.queued > 0) parts.push(`${counts.queued}q`);
-              if (counts.inProgress > 0) parts.push(`${counts.inProgress} active`);
-              if (counts.failed > 0) parts.push(`${counts.failed} failed`);
-              if (counts.warning > 0) parts.push(`${counts.warning} warn`);
-              if (parts.length === 0) return <span>{pr.feedbackItems.length} items</span>;
-              return <span>{parts.join(" · ")}</span>;
-            })()}
+            <span>{pr.accepted + pr.rejected + pr.flagged} triaged</span>
             {checkedAt && <span>checked {checkedAt}</span>}
           </div>
         </div>
@@ -1125,12 +1121,12 @@ export default function Dashboard() {
     }
   };
 
-  const { data: prs = [], isLoading } = useQuery<PR[]>({
+  const { data: prs = [], isLoading } = useQuery<PRSummary[]>({
     queryKey: ["/api/prs"],
     refetchInterval: 3000,
   });
 
-  const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PR[]>({
+  const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PRSummary[]>({
     queryKey: ["/api/prs/archived"],
     refetchInterval: 10000,
   });
@@ -1141,11 +1137,12 @@ export default function Dashboard() {
   });
   const globalDrainMode = runtimeState?.drainMode === true;
 
-  const { data: issues = [], isLoading: isLoadingIssues } = useQuery<Issue[]>({
+  const { data: issuesPage, isLoading: isLoadingIssues } = useQuery<IssueListPage>({
     queryKey: ["/api/issues"],
     enabled: runtimeState !== undefined && !globalDrainMode,
     refetchInterval: 30000,
   });
+  const issues = issuesPage?.items ?? [];
 
   const { data: config } = useQuery<Config>({
     queryKey: ["/api/config"],
@@ -1179,10 +1176,22 @@ export default function Dashboard() {
     : viewMode === "issues"
       ? issueLinkedPRs
       : prs
-  ).filter((pr) => matchesNumberSearch(pr.number, prNumberSearch));
+  )
+    .filter((pr) => matchesNumberSearch(pr.number, prNumberSearch))
+    .sort((a, b) => b.number - a.number);
   const isArchived = viewMode === "archived";
   const normalizedPrNumberSearch = normalizeNumberSearch(prNumberSearch);
   const isLoadingCurrentView = isArchived ? isLoadingArchived : viewMode === "issues" ? isLoading || isLoadingIssues : isLoading;
+  const selectedPRSummary = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
+  const { data: selectedPRDetail } = useQuery<PR | null>({
+    queryKey: ["/api/prs", selectedPRId],
+    enabled: selectedPRId !== null,
+    queryFn: async () => {
+      if (!selectedPRId) return null;
+      return fetchJson<PR>(`/api/prs/${selectedPRId}`);
+    },
+    refetchInterval: 3000,
+  });
 
   useEffect(() => {
     if (displayedPRs.length === 0) {
@@ -1197,11 +1206,11 @@ export default function Dashboard() {
     }
   }, [displayedPRs, selectedPRId]);
 
-  const selectedPR = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
-  const selectedPRWatchEnabled = selectedPR ? isPRWatchEnabled(selectedPR) : true;
-  const selectedFailedActivity = selectedPR ? latestActivityForTarget(activities.failed, selectedPR.id) : undefined;
-  const selectedPRQueueStatus = selectedPR ? queueStatusById.get(selectedPR.id) ?? null : null;
-  const selectedPRErrorMessage = selectedPR?.status === "error"
+  const selectedPR = selectedPRDetail ?? null;
+  const selectedPRWatchEnabled = selectedPRSummary ? isPRWatchEnabled(selectedPRSummary) : true;
+  const selectedFailedActivity = selectedPRSummary ? latestActivityForTarget(activities.failed, selectedPRSummary.id) : undefined;
+  const selectedPRQueueStatus = selectedPRSummary ? queueStatusById.get(selectedPRSummary.id) ?? null : null;
+  const selectedPRErrorMessage = selectedPRSummary?.status === "error"
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
   const activeErrorCount = activities.failed.length + activities.warnings.length;
@@ -1433,7 +1442,11 @@ export default function Dashboard() {
           </div>
           <div className="flex-1">
             {isLoadingCurrentView ? (
-              <div className="p-4 text-[12px] text-muted-foreground">Loading...</div>
+              <div data-testid="pr-list-loading" aria-label="Loading pull requests">
+                {Array.from({ length: 6 }).map((_, idx) => (
+                  <PRRowSkeleton key={idx} />
+                ))}
+              </div>
             ) : displayedPRs.length === 0 ? (
               <div className="p-4 text-[12px] text-muted-foreground">
                 {normalizedPrNumberSearch

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -764,7 +764,7 @@ function IssuesPage() {
     },
     [filteredIssues, issueNumberSearch, issues, selectedIssueId, selectedRepo, selectedWorkFilter],
   );
-  const { data: selectedIssueDetail, refetch: refetchSelectedIssueDetail } = useQuery<Issue>({
+  const { data: selectedIssueDetail } = useQuery<Issue>({
     queryKey: ["/api/issues/detail", selectedIssueFromList?.repo ?? "", selectedIssueFromList?.number ?? 0],
     queryFn: async () => {
       if (!selectedIssueFromList) {

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -1,19 +1,20 @@
-import { useEffect, useMemo, useState } from "react";
+import { Component, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLink, Loader2, Plus, RefreshCw, ShieldCheck, Trash2, Wrench, X } from "lucide-react";
+import { CheckCircle2, CircleDashed, CircleSlash, ExternalLink, Loader2, Plus, RefreshCw, ShieldCheck, Trash2, Wrench, X } from "lucide-react";
 import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
-import type { ActivitySnapshot, Config, Issue, IssueListPage, LogEntry, RuntimeState } from "@shared/schema";
+import { issueListPageSchema, issueSchema, type ActivitySnapshot, type Config, type Issue, type IssueListPage, type IssueSubtask, type LogEntry, type RuntimeState } from "@shared/schema";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 
-const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v1";
+const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v2";
 const ISSUES_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
-const ISSUES_PAGE_SIZE = 20;
+const ISSUES_PAGE_SIZE = 100;
 
 function readCachedIssues(): { data: IssueListPage; updatedAt: number } | null {
   if (typeof window === "undefined") return null;
@@ -27,7 +28,15 @@ function readCachedIssues(): { data: IssueListPage; updatedAt: number } | null {
     if (Date.now() - parsed.updatedAt > ISSUES_CACHE_MAX_AGE_MS) {
       return null;
     }
-    return { data: parsed.data as IssueListPage, updatedAt: parsed.updatedAt };
+    const normalized = issueListPageSchema.safeParse(parsed.data);
+    if (!normalized.success) {
+      window.localStorage.removeItem(ISSUES_CACHE_KEY);
+      return null;
+    }
+    if (normalized.data.limit !== ISSUES_PAGE_SIZE) {
+      return null;
+    }
+    return { data: normalized.data, updatedAt: parsed.updatedAt };
   } catch {
     return null;
   }
@@ -43,6 +52,22 @@ function writeCachedIssues(data: IssueListPage): void {
   } catch {
     // Best-effort cache only.
   }
+}
+
+function parseIssueListPageOrThrow(value: unknown): IssueListPage {
+  const parsed = issueListPageSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error("Invalid issue list response");
+  }
+  return parsed.data;
+}
+
+function parseIssueOrNull(value: unknown): Issue | null {
+  const parsed = issueSchema.safeParse(value);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data;
 }
 
 function formatDateTime(value: string | null | undefined): string {
@@ -269,11 +294,13 @@ function IssueRow({
   selected,
   onSelect,
   queueStatus,
+  verifyState,
 }: {
   issue: Issue;
   selected: boolean;
   onSelect: (issueId: string) => void;
   queueStatus: QueueStatusView | null;
+  verifyState: VerifyState | null;
 }) {
   const showInlineStatusBadge = issue.workStatus !== "queued" && issue.workStatus !== "in_progress";
   const rowAction =
@@ -350,6 +377,16 @@ function IssueRow({
               {formatEvaluationState(issue)}
             </span>
             <QueueStatusBadge status={queueStatus} />
+            {verifyState && <VerifyStateBadge state={verifyState} />}
+            {issue.subtasks && issue.subtasks.length >= 2 && (
+              <span
+                data-testid="issue-multi-bug-badge"
+                title={issue.subtasks.map((task) => `• ${task.title}`).join("\n")}
+                className="border border-primary/60 bg-primary/10 px-1.5 py-0 text-[10px] uppercase tracking-wider text-primary"
+              >
+                {issue.subtasks.length} bugs
+              </span>
+            )}
             {issue.labels.slice(0, 3).map((label) => (
               <span key={label} className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
                 {label}
@@ -367,6 +404,110 @@ function IssueRow({
         </span>
       </button>
       {rowAction}
+    </div>
+  );
+}
+
+type VerifyState = "verifying" | "verified";
+
+function VerifyStateBadge({ state }: { state: VerifyState }) {
+  const isPending = state === "verifying";
+  return (
+    <span
+      data-testid="issue-verify-state-badge"
+      data-verify-state={state}
+      className={`inline-flex items-center gap-1 border px-1.5 py-0 text-[10px] uppercase tracking-wider ${
+        isPending
+          ? "border-primary/60 bg-primary/10 text-primary animate-pulse"
+          : "border-success-border bg-success-muted text-success-foreground"
+      }`}
+    >
+      {isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle2 className="h-3 w-3" />}
+      {isPending ? "re-verifying" : "re-verified"}
+    </span>
+  );
+}
+
+function IssueRowSkeleton() {
+  return (
+    <div className="border-b border-l-2 border-l-transparent border-border px-4 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-3 w-32" />
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-5/6" />
+          <div className="flex gap-1.5 pt-1">
+            <Skeleton className="h-3 w-14" />
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-3 w-10" />
+          </div>
+        </div>
+        <Skeleton className="h-3 w-20 shrink-0" />
+      </div>
+    </div>
+  );
+}
+
+function SubtaskStatusIcon({ status }: { status: IssueSubtask["status"] }) {
+  if (status === "done") {
+    return <CheckCircle2 className="h-3.5 w-3.5 text-success-foreground" aria-label="done" />;
+  }
+  if (status === "deferred" || status === "skipped") {
+    return <CircleSlash className="h-3.5 w-3.5 text-muted-foreground" aria-label={status} />;
+  }
+  return <CircleDashed className="h-3.5 w-3.5 text-warning-foreground" aria-label="pending" />;
+}
+
+function SubtaskListPanel({ subtasks }: { subtasks: IssueSubtask[] }) {
+  const doneCount = subtasks.reduce((sum, task) => sum + (task.status === "done" ? 1 : 0), 0);
+
+  return (
+    <div
+      data-testid="issue-subtasks"
+      className="mt-3 border border-border/60 bg-muted/10"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          Subtasks
+        </div>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {doneCount} / {subtasks.length} done
+        </span>
+      </div>
+      <ul className="divide-y divide-border/60">
+        {subtasks.map((task) => (
+          <li
+            key={task.id}
+            data-testid="issue-subtask-row"
+            data-subtask-status={task.status}
+            className="flex items-start gap-2 px-3 py-2"
+          >
+            <span className="mt-0.5 shrink-0">
+              <SubtaskStatusIcon status={task.status} />
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="truncate text-[12px] font-medium text-foreground">{task.title}</span>
+                <span className="border border-border/60 px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  {task.status}
+                </span>
+              </div>
+              {task.summary && (
+                <div className="mt-0.5 text-[11px] leading-5 text-muted-foreground">
+                  {task.summary}
+                </div>
+              )}
+              {task.statusReason && (
+                <div className="mt-1 text-[11px] italic leading-5 text-foreground/70">
+                  {task.statusReason}
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
@@ -416,7 +557,41 @@ function IssueLogRow({ entry }: { entry: LogEntry }) {
   );
 }
 
-export default function Issues() {
+type IssuesErrorBoundaryState = {
+  hasError: boolean;
+  message: string;
+};
+
+class IssuesErrorBoundary extends Component<{ children: ReactNode }, IssuesErrorBoundaryState> {
+  state: IssuesErrorBoundaryState = {
+    hasError: false,
+    message: "",
+  };
+
+  static getDerivedStateFromError(error: unknown): IssuesErrorBoundaryState {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background p-6">
+          <div className="max-w-2xl border border-destructive/40 bg-destructive/10 p-4 text-[12px] text-destructive">
+            <div className="text-[11px] uppercase tracking-wider text-destructive/80">Issues UI runtime error</div>
+            <pre className="mt-2 whitespace-pre-wrap break-words">{this.state.message || "Unknown render error"}</pre>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+function IssuesPage() {
   const { data: runtime } = useQuery<RuntimeState>({
     queryKey: ["/api/runtime"],
   });
@@ -447,7 +622,7 @@ export default function Issues() {
 
   const issuesQuery = useQuery<IssueListPage>({
     queryKey: ["/api/issues", ISSUES_PAGE_SIZE, 0],
-    queryFn: async () => fetchJson<IssueListPage>(issueListUrl(ISSUES_PAGE_SIZE, 0)),
+    queryFn: async () => parseIssueListPageOrThrow(await fetchJson<unknown>(issueListUrl(ISSUES_PAGE_SIZE, 0))),
     enabled: runtime !== undefined && !globalDrainMode,
     initialData: cachedIssues?.data,
     initialDataUpdatedAt: cachedIssues?.updatedAt,
@@ -463,9 +638,10 @@ export default function Issues() {
         : false;
     },
   });
-  const { data: issuesPage, isLoading, refetch, isFetching } = issuesQuery;
+  const { data: issuesPage, isLoading, isFetching } = issuesQuery;
   const [extraPages, setExtraPages] = useState<IssueListPage[]>([]);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isSyncingRepos, setIsSyncingRepos] = useState(false);
   useEffect(() => {
     if (issuesQuery.status === "success") {
       writeCachedIssues(issuesQuery.data);
@@ -479,17 +655,19 @@ export default function Issues() {
     const all = [issuesPage, ...extraPages].flatMap((page) => page?.items ?? []);
     const deduped = new Map<string, Issue>();
     for (const issue of all) deduped.set(issue.id, issue);
-    return Array.from(deduped.values()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return Array.from(deduped.values()).sort((a, b) => b.number - a.number);
   }, [issuesPage, extraPages]);
   const latestPage = extraPages[extraPages.length - 1] ?? issuesPage ?? null;
   const canLoadMore = Boolean(latestPage?.hasMore);
   const nextOffset = latestPage?.nextOffset ?? null;
+  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+  const issueListScrollRef = useRef<HTMLDivElement | null>(null);
 
   const loadMoreIssues = async (): Promise<void> => {
     if (!canLoadMore || nextOffset === null || globalDrainMode || isLoadingMore) return;
     setIsLoadingMore(true);
     try {
-      const nextPage = await fetchJson<IssueListPage>(issueListUrl(ISSUES_PAGE_SIZE, nextOffset));
+      const nextPage = parseIssueListPageOrThrow(await fetchJson<unknown>(issueListUrl(ISSUES_PAGE_SIZE, nextOffset)));
       setExtraPages((current) => [...current, nextPage]);
     } catch (error) {
       toast({
@@ -500,6 +678,41 @@ export default function Issues() {
       setIsLoadingMore(false);
     }
   };
+
+  const handleSyncIssues = async (): Promise<void> => {
+    setIsSyncingRepos(true);
+    try {
+      await apiRequest("POST", "/api/repos/sync");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues/detail"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/runtime"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] }),
+      ]);
+      setExtraPages([]);
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        description: `Could not sync repositories: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    } finally {
+      setIsSyncingRepos(false);
+    }
+  };
+
+  useEffect(() => {
+    const sentinel = loadMoreSentinelRef.current;
+    const scrollRoot = issueListScrollRef.current;
+    if (!sentinel || !scrollRoot || !canLoadMore || globalDrainMode) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        void loadMoreIssues();
+      }
+    }, { root: scrollRoot, rootMargin: "200px 0px" });
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [canLoadMore, globalDrainMode, isLoadingMore, nextOffset]);
 
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<string>("all");
@@ -558,7 +771,11 @@ export default function Issues() {
         throw new Error("No issue selected");
       }
 
-      return fetchJson<Issue>(issueDetailUrl(selectedIssueFromList));
+      const parsed = parseIssueOrNull(await fetchJson<unknown>(issueDetailUrl(selectedIssueFromList)));
+      if (!parsed) {
+        throw new Error("Invalid issue detail response");
+      }
+      return parsed;
     },
     enabled: Boolean(selectedIssueFromList) && !globalDrainMode,
     refetchInterval: selectedIssueFromList && isActiveWorkStatus(selectedIssueFromList.workStatus) && !globalDrainMode ? 5000 : false,
@@ -579,13 +796,11 @@ export default function Issues() {
       issues: repoIssues,
     }));
   }, [filteredIssues]);
-  const repoCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const issue of issues) {
-      counts.set(issue.repo, (counts.get(issue.repo) ?? 0) + 1);
-    }
-    return Array.from(counts.entries()).sort(([left], [right]) => left.localeCompare(right));
-  }, [issues]);
+  const repoCounts = useMemo(
+    () => Object.entries(issuesPage?.repoTotals ?? {}).sort(([left], [right]) => left.localeCompare(right)),
+    [issuesPage?.repoTotals],
+  );
+  const totalIssueCount = issuesPage?.totalCount ?? issues.length;
 
   const { data: issueLogs = [] } = useQuery<LogEntry[]>({
     queryKey: ["/api/logs", selectedIssueKey ?? "issue"],
@@ -664,6 +879,70 @@ export default function Issues() {
       toast({ variant: "destructive", description: `Could not queue issue evaluation: ${error.message}` });
     },
   });
+  const verifyingIssueIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const activity of activities.queued) {
+      if (activity.kind === "verify_issue") ids.add(activity.targetId);
+    }
+    for (const activity of activities.inProgress) {
+      if (activity.kind === "verify_issue") ids.add(activity.targetId);
+    }
+    return ids;
+  }, [activities.queued, activities.inProgress]);
+
+  const previousVerifyingRef = useRef<Set<string>>(new Set());
+  const [recentlyVerifiedIds, setRecentlyVerifiedIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    const prior = previousVerifyingRef.current;
+    const justFinished: string[] = [];
+    prior.forEach((id) => {
+      if (!verifyingIssueIds.has(id)) justFinished.push(id);
+    });
+    previousVerifyingRef.current = verifyingIssueIds;
+
+    if (justFinished.length === 0) return;
+
+    setRecentlyVerifiedIds((prev) => {
+      const next = new Set(prev);
+      justFinished.forEach((id) => next.add(id));
+      return next;
+    });
+    const timers = justFinished.map((id) =>
+      window.setTimeout(() => {
+        setRecentlyVerifiedIds((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }, 8000),
+    );
+    return () => { timers.forEach((t) => window.clearTimeout(t)); };
+  }, [verifyingIssueIds]);
+
+  const verifyMutation = useMutation({
+    mutationFn: async (issue: Issue) => {
+      const res = await apiRequest("POST", "/api/issues/verify", {
+        repo: issue.repo,
+        number: issue.number,
+      });
+      return res.json() as Promise<Issue>;
+    },
+    onSuccess: async (issue) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] }),
+      ]);
+      toast({ description: `Queued verification for #${issue.number}.` });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Could not queue verification: ${error.message}` });
+    },
+  });
+
   const syncIssueMutation = useMutation({
     mutationFn: async (issue: Issue) => {
       const res = await apiRequest("POST", "/api/issues/sync", {
@@ -751,17 +1030,12 @@ export default function Issues() {
           <>
             <button
               type="button"
-              onClick={() => {
-                void Promise.all([
-                  refetch().then(() => setExtraPages([])),
-                  selectedIssueFromList ? refetchSelectedIssueDetail() : Promise.resolve(),
-                ]);
-              }}
-              disabled={isFetching || globalDrainMode}
+              onClick={() => { void handleSyncIssues(); }}
+              disabled={isSyncingRepos || globalDrainMode}
               data-testid="button-sync-issues"
               className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
             >
-              {globalDrainMode ? <span className="h-3.5 w-3.5" /> : isFetching ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              {globalDrainMode ? <span className="h-3.5 w-3.5" /> : (isSyncingRepos || isFetching) ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
               {globalDrainMode ? "paused" : "sync"}
             </button>
             <ActivityMenu
@@ -810,7 +1084,7 @@ export default function Issues() {
                       : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
                   }`}
                 >
-                  all ({issues.length})
+                  all ({totalIssueCount})
                 </button>
                 {repoCounts.map(([repo, count]) => (
                   <button
@@ -918,10 +1192,14 @@ export default function Issues() {
               </div>
             </div>
           </div>
-          <div className="flex-1 overflow-y-auto">
+          <div ref={issueListScrollRef} className="flex-1 overflow-y-auto">
             <div data-testid="issue-list">
               {isLoading ? (
-                <div className="p-4 text-[12px] text-muted-foreground">Loading...</div>
+                <div data-testid="issue-list-loading" aria-label="Loading issues">
+                  {Array.from({ length: 6 }).map((_, idx) => (
+                    <IssueRowSkeleton key={idx} />
+                  ))}
+                </div>
               ) : visibleIssues.length === 0 ? (
                 <div className="p-4 text-[12px] text-muted-foreground">
                   {normalizedIssueNumberSearch
@@ -942,23 +1220,18 @@ export default function Issues() {
                           selected={issue.id === selectedIssueId}
                           onSelect={setSelectedIssueId}
                           queueStatus={queueStatusById.get(issue.id) ?? null}
+                          verifyState={
+                            verifyingIssueIds.has(issue.id)
+                              ? "verifying"
+                              : recentlyVerifiedIds.has(issue.id)
+                                ? "verified"
+                                : null
+                          }
                         />
                       ))}
                     </div>
                   ))}
-                  {canLoadMore && (
-                    <div className="border-t border-border/60 px-4 py-2">
-                      <button
-                        type="button"
-                        onClick={() => void loadMoreIssues()}
-                        disabled={isLoadingMore || globalDrainMode}
-                        className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:opacity-50"
-                      >
-                        {isLoadingMore ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
-                        load more
-                      </button>
-                    </div>
-                  )}
+                  {canLoadMore && <div ref={loadMoreSentinelRef} className="h-8 w-full" data-testid="issues-load-more-sentinel" />}
                 </>
               )}
             </div>
@@ -1083,6 +1356,41 @@ export default function Issues() {
                         </>
                       )}
                     </button>
+                    {(() => {
+                      const isVerifying = verifyingIssueIds.has(selectedIssue.id) || verifyMutation.isPending;
+                      return (
+                    <button
+                      type="button"
+                      onClick={() => verifyMutation.mutate(selectedIssue)}
+                      disabled={
+                        isVerifying
+                        || Boolean(runtime?.drainMode)
+                        || !selectedIssue.workPrUrl
+                      }
+                      title={
+                        runtime?.drainMode
+                          ? "Verification is paused by drain mode"
+                          : !selectedIssue.workPrUrl
+                            ? "Verification requires an open work PR"
+                            : "Check the work PR diff against this issue's subtasks"
+                      }
+                      data-testid="button-verify-issue"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {isVerifying ? (
+                        <>
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          Verifying
+                        </>
+                      ) : (
+                        <>
+                          <CheckCircle2 className="h-3.5 w-3.5" />
+                          Verify work
+                        </>
+                      )}
+                    </button>
+                      );
+                    })()}
                     <button
                       type="button"
                       onClick={() => workMutation.mutate(selectedIssue)}
@@ -1240,6 +1548,9 @@ export default function Issues() {
                     </div>
                   </div>
                 )}
+                {selectedIssue.subtasks && selectedIssue.subtasks.length > 0 && (
+                  <SubtaskListPanel subtasks={selectedIssue.subtasks} />
+                )}
                 <div
                   data-testid="issue-evaluation-detail"
                   className="mt-3 border border-border/60 bg-muted/10 px-3 py-2"
@@ -1323,5 +1634,13 @@ export default function Issues() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function Issues() {
+  return (
+    <IssuesErrorBoundary>
+      <IssuesPage />
+    </IssuesErrorBoundary>
   );
 }

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -67,6 +67,8 @@ const DRAIN_PAUSED_TITLE = "Paused by drain mode";
 type GitHubRateLimitState = {
   limited: boolean;
   resetAt: string | null;
+  recentlyLimited: boolean;
+  lastLimitedAt: string | null;
 };
 
 type GitHubTokenTestResult = {
@@ -1572,12 +1574,14 @@ export default function Settings() {
               <SettingsGroup id="system" title="System" description="Runtime and process-level controls.">
                 <SettingsSubsection id="system-runtime" title="Runtime">
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
-              {githubRateLimit?.limited && githubRateLimit.resetAt ? (
+              {(githubRateLimit?.limited || githubRateLimit?.recentlyLimited) ? (
                 <div
                   className="border-l-2 border-warning bg-warning-muted/40 px-3 py-2 text-[11px] text-warning-foreground"
                   data-testid="runtime-github-rate-limit"
                 >
-                  GitHub rate limit active until {new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}
+                  {githubRateLimit?.limited && githubRateLimit.resetAt
+                    ? `GitHub rate limit active until ${new Date(githubRateLimit.resetAt).toLocaleTimeString("en-US")}`
+                    : "GitHub rate limit was hit recently. Sync may be delayed."}
                 </div>
               ) : null}
               <div className="flex items-start justify-between gap-3">

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -299,6 +299,24 @@ export async function applyFixesWithAgent(params: {
   );
 }
 
+export async function runAgentOneShot(params: {
+  agent: CodingAgent;
+  prompt: string;
+  cwd: string;
+  settings?: AgentRuntimeSettings;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}): Promise<CommandResult> {
+  return applyFixesWithAgent({
+    agent: params.agent,
+    cwd: params.cwd,
+    prompt: params.prompt,
+    settings: params.settings,
+    env: params.env,
+    timeoutMs: params.timeoutMs ?? 30000,
+  });
+}
+
 export function buildAgentCommandArgs(
   agent: CodingAgent,
   args: string[],

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -214,7 +214,7 @@ test("runtime updateConfig persists updates and exposes them through getConfig",
   assert.equal(config.postGitHubProgressReplies, true);
 });
 
-test("watcher tick does not enqueue sync jobs while global manual mode is on", async () => {
+test("manual sync runs immediately even when global manual mode is on", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({
     storage,

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -12,6 +12,7 @@ import type {
   LogEntry,
   OperatorWarning,
   PR,
+  PRSummary,
   PRQuestion,
   ReleaseRun,
   ReleaseSocialPost,
@@ -62,7 +63,6 @@ import {
   listOpenLinkedPullRequestsForIssue,
   listReleasesForRepo,
   listUnreleasedMergedPulls,
-  type GitHubIssueSummary,
   type MergedPRSummary,
   parsePRUrl,
   parseRepoSlug,
@@ -119,7 +119,7 @@ export type AppRuntime = {
   updateRepoSettings(repoInput: string, updates: Partial<Omit<WatchedRepo, "repo">>): Promise<WatchedRepo>;
   syncRepos(): Promise<{ ok: true }>;
   createManualRelease(repoInput: string): Promise<ReleaseRun>;
-  listPRs(view?: "active" | "archived"): Promise<PR[]>;
+  listPRs(view?: "active" | "archived"): Promise<PRSummary[]>;
   getPR(id: string): Promise<PR | null>;
   addPR(url: string): Promise<PR>;
   removePR(id: string): Promise<{ ok: true }>;
@@ -155,6 +155,7 @@ export type AppRuntime = {
   getIssue(repo: string, number: number): Promise<Issue>;
   updateIssueLabels(repo: string, number: number, updates: { add?: string[]; remove?: string[] }): Promise<Issue>;
   evaluateIssue(repo: string, number: number): Promise<Issue>;
+  verifyIssueWork(repo: string, number: number): Promise<Issue>;
   workIssue(repo: string, number: number): Promise<Issue>;
   clearIssueWorkFailures(repo: string, number: number): Promise<{ repo: string; number: number; id: string; cleared: number }>;
   syncIssue(repo: string, number: number): Promise<Issue>;
@@ -184,6 +185,8 @@ function fallbackJobLabel(job: BackgroundJob): string {
       return "Answering PR question";
     case "evaluate_issue":
       return "Evaluating issue";
+    case "verify_issue":
+      return "Verifying issue work";
     case "work_issue":
       return "Working issue";
     case "generate_social_changelog":
@@ -217,11 +220,9 @@ const AUTO_WORK_READY_LABELS = new Set([
   "agent-ready",
   "ready",
 ]);
-const DEFAULT_ISSUES_PAGE_SIZE = 20;
+const DEFAULT_ISSUES_PAGE_SIZE = 100;
 const MAX_ISSUES_PAGE_SIZE = 100;
-const ISSUES_PAGE_CACHE_TTL_HOT_MS = 60 * 1000;
-const ISSUES_PAGE_CACHE_TTL_WARM_MS = 10 * 60 * 1000;
-const ISSUES_PAGE_CACHE_TTL_COLD_MS = 30 * 60 * 1000;
+const MAX_AUTO_ISSUE_SWEEP_PAGES = 50;
 const AUTO_WORK_BLOCKED_LABELS = new Set([
   "blocked",
   "question",
@@ -793,6 +794,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         "runtime:1",
         buildBackgroundJobDedupeKey("sync_watched_repos", "runtime:1"),
       );
+      await syncStoredIssuesStep();
       await queueAutomaticIssueWorkInternal();
     },
     (error) => {
@@ -816,24 +818,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     lastSyncSucceededAt: string | null;
     lastSyncError: string | null;
   }>();
-  const issuePageCache = new Map<string, {
-    items: GitHubIssueSummary[];
-    hasMore: boolean;
-    fetchedAt: string;
-    staleAt: string;
-    expiresAtMs: number;
-  }>();
-  const issuePageRefreshes = new Map<string, Promise<void>>();
-
-  function issuePageCacheKey(repo: string, limit: number, offset: number): string {
-    return `${repo}|${limit}|${offset}`;
-  }
-
-  function issuePageCacheTtlMs(offset: number): number {
-    if (offset <= 0) return ISSUES_PAGE_CACHE_TTL_HOT_MS;
-    if (offset < 100) return ISSUES_PAGE_CACHE_TTL_WARM_MS;
-    return ISSUES_PAGE_CACHE_TTL_COLD_MS;
-  }
+  const issueRepoSyncOffsets = new Map<string, number>();
+  const issueRepoBackoffUntilMs = new Map<string, number>();
+  let issueRepoCursor = 0;
 
   function markIssueSyncAttempt(targetId: string): string {
     const now = new Date().toISOString();
@@ -925,6 +912,77 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     notifyChange();
     return applyIssueWorkState(issue);
+  }
+
+  async function verifyIssueWorkInternal(
+    repoInput: string,
+    number: number,
+  ): Promise<Issue> {
+    const parsedRepo = parseRepoSlug(repoInput);
+    if (!parsedRepo) {
+      throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+    }
+
+    const canonical = formatRepoSlug(parsedRepo);
+    const config = await storage.getConfig();
+    if (!config.watchedRepos.includes(canonical)) {
+      throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
+    }
+
+    const runtimeState = await storage.getRuntimeState();
+    if (runtimeState.drainMode) {
+      await rejectManualRunDuringDrain(runtimeState, {
+        logMessageBase: "Manual issue verification blocked because drain mode is enabled",
+        metadata: { repo: canonical, issueNumber: number },
+      });
+    }
+
+    const octokit = await buildOctokit(config);
+    const issueSummary = await fetchIssueSummary(octokit, { ...parsedRepo, number });
+    const enriched = await applyIssueWorkState(issueSummary);
+    const targetId = formatIssueTargetId(issueSummary.repoFullName, issueSummary.number);
+
+    if (!enriched.workPrUrl || enriched.workPrNumber === undefined || enriched.workPrNumber === null) {
+      throw new AppRuntimeError(400, `Issue ${issueSummary.repoFullName}#${issueSummary.number} has no work PR to verify yet`);
+    }
+
+    const job = await scheduleBackgroundJob(
+      "verify_issue",
+      targetId,
+      buildBackgroundJobDedupeKey("verify_issue", targetId),
+      {
+        repo: issueSummary.repoFullName,
+        issueNumber: issueSummary.number,
+        issueTitle: issueSummary.title,
+        issueUrl: issueSummary.url,
+        workPrNumber: enriched.workPrNumber,
+        workPrUrl: enriched.workPrUrl,
+        ...buildActivityPayload({
+          label: `Verifying issue #${issueSummary.number}`,
+          detail: `${issueSummary.repoFullName} - ${issueSummary.title}`,
+          targetUrl: enriched.workPrUrl,
+        }),
+      },
+    );
+
+    await storage.addLog(
+      targetId,
+      "info",
+      `Queued verification for ${issueSummary.repoFullName}#${issueSummary.number} against PR #${enriched.workPrNumber}`,
+      {
+        metadata: {
+          repo: issueSummary.repoFullName,
+          issueNumber: issueSummary.number,
+          prNumber: enriched.workPrNumber,
+          prUrl: enriched.workPrUrl,
+          jobId: job.id,
+          stage: "queued_verification",
+        },
+      },
+    );
+
+    notifyChange();
+    return enriched;
   }
 
   async function queueIssueWorkInternal(
@@ -1031,6 +1089,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     const workState = issueWorkStatusFromJobs(issueJobs);
     const workLogs = latestJob ? await storage.getLogs(targetId) : [];
     const evaluation = await storage.getIssueEvaluation(targetId);
+    const subtaskSet = await storage.getIssueSubtasks(targetId);
     const readyPr = latestJob?.status === "completed"
       ? issueWorkPrFromLogs(workLogs, issue.repoFullName)
       : null;
@@ -1094,7 +1153,56 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       evaluationSafetyFlags: evaluation?.safetyFlags ?? [],
       evaluationRecommendedLabels: evaluation?.recommendedLabels ?? [],
       evaluationUpdatedAt: evaluation?.updatedAt ?? null,
+      subtasks: subtaskSet?.subtasks ?? null,
     };
+  }
+
+  async function syncStoredIssuesStep(options?: { fullSweep?: boolean }): Promise<void> {
+    const config = await storage.getConfig();
+    if (config.watchedRepos.length === 0) return;
+    const octokit = await buildOctokit(config);
+    const nowMs = Date.now();
+    const repoCount = config.watchedRepos.length;
+    const candidates = options?.fullSweep
+      ? config.watchedRepos
+      : Array.from({ length: repoCount }).map((_, i) => config.watchedRepos[(issueRepoCursor + i) % repoCount]).filter(Boolean) as string[];
+
+    for (const repoSlug of candidates) {
+      try {
+        const backoffUntilMs = issueRepoBackoffUntilMs.get(repoSlug) ?? 0;
+        if (backoffUntilMs > nowMs) continue;
+        const parsed = parseRepoSlug(repoSlug);
+        if (!parsed) continue;
+        const limit = MAX_ISSUES_PAGE_SIZE;
+        const loops = options?.fullSweep ? MAX_AUTO_ISSUE_SWEEP_PAGES : 1;
+        let nextOffset = options?.fullSweep ? 0 : (issueRepoSyncOffsets.get(repoSlug) ?? 0);
+        let didWork = false;
+        for (let i = 0; i < loops; i += 1) {
+          const page = await listOpenIssuesForRepo(octokit, parsed, { limit, offset: nextOffset });
+          const seenAt = new Date().toISOString();
+          if (nextOffset === 0) {
+            await storage.markRepoIssuesStale(repoSlug);
+          }
+          await storage.upsertSyncedIssues(repoSlug, page.items, seenAt);
+          nextOffset = page.hasMore ? nextOffset + limit : 0;
+          issueRepoSyncOffsets.set(repoSlug, nextOffset);
+          didWork = true;
+          if (!page.hasMore || !options?.fullSweep) break;
+        }
+        if (didWork) {
+          issueRepoBackoffUntilMs.delete(repoSlug);
+          const index = config.watchedRepos.indexOf(repoSlug);
+          issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
+          if (!options?.fullSweep) return;
+        }
+      } catch (error) {
+        issueRepoBackoffUntilMs.set(repoSlug, Date.now() + 60_000);
+        log.warn(
+          { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
+          "Issue sync step failed; backing off",
+        );
+      }
+    }
   }
 
   async function listIssuesInternal(input?: { limit?: number; offset?: number }): Promise<IssueListPage> {
@@ -1103,89 +1211,22 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     const config = await storage.getConfig();
     const nowMs = Date.now();
     if (config.watchedRepos.length === 0) {
-      const ttlMs = issuePageCacheTtlMs(offset);
       return {
         items: [],
         limit,
         offset,
         nextOffset: null,
         hasMore: false,
+        totalCount: 0,
+        repoTotals: {},
         fetchedAt: new Date(nowMs).toISOString(),
-        staleAt: new Date(nowMs + ttlMs).toISOString(),
+        staleAt: new Date(nowMs).toISOString(),
       };
     }
 
+    const synced = await storage.listSyncedIssues({ repos: config.watchedRepos, limit, offset });
+    const counts = await storage.listSyncedIssueCounts({ repos: config.watchedRepos });
     const octokit = await buildOctokit(config);
-    const refreshIssuePageCache = async (parsed: ReturnType<typeof parseRepoSlug>, limitValue: number, offsetValue: number): Promise<void> => {
-      if (!parsed) return;
-      const canonicalRepo = formatRepoSlug(parsed);
-      const cacheKey = issuePageCacheKey(canonicalRepo, limitValue, offsetValue);
-      const existing = issuePageRefreshes.get(cacheKey);
-      if (existing) {
-        await existing;
-        return;
-      }
-
-      const refreshPromise = (async () => {
-        const fetched = await listOpenIssuesForRepo(octokit, parsed, { limit: limitValue, offset: offsetValue });
-        const now = Date.now();
-        const ttlMs = issuePageCacheTtlMs(offsetValue);
-        issuePageCache.set(cacheKey, {
-          items: fetched.items,
-          hasMore: fetched.hasMore,
-          fetchedAt: new Date(now).toISOString(),
-          staleAt: new Date(now + ttlMs).toISOString(),
-          expiresAtMs: now + ttlMs,
-        });
-      })();
-
-      issuePageRefreshes.set(cacheKey, refreshPromise);
-      try {
-        await refreshPromise;
-      } finally {
-        issuePageRefreshes.delete(cacheKey);
-      }
-    };
-
-    const perRepoPages = await Promise.all(
-      config.watchedRepos.map(async (repoSlug) => {
-        const ttlMs = issuePageCacheTtlMs(offset);
-        const fetchedAt = new Date(nowMs).toISOString();
-        const staleAt = new Date(nowMs + ttlMs).toISOString();
-        const parsed = parseRepoSlug(repoSlug);
-        if (!parsed) {
-          return { items: [], hasMore: false, fetchedAt, staleAt };
-        }
-        const canonicalRepo = formatRepoSlug(parsed);
-        const cacheKey = issuePageCacheKey(canonicalRepo, limit, offset);
-        const cached = issuePageCache.get(cacheKey);
-        if (cached) {
-          if (cached.expiresAtMs <= nowMs) {
-            void refreshIssuePageCache(parsed, limit, offset).catch((error) => {
-              log.warn(
-                {
-                  err: error instanceof Error ? error.message : String(error),
-                  repo: canonicalRepo,
-                  limit,
-                  offset,
-                },
-                "Issue page cache refresh failed",
-              );
-            });
-          }
-          return { items: cached.items, hasMore: cached.hasMore, fetchedAt: cached.fetchedAt, staleAt: cached.staleAt };
-        }
-
-        await refreshIssuePageCache(parsed, limit, offset);
-        const refreshed = issuePageCache.get(cacheKey);
-        return {
-          items: refreshed?.items ?? [],
-          hasMore: refreshed?.hasMore ?? false,
-          fetchedAt: refreshed?.fetchedAt ?? fetchedAt,
-          staleAt: refreshed?.staleAt ?? staleAt,
-        };
-      }),
-    );
     const workJobs = await storage.listBackgroundJobs({ kind: "work_issue" });
     const workJobsByTarget = new Map<string, BackgroundJob[]>();
 
@@ -1195,7 +1236,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       workJobsByTarget.set(job.targetId, existing);
     }
 
-    const issuesWithWorkLinks = await Promise.all(perRepoPages.flatMap((repoPage) => repoPage.items).map((issue) => {
+    const issuesWithWorkLinks = await Promise.all(synced.items.map((record) => {
+      const issue = record.payload;
       const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
       const attemptedAt = markIssueSyncAttempt(targetId);
       markIssueSyncSuccess(targetId, attemptedAt);
@@ -1203,16 +1245,18 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }));
 
     const sortedItems = issuesWithWorkLinks
-      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-    const hasMore = perRepoPages.some((repoPage) => repoPage.hasMore);
-    const fetchedAtMs = Math.min(...perRepoPages.map((repoPage) => new Date(repoPage.fetchedAt).getTime()));
-    const staleAtMs = Math.min(...perRepoPages.map((repoPage) => new Date(repoPage.staleAt).getTime()));
+      .sort((a, b) => b.number - a.number);
+    const hasMore = synced.hasMore;
+    const fetchedAtMs = Date.now();
+    const staleAtMs = fetchedAtMs;
     return {
       items: sortedItems,
       limit,
       offset,
       nextOffset: hasMore ? offset + limit : null,
       hasMore,
+      totalCount: counts.totalCount,
+      repoTotals: counts.repoTotals,
       fetchedAt: new Date(fetchedAtMs).toISOString(),
       staleAt: new Date(staleAtMs).toISOString(),
     };
@@ -1241,6 +1285,33 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       markIssueSyncFailure(targetId, attemptedAt, getErrorMessage(error));
       throw error;
     }
+  }
+
+  async function syncIssueInternal(repoInput: string, number: number): Promise<Issue> {
+    const parsedRepo = parseRepoSlug(repoInput);
+    if (!parsedRepo) {
+      throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+    }
+
+    const canonical = formatRepoSlug(parsedRepo);
+    const config = await storage.getConfig();
+    if (!config.watchedRepos.includes(canonical)) {
+      throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
+    }
+
+    const existing = await storage.getSyncedIssue(canonical, number);
+    const targetId = formatIssueTargetId(canonical, number);
+    const attemptedAt = markIssueSyncAttempt(targetId);
+    if (existing?.isWorked) {
+      markIssueSyncSuccess(targetId, attemptedAt);
+      return applyIssueWorkState(existing.payload, { includePrMergeability: true });
+    }
+
+    const octokit = await buildOctokit(config);
+    const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });
+    await storage.upsertSyncedIssues(canonical, [issue], new Date().toISOString());
+    markIssueSyncSuccess(targetId, attemptedAt);
+    return applyIssueWorkState(issue, { includePrMergeability: true, octokit });
   }
 
   async function updateIssueLabelsInternal(
@@ -1345,13 +1416,26 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       return;
     }
 
-    const [repoSettings, issuesPage, evaluationJobs, workJobs] = await Promise.all([
+    const [repoSettings, firstIssuesPage, evaluationJobs, workJobs] = await Promise.all([
       storage.listRepoSettings(),
       listIssuesInternal({ limit: MAX_ISSUES_PAGE_SIZE, offset: 0 }),
       storage.listBackgroundJobs({ kind: "evaluate_issue" }),
       storage.listBackgroundJobs({ kind: "work_issue" }),
     ]);
-    const issues = issuesPage.items;
+    const issuesById = new Map(firstIssuesPage.items.map((issue) => [issue.id, issue]));
+    let nextOffset = firstIssuesPage.nextOffset;
+    let pageCount = 1;
+    while (nextOffset !== null && pageCount < MAX_AUTO_ISSUE_SWEEP_PAGES) {
+      const page = await listIssuesInternal({ limit: MAX_ISSUES_PAGE_SIZE, offset: nextOffset });
+      for (const issue of page.items) {
+        if (!issuesById.has(issue.id)) {
+          issuesById.set(issue.id, issue);
+        }
+      }
+      nextOffset = page.nextOffset;
+      pageCount += 1;
+    }
+    const issues = Array.from(issuesById.values());
 
     const isJobActive = (status: string) => status === "queued" || status === "leased";
     const activeEvaluationTargets = new Set(
@@ -1869,7 +1953,13 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async syncRepos() {
-      await watcherScheduler.runAndReportErrors();
+      const runtimeState = await storage.getRuntimeState();
+      if (runtimeState.drainMode) {
+        return { ok: true as const };
+      }
+
+      await babysitter.syncAndBabysitTrackedRepos({ includeAllOpenPrs: true, fullSweep: true });
+      await syncStoredIssuesStep({ fullSweep: true });
       notifyChange();
       return { ok: true as const };
     },
@@ -1907,7 +1997,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async syncIssue(repoInput, number) {
-      return getIssueInternal(repoInput, number);
+      return syncIssueInternal(repoInput, number);
     },
 
     async updateIssueLabels(repoInput, number, updates) {
@@ -1916,6 +2006,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     async evaluateIssue(repoInput, number) {
       return queueIssueEvaluationInternal(repoInput, number, "manual");
+    },
+
+    async verifyIssueWork(repoInput, number) {
+      return verifyIssueWorkInternal(repoInput, number);
     },
 
     async workIssue(repoInput, number) {
@@ -1928,10 +2022,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     async listPRs(view = "active") {
       if (view === "archived") {
-        return storage.getArchivedPRs();
+        return storage.getArchivedPRSummaries();
       }
 
-      return storage.getPRs();
+      return storage.getPRSummaries();
     },
 
     async getPR(id) {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -78,6 +78,7 @@ const CODE_OWNER_FALLBACK_TIMEOUT_MS = 30 * 60 * 1000;
 const AGENT_STREAM_LOG_LINE_LIMIT = 120;
 const MAX_FEEDBACK_SYNCS_PER_TICK = 20;
 const FEEDBACK_SYNC_RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000;
+const REPO_SYNC_FAILURE_BACKOFF_MS = 60_000;
 const APP_NAME = "patchdeck";
 const APP_REPOSITORY_URL = "https://github.com/jeremymcs/patchdeck";
 export const APP_COMMENT_FOOTER = formatAppCommentFooter(APP_NAME, true);
@@ -1319,6 +1320,8 @@ export class PRBabysitter {
   private readonly clock: () => Date;
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
+  private readonly repoSyncBackoffUntilMs = new Map<string, number>();
+  private repoSyncCursor = 0;
 
   constructor(
     storage: IStorage,
@@ -1804,7 +1807,9 @@ export class PRBabysitter {
     return updated;
   }
 
-  async syncAndBabysitTrackedRepos(): Promise<void> {
+  async syncAndBabysitTrackedRepos(options?: { includeAllOpenPrs?: boolean; fullSweep?: boolean }): Promise<void> {
+    const includeAllOpenPrs = options?.includeAllOpenPrs === true;
+    const fullSweep = options?.fullSweep === true;
     const [runtimeState, configEarly] = await Promise.all([
       this.storage.getRuntimeState(),
       this.storage.getConfig(),
@@ -1884,14 +1889,36 @@ export class PRBabysitter {
     const repos = Array.from(repoCandidates)
       .map((repo) => parseRepoSlug(repo))
       .filter((repo): repo is NonNullable<typeof repo> => Boolean(repo));
+    if (repos.length === 0) {
+      return;
+    }
 
-    for (const repo of repos) {
+    const nowMs = this.now().getTime();
+    const selectedRepos = fullSweep
+      ? repos
+      : Array.from({ length: repos.length })
+          .map((_, i) => repos[(this.repoSyncCursor + i) % repos.length])
+          .filter((repo): repo is NonNullable<typeof repo> => Boolean(repo))
+          .filter((repo) => {
+            const repoSlug = formatRepoSlug(repo);
+            const backoffUntilMs = this.repoSyncBackoffUntilMs.get(repoSlug) ?? 0;
+            return backoffUntilMs <= nowMs;
+          })
+          .slice(0, 1);
+
+    for (const repo of selectedRepos) {
       const repoSlug = formatRepoSlug(repo);
 
       let openPulls;
       try {
         openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
+        this.repoSyncBackoffUntilMs.delete(repoSlug);
+        const repoIndex = repos.findIndex((entry) => formatRepoSlug(entry) === repoSlug);
+        if (repoIndex >= 0) {
+          this.repoSyncCursor = (repoIndex + 1) % repos.length;
+        }
       } catch (error) {
+        this.repoSyncBackoffUntilMs.set(repoSlug, this.now().getTime() + REPO_SYNC_FAILURE_BACKOFF_MS);
         log.warn(
           { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
           "Failed to list open PRs",
@@ -2048,7 +2075,7 @@ export class PRBabysitter {
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {
-          if (!automationScopeNumbers.has(pull.number)) {
+          if (!automationScopeNumbers.has(pull.number) && !includeAllOpenPrs) {
             continue;
           }
 

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -12,11 +12,15 @@ import {
   addLabelsToIssue,
   createIssueComment,
   fetchIssueSummary,
+  fetchPullDiff,
+  parsePRUrl,
   parseRepoSlug,
   resolveGitHubAuthToken,
 } from "./github";
 import { buildIssueEvaluationComment, evaluateIssueForAutomation } from "./issueEvaluator";
-import { buildIssueReplyBody, buildIssueWorkStatusComment, buildPullRequestBody } from "./issueFormatter";
+import { buildIssueReplyBody, buildIssueVerifyComment, buildIssueWorkStatusComment, buildPullRequestBody } from "./issueFormatter";
+import { decomposeIssueBody, hashIssueBody } from "./issueDecompose";
+import { verifySubtasksAgainstPr } from "./issueVerify";
 import { runIssueWorkRepair } from "./issueWorkAgent";
 import { answerPRQuestion } from "./prQuestionAgent";
 import type { ReleaseManager } from "./releaseManager";
@@ -218,6 +222,115 @@ export function createBackgroundJobHandlers(params: {
       );
     },
 
+    verify_issue: async (job) => {
+      const repo = readStringPayload(job, "repo");
+      const issueNumber = Number(job.payload.issueNumber);
+      const workPrUrl = readStringPayload(job, "workPrUrl");
+      const workPrNumber = Number(job.payload.workPrNumber);
+
+      if (!repo || !workPrUrl || !Number.isFinite(issueNumber) || !Number.isFinite(workPrNumber)) {
+        throw new CancelBackgroundJobError(`Background job ${job.id} is missing required verify fields`);
+      }
+
+      const parsedRepo = parseRepoSlug(repo);
+      if (!parsedRepo) {
+        throw new CancelBackgroundJobError(`Background job ${job.id} has invalid repo context: ${repo}`);
+      }
+
+      const parsedPr = parsePRUrl(workPrUrl);
+      if (!parsedPr) {
+        throw new CancelBackgroundJobError(`Background job ${job.id} has invalid work PR URL: ${workPrUrl}`);
+      }
+
+      const config = await storage.getConfig();
+      const octokit = await buildOctokitFn(config);
+      const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number: issueNumber });
+      const targetId = `${issue.repoFullName}#${issue.number}`;
+      const baseMetadata = {
+        repo: issue.repoFullName,
+        issueNumber: issue.number,
+        prNumber: workPrNumber,
+        prUrl: workPrUrl,
+        jobId: job.id,
+      };
+
+      const diff = await fetchPullDiff(octokit, parsedPr);
+
+      const repoSettings = await storage.getRepoSettings(issue.repoFullName);
+      const agent = resolveRepoCodingAgent(config, repoSettings);
+      const agentSettings = resolveRepoAgentRuntimeSettings(config, repoSettings);
+
+      const freshDecomposed = await decomposeIssueBody({
+        body: issue.body,
+        agent,
+        settings: agentSettings,
+      });
+      const existingSet = await storage.getIssueSubtasks(targetId);
+      const subtasks = freshDecomposed.length >= 2
+        ? freshDecomposed
+        : existingSet?.subtasks?.length
+          ? existingSet.subtasks
+          : [{
+            id: "issue",
+            title: issue.title.slice(0, 120),
+            summary: (issue.body ?? "").trim().slice(0, 500) || issue.title.slice(0, 500),
+            status: "pending" as const,
+          }];
+
+      const result = await verifySubtasksAgainstPr({
+        issueTitle: issue.title,
+        issueBody: issue.body,
+        subtasks,
+        prDiff: diff,
+        agent,
+        settings: agentSettings,
+      });
+
+      await storage.upsertIssueSubtasks({
+        targetId,
+        repo: issue.repoFullName,
+        issueNumber: issue.number,
+        subtasks: result.subtasks,
+        analyzedBodyHash: hashIssueBody(issue.body),
+      });
+
+      if (config.postGitHubProgressReplies) {
+        try {
+          await octokit.issues.createComment({
+            owner: parsedPr.owner,
+            repo: parsedPr.repo,
+            issue_number: workPrNumber,
+            body: buildIssueVerifyComment({
+              repoFullName: issue.repoFullName,
+              issueNumber: issue.number,
+              issueTitle: issue.title,
+              issueUrl: issue.url,
+              prNumber: workPrNumber,
+              prUrl: workPrUrl,
+              subtasks: result.subtasks,
+              doneCount: result.doneCount,
+              totalCount: result.totalCount,
+            }),
+          });
+        } catch (error) {
+          await addIssueWorkStageLog(
+            targetId,
+            "verifying",
+            `Failed to post verification comment on PR #${workPrNumber}: ${error instanceof Error ? error.message : String(error)}`,
+            baseMetadata,
+            "warn",
+          );
+        }
+      }
+
+      await addIssueWorkStageLog(
+        targetId,
+        "verifying",
+        `Verified work PR #${workPrNumber} for ${issue.repoFullName}#${issue.number} — ${result.doneCount} of ${result.totalCount} subtasks addressed`,
+        baseMetadata,
+      );
+    },
+
     work_issue: async (job) => {
       const repo = readStringPayload(job, "repo");
       const issueNumber = Number(job.payload.issueNumber);
@@ -281,6 +394,25 @@ export function createBackgroundJobHandlers(params: {
         const repoSettings = await storage.getRepoSettings(issue.repoFullName);
         const agent = resolveRepoCodingAgent(config, repoSettings);
         const agentSettings = resolveRepoAgentRuntimeSettings(config, repoSettings);
+
+        const bodyHash = hashIssueBody(issue.body);
+        const existingSubtasks = await storage.getIssueSubtasks(targetId);
+        let subtasks = existingSubtasks?.subtasks ?? [];
+        if (!existingSubtasks || existingSubtasks.analyzedBodyHash !== bodyHash) {
+          subtasks = await decomposeIssueBody({
+            body: issue.body,
+            agent,
+            settings: agentSettings,
+          });
+          await storage.upsertIssueSubtasks({
+            targetId,
+            repo: issue.repoFullName,
+            issueNumber: issue.number,
+            subtasks,
+            analyzedBodyHash: bodyHash,
+          });
+        }
+
         repairResult = await runIssueWorkRepairFn({
           repo: issue.repoFullName,
           issueNumber: issue.number,
@@ -293,6 +425,7 @@ export function createBackgroundJobHandlers(params: {
           repoCloneUrl: buildGitHubCloneUrl(issue.repoFullName, githubToken),
           agent,
           agentSettings,
+          subtasks: subtasks.length >= 2 ? subtasks : undefined,
         });
       } catch (error) {
         if (progressRepliesEnabled) {
@@ -356,6 +489,16 @@ export function createBackgroundJobHandlers(params: {
         throw new TerminalBackgroundJobError(repairResult.rejectionReason ?? "Issue work not accepted");
       }
 
+      if (repairResult.subtasks && repairResult.subtasks.length >= 2) {
+        await storage.upsertIssueSubtasks({
+          targetId,
+          repo: issue.repoFullName,
+          issueNumber: issue.number,
+          subtasks: repairResult.subtasks,
+          analyzedBodyHash: hashIssueBody(issue.body),
+        });
+      }
+
       await addIssueWorkStageLog(
         targetId,
         "verifying",
@@ -407,6 +550,7 @@ export function createBackgroundJobHandlers(params: {
           issueUrl: issue.url,
           summary: repairResult.summary,
           branch: repairResult.fixBranch,
+          subtasks: repairResult.subtasks,
         }),
       });
 
@@ -439,6 +583,7 @@ export function createBackgroundJobHandlers(params: {
           branch: repairResult.fixBranch,
         },
       );
+      await storage.markSyncedIssueWorked(issue.repoFullName, issue.number);
     },
 
     answer_pr_question: async (job) => {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -819,6 +819,72 @@ test("listOpenIssuesForRepo filters pull requests and normalizes issue metadata"
   assert.match(page.items[0]?.bodyHtml ?? "", /<p>The toggle is stuck<\/p>/);
 });
 
+test("listOpenIssuesForRepo continues pagination when a page contains pull requests", async () => {
+  let calls = 0;
+  const octokit = {
+    issues: {
+      listForRepo: async () => {
+        calls += 1;
+        if (calls === 1) {
+          const firstPage = Array.from({ length: 100 }, (_, index) => {
+            const number = index + 1;
+            if (index < 50) {
+              return {
+                number,
+                title: `PR ${number}`,
+                pull_request: { url: `https://api.github.com/repos/owner/repo/pulls/${number}` },
+              };
+            }
+            return {
+              number,
+              title: `Issue ${number}`,
+              body: `Body ${number}`,
+              html_url: `https://github.com/owner/repo/issues/${number}`,
+              user: { login: "alice" },
+              labels: [],
+              assignees: [],
+              comments: 0,
+              created_at: "2026-05-03T17:00:00.000Z",
+              updated_at: "2026-05-03T18:00:00.000Z",
+            };
+          });
+          return { data: firstPage };
+        }
+        if (calls === 2) {
+          return {
+            data: [
+              {
+                number: 101,
+                title: "Issue 101",
+                body: "Body 101",
+                html_url: "https://github.com/owner/repo/issues/101",
+                user: { login: "alice" },
+                labels: [],
+                assignees: [],
+                comments: 0,
+                created_at: "2026-05-03T17:00:00.000Z",
+                updated_at: "2026-05-03T18:00:00.000Z",
+              },
+            ],
+          };
+        }
+        return { data: [] };
+      },
+    },
+  };
+
+  const page = await listOpenIssuesForRepo(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    { offset: 0, limit: 100 },
+  );
+
+  assert.equal(calls, 2);
+  assert.equal(page.items.length, 51);
+  assert.equal(page.items[0]?.number, 51);
+  assert.equal(page.items[50]?.number, 101);
+});
+
 test("listOpenLinkedPullRequestsForIssue returns unique open cross-referenced PRs", async () => {
   const octokit = {
     paginate: async () => [

--- a/server/github.ts
+++ b/server/github.ts
@@ -1285,6 +1285,22 @@ export async function fetchPullSummary(
   };
 }
 
+export async function fetchPullDiff(
+  octokit: Octokit,
+  parsed: ParsedPRUrl,
+): Promise<string> {
+  const response = await withGitHubErrorHandling("PR diff", parsed, () =>
+    octokit.pulls.get({
+      owner: parsed.owner,
+      repo: parsed.repo,
+      pull_number: parsed.number,
+      mediaType: { format: "diff" },
+    }),
+  );
+
+  return typeof response.data === "string" ? response.data : String(response.data ?? "");
+}
+
 export async function fetchPullCloseState(
   octokit: Octokit,
   parsed: ParsedPRUrl,
@@ -2097,7 +2113,7 @@ export async function listOpenIssuesForRepo(
     }));
 
     collected.push(...pageItems);
-    if (pageItems.length < perPage) {
+    if (issues.data.length < perPage) {
       break;
     }
 

--- a/server/issueDecompose.test.ts
+++ b/server/issueDecompose.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { CommandResult } from "./agentRunner";
+import { decomposeFromHeuristic, decomposeIssueBody, hashIssueBody } from "./issueDecompose";
+
+const MULTI_BUG_BODY = `## Summary
+
+Auto-mode marked T01–T04 as failed. Root cause is **five distinct bugs**.
+
+## Bug 1 — \`grep\` absence-check inverted (P0)
+
+The verifier treats \`exitCode === 0\` as the only pass condition.
+
+**Evidence:** T01-VERIFY.json shows exitCode 1, verdict fail.
+
+## Bug 2 — \`discoverySource: "preference"\` silently overrides the plan (P0)
+
+When the verifier cannot parse the plan's verification section, it falls back to a global preference.
+
+## Bug 3 — Project test runner path not resolved (P1)
+
+T02/T03/T04 VERIFY.json all show command pytest, exitCode 127.
+
+## Bug 4 — Safety system flags artifacts as 396 unexpected changes (P2)
+
+Pre-verification gate flagged 396 files outside the task plan.
+
+## Bug 5 — Subagent dispatch silently dies after model setup (P0)
+
+Only thinking_level_change and model_change events, no tool calls.
+`;
+
+const SINGLE_BUG_BODY = `## Summary
+
+The login button does not respond on Safari 17.
+
+## Steps to reproduce
+
+1. Open the page on Safari.
+2. Click the login button.
+3. Nothing happens.
+
+## Expected
+
+Login modal should appear.
+`;
+
+function buildResult(stdout: string, code = 0): CommandResult {
+  return {
+    code,
+    stdout,
+    stderr: "",
+    durationMs: 1,
+    timedOut: false,
+  };
+}
+
+test("decomposeFromHeuristic extracts ## Bug N headers", () => {
+  const tasks = decomposeFromHeuristic(MULTI_BUG_BODY);
+  assert.equal(tasks.length, 5);
+  assert.equal(tasks[0].id, "bug-1");
+  assert.match(tasks[0].title, /grep.+absence-check inverted/);
+  assert.equal(tasks[0].status, "pending");
+  assert.ok(tasks[0].summary.includes("exitCode"));
+  assert.equal(tasks[4].id, "bug-5");
+  assert.match(tasks[4].title, /Subagent dispatch/);
+});
+
+test("decomposeFromHeuristic returns [] for single-bug bodies", () => {
+  assert.deepEqual(decomposeFromHeuristic(SINGLE_BUG_BODY), []);
+});
+
+test("decomposeFromHeuristic also recognizes ### and plain 'Bug N — title' lines", () => {
+  const body = `Intro paragraph.
+
+### Bug 1 — first
+First details.
+
+### Bug 2 — second
+Second details.
+`;
+  const tasks = decomposeFromHeuristic(body);
+  assert.equal(tasks.length, 2);
+  assert.equal(tasks[1].id, "bug-2");
+
+  const plain = `Intro.
+
+Bug 1 — alpha
+alpha body
+
+Bug 2 — beta
+beta body
+`;
+  const plainTasks = decomposeFromHeuristic(plain);
+  assert.equal(plainTasks.length, 2);
+  assert.equal(plainTasks[0].title, "alpha");
+});
+
+test("hashIssueBody is stable and changes with body changes", () => {
+  const a = hashIssueBody("hello");
+  const b = hashIssueBody("hello");
+  const c = hashIssueBody("hello!");
+  assert.equal(a, b);
+  assert.notEqual(a, c);
+  assert.equal(hashIssueBody(null).length, 32);
+});
+
+test("decomposeIssueBody skips short bodies without invoking the agent", async () => {
+  let called = false;
+  const tasks = await decomposeIssueBody(
+    { body: "tiny body", agent: "claude" },
+    {
+      runOneShot: async () => {
+        called = true;
+        return buildResult("[]");
+      },
+    },
+  );
+  assert.deepEqual(tasks, []);
+  assert.equal(called, false);
+});
+
+test("decomposeIssueBody uses heuristic without invoking the agent when it succeeds", async () => {
+  let called = false;
+  const tasks = await decomposeIssueBody(
+    { body: MULTI_BUG_BODY, agent: "claude" },
+    {
+      runOneShot: async () => {
+        called = true;
+        return buildResult("[]");
+      },
+    },
+  );
+  assert.equal(called, false);
+  assert.equal(tasks.length, 5);
+});
+
+test("decomposeIssueBody falls back to the agent when heuristic finds <2 bugs", async () => {
+  const seenAgents: string[] = [];
+  const tasks = await decomposeIssueBody(
+    {
+      body: SINGLE_BUG_BODY + "\n\nAlso unrelated: the export button crashes the tab.\n".repeat(5),
+      agent: "codex",
+    },
+    {
+      runOneShot: async (params) => {
+        seenAgents.push(params.agent);
+        return buildResult(
+          JSON.stringify([
+            { title: "Login button unresponsive", summary: "Safari 17 does not fire click events." },
+            { title: "Export button crashes tab", summary: "Memory blowup on large exports." },
+          ]),
+        );
+      },
+    },
+  );
+  assert.deepEqual(seenAgents, ["codex"]);
+  assert.equal(tasks.length, 2);
+  assert.equal(tasks[0].id, "bug-1");
+  assert.equal(tasks[0].title, "Login button unresponsive");
+  assert.equal(tasks[1].title, "Export button crashes tab");
+});
+
+test("decomposeIssueBody returns [] when agent emits invalid JSON", async () => {
+  const tasks = await decomposeIssueBody(
+    { body: SINGLE_BUG_BODY.repeat(3), agent: "claude" },
+    {
+      runOneShot: async () => buildResult("not json at all"),
+    },
+  );
+  assert.deepEqual(tasks, []);
+});
+
+test("decomposeIssueBody returns [] when agent returns a single bug", async () => {
+  const tasks = await decomposeIssueBody(
+    { body: SINGLE_BUG_BODY.repeat(3), agent: "claude" },
+    {
+      runOneShot: async () => buildResult(JSON.stringify([{ title: "single", summary: "x" }])),
+    },
+  );
+  assert.deepEqual(tasks, []);
+});
+
+test("decomposeIssueBody tolerates agent failure", async () => {
+  const tasks = await decomposeIssueBody(
+    { body: SINGLE_BUG_BODY.repeat(3), agent: "claude" },
+    {
+      runOneShot: async () => buildResult("", 1),
+    },
+  );
+  assert.deepEqual(tasks, []);
+});
+
+test("decomposeIssueBody extracts JSON array from wrapped agent output", async () => {
+  const tasks = await decomposeIssueBody(
+    { body: SINGLE_BUG_BODY.repeat(3), agent: "codex" },
+    {
+      runOneShot: async () =>
+        buildResult(
+          `Here is the array:\n[${JSON.stringify({ title: "a", summary: "a" })},${JSON.stringify({ title: "b", summary: "b" })}]\nDone.`,
+        ),
+    },
+  );
+  assert.equal(tasks.length, 2);
+  assert.equal(tasks[0].title, "a");
+});

--- a/server/issueDecompose.ts
+++ b/server/issueDecompose.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { AgentRuntimeSettings, CodingAgent } from "./agentRunner";
+import { runAgentOneShot } from "./agentRunner";
+import { childLogger } from "./logger";
+import type { IssueSubtask } from "@shared/schema";
+
+const log = childLogger("issue-decompose");
+
+export type DecomposeInput = {
+  body: string | null;
+  agent: CodingAgent;
+  settings?: AgentRuntimeSettings;
+  timeoutMs?: number;
+};
+
+export type DecomposeDependencies = {
+  runOneShot: typeof runAgentOneShot;
+};
+
+export function hashIssueBody(body: string | null): string {
+  return createHash("sha256").update(body ?? "").digest("hex").slice(0, 32);
+}
+
+const HEADING_PATTERN = /^(#{2,3})\s+Bug\s+(\d+)\s*[—\-:]\s*(.+?)\s*$/i;
+const PLAIN_BUG_PATTERN = /^Bug\s+(\d+)\s+[—\-:]\s+(.+?)\s*$/i;
+
+export function decomposeFromHeuristic(body: string): IssueSubtask[] {
+  const lines = body.split(/\r?\n/);
+  const headings: Array<{ lineIndex: number; bugNumber: number; title: string }> = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const heading = line.match(HEADING_PATTERN);
+    if (heading) {
+      headings.push({ lineIndex: i, bugNumber: Number(heading[2]), title: heading[3].trim() });
+      continue;
+    }
+    const plain = line.match(PLAIN_BUG_PATTERN);
+    if (plain) {
+      headings.push({ lineIndex: i, bugNumber: Number(plain[1]), title: plain[2].trim() });
+    }
+  }
+
+  if (headings.length < 2) return [];
+
+  return headings.map((heading, idx) => {
+    const nextIndex = headings[idx + 1]?.lineIndex ?? lines.length;
+    const summaryLines = lines
+      .slice(heading.lineIndex + 1, nextIndex)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("---"));
+    const summary = summaryLines.slice(0, 8).join(" ").replace(/\s+/g, " ").trim();
+    return {
+      id: `bug-${heading.bugNumber}`,
+      title: heading.title.slice(0, 120),
+      summary: summary.slice(0, 500),
+      status: "pending" as const,
+    };
+  });
+}
+
+const LLM_INSTRUCTIONS = `You analyze a GitHub issue body to determine whether it describes one bug or multiple distinct independent bugs.
+
+Rules:
+- Return ONLY a JSON array. No prose, no markdown code fences, no explanation.
+- If the issue describes a single bug (even if it has multiple steps or symptoms of one root cause), return [].
+- If it describes 2 or more distinct, independent bugs that could each be fixed in a separate change, return one object per bug.
+- Each object must have exactly two string fields: title (under 80 chars) and summary (one paragraph, under 500 chars).
+- Multiple symptoms of one root cause count as a single bug. Return [].`;
+
+function buildDecomposePrompt(body: string): string {
+  const truncated = body.length > 12000 ? `${body.slice(0, 12000)}…` : body;
+  return `${LLM_INSTRUCTIONS}
+
+Issue body:
+"""
+${truncated}
+"""
+
+JSON array output:`;
+}
+
+function extractJsonArray(text: string): unknown[] | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // fall through to bracket extraction
+  }
+
+  const firstBracket = trimmed.indexOf("[");
+  const lastBracket = trimmed.lastIndexOf("]");
+  if (firstBracket === -1 || lastBracket === -1 || lastBracket <= firstBracket) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed.slice(firstBracket, lastBracket + 1));
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAgentSubtasks(raw: unknown[]): IssueSubtask[] {
+  const cleaned: IssueSubtask[] = [];
+  raw.forEach((entry, index) => {
+    if (!entry || typeof entry !== "object") return;
+    const candidate = entry as { title?: unknown; summary?: unknown };
+    if (typeof candidate.title !== "string" || typeof candidate.summary !== "string") return;
+    cleaned.push({
+      id: `bug-${index + 1}`,
+      title: candidate.title.trim().slice(0, 120),
+      summary: candidate.summary.trim().slice(0, 500),
+      status: "pending",
+    });
+  });
+  return cleaned;
+}
+
+async function decomposeFromAgent(
+  input: DecomposeInput,
+  body: string,
+  runOneShot: typeof runAgentOneShot,
+): Promise<IssueSubtask[]> {
+  let workCwd: string | null = null;
+  try {
+    workCwd = await mkdtemp(path.join(tmpdir(), "patchdeck-decompose-"));
+    const result = await runOneShot({
+      agent: input.agent,
+      prompt: buildDecomposePrompt(body),
+      cwd: workCwd,
+      settings: input.settings,
+      timeoutMs: input.timeoutMs ?? 30000,
+    });
+
+    if (result.code !== 0) {
+      log.info(
+        { agent: input.agent, code: result.code, stderr: result.stderr.slice(0, 200) },
+        "issue decompose agent exited non-zero; treating as single-bug",
+      );
+      return [];
+    }
+
+    const parsed = extractJsonArray(result.stdout);
+    if (!parsed || parsed.length < 2) {
+      return [];
+    }
+
+    const normalized = normalizeAgentSubtasks(parsed);
+    return normalized.length >= 2 ? normalized : [];
+  } catch (error) {
+    log.info(
+      { agent: input.agent, err: error instanceof Error ? error.message : String(error) },
+      "issue decompose threw; treating as single-bug",
+    );
+    return [];
+  } finally {
+    if (workCwd) {
+      try {
+        await rm(workCwd, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
+export async function decomposeIssueBody(
+  input: DecomposeInput,
+  deps?: Partial<DecomposeDependencies>,
+): Promise<IssueSubtask[]> {
+  const body = input.body?.trim();
+  if (!body || body.length < 200) {
+    return [];
+  }
+
+  const heuristic = decomposeFromHeuristic(body);
+  if (heuristic.length >= 2) {
+    return heuristic;
+  }
+
+  const runOneShot = deps?.runOneShot ?? runAgentOneShot;
+  return decomposeFromAgent(input, body, runOneShot);
+}

--- a/server/issueFormatter.test.ts
+++ b/server/issueFormatter.test.ts
@@ -72,6 +72,47 @@ test("buildIssueWorkStatusComment renders the issue workflow milestones", () => 
   assert.match(failed, /agent timed out/);
 });
 
+test("buildPullRequestBody renders a Bugs Addressed section when subtasks are present", () => {
+  const body = buildPullRequestBody({
+    repoFullName: input.repoFullName,
+    issueNumber: input.issueNumber,
+    issueTitle: input.issueTitle,
+    issueUrl: input.issueUrl,
+    summary: input.summary,
+    branch: input.branch,
+    subtasks: [
+      { id: "bug-1", title: "Exit code inverted", summary: "x", status: "done" },
+      {
+        id: "bug-2",
+        title: "Preference overrides plan",
+        summary: "x",
+        status: "deferred",
+        statusReason: "needs config redesign",
+      },
+      { id: "bug-3", title: "Path not resolved", summary: "x", status: "skipped", statusReason: "out of scope" },
+    ],
+  });
+
+  assert.match(body, /## Bugs Addressed/);
+  assert.match(body, /- \[x\] \*\*Exit code inverted\*\*/);
+  assert.match(body, /- \[ \] \*\*Preference overrides plan\*\* _\(deferred: needs config redesign\)_/);
+  assert.match(body, /- \[ \] \*\*Path not resolved\*\* _\(skipped: out of scope\)_/);
+});
+
+test("buildPullRequestBody omits Bugs Addressed when there are fewer than two subtasks", () => {
+  const body = buildPullRequestBody({
+    repoFullName: input.repoFullName,
+    issueNumber: input.issueNumber,
+    issueTitle: input.issueTitle,
+    issueUrl: input.issueUrl,
+    summary: input.summary,
+    branch: input.branch,
+    subtasks: [{ id: "bug-1", title: "lonely", summary: "x", status: "done" }],
+  });
+
+  assert.doesNotMatch(body, /## Bugs Addressed/);
+});
+
 test("buildIssueWorkStatusComment redacts local file paths from failure details", () => {
   const failed = buildIssueWorkStatusComment({
     repoFullName: input.repoFullName,

--- a/server/issueFormatter.ts
+++ b/server/issueFormatter.ts
@@ -1,3 +1,5 @@
+import type { IssueSubtask } from "@shared/schema";
+
 function normalizeSectionLines(text: string | null | undefined, fallback: string): string[] {
   const trimmed = text?.trim();
   if (!trimmed) {
@@ -38,7 +40,22 @@ type IssueReplyBodyInput = IssueWorkBodyInput & {
 
 type PullRequestBodyInput = IssueWorkBodyInput & {
   branch: string;
+  subtasks?: IssueSubtask[];
 };
+
+function formatBugsAddressedSection(subtasks: IssueSubtask[]): string[] {
+  if (subtasks.length < 2) return [];
+  const lines = ["## Bugs Addressed"];
+  for (const task of subtasks) {
+    const marker = task.status === "done" ? "x" : " ";
+    const suffix = task.status === "done"
+      ? ""
+      : ` _(${task.status}${task.statusReason ? `: ${task.statusReason}` : ""})_`;
+    lines.push(`- [${marker}] **${task.title}**${suffix}`);
+  }
+  lines.push("");
+  return lines;
+}
 
 type IssueWorkStatusStage = "started" | "verifying" | "failed";
 
@@ -75,11 +92,13 @@ export function buildIssueReplyBody(input: IssueReplyBodyInput): string {
 
 export function buildPullRequestBody(input: PullRequestBodyInput): string {
   const summaryLines = bulletLines(normalizeSectionLines(input.summary, "No summary provided."));
+  const bugsSection = input.subtasks ? formatBugsAddressedSection(input.subtasks) : [];
 
   return [
     "## Summary",
     ...summaryLines,
     "",
+    ...bugsSection,
     "## Verification",
     "- Completed in the repository worktree before push.",
     "",
@@ -92,6 +111,47 @@ export function buildPullRequestBody(input: PullRequestBodyInput): string {
     "",
     "## Branch",
     `- \`${input.branch}\``,
+  ].join("\n");
+}
+
+type IssueVerifyCommentInput = {
+  repoFullName: string;
+  issueNumber: number;
+  issueTitle: string;
+  issueUrl: string;
+  prNumber: number;
+  prUrl: string;
+  subtasks: IssueSubtask[];
+  doneCount: number;
+  totalCount: number;
+};
+
+export function buildIssueVerifyComment(input: IssueVerifyCommentInput): string {
+  const issueLink = `[#${input.issueNumber} ${input.issueTitle}](${input.issueUrl})`;
+  const allDone = input.totalCount > 0 && input.doneCount === input.totalCount;
+  const header = allDone
+    ? `✅ **Verification — all ${input.totalCount} ${input.totalCount === 1 ? "task is" : "tasks are"} addressed**`
+    : `🔎 **Verification — ${input.doneCount} of ${input.totalCount} addressed**`;
+
+  const checklist = input.subtasks.length === 0
+    ? ["- _No subtasks recorded for this issue._"]
+    : input.subtasks.map((task) => {
+      const marker = task.status === "done" ? "x" : " ";
+      const suffix = task.status === "done"
+        ? ""
+        : ` _(${task.status}${task.statusReason ? `: ${task.statusReason}` : ""})_`;
+      return `- [${marker}] **${task.title}**${suffix}`;
+    });
+
+  return [
+    header,
+    "",
+    `Re-checked PR #${input.prNumber} against ${issueLink}.`,
+    "",
+    "## Subtasks",
+    ...checklist,
+    "",
+    `_Re-run from Patchdeck to refresh._`,
   ].join("\n");
 }
 

--- a/server/issueVerify.ts
+++ b/server/issueVerify.ts
@@ -1,0 +1,194 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { AgentRuntimeSettings, CodingAgent } from "./agentRunner";
+import { runAgentOneShot } from "./agentRunner";
+import { childLogger } from "./logger";
+import type { IssueSubtask, IssueSubtaskStatus } from "@shared/schema";
+
+const log = childLogger("issue-verify");
+
+export type VerifyInput = {
+  issueTitle: string;
+  issueBody: string | null;
+  subtasks: IssueSubtask[];
+  prDiff: string;
+  agent: CodingAgent;
+  settings?: AgentRuntimeSettings;
+  timeoutMs?: number;
+};
+
+export type VerifyDependencies = {
+  runOneShot: typeof runAgentOneShot;
+};
+
+export type VerifyResult = {
+  subtasks: IssueSubtask[];
+  doneCount: number;
+  totalCount: number;
+};
+
+const MAX_DIFF_CHARS = 60000;
+const MAX_BODY_CHARS = 12000;
+
+const LLM_INSTRUCTIONS = `You verify whether a pull request addresses each subtask of a GitHub issue.
+
+Rules:
+- Return ONLY a JSON array. No prose, no markdown code fences, no explanation.
+- Output one object per provided subtask, in the SAME order, with the SAME id.
+- Each object has exactly: id (string), status ("done" | "pending" | "deferred"), reason (string, under 200 chars).
+- Use "done" only when the diff clearly addresses the subtask.
+- Use "deferred" when the diff intentionally skips it (e.g. comment saying so).
+- Use "pending" when the diff does not address it.`;
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function buildVerifyPrompt(input: VerifyInput): string {
+  const body = input.issueBody?.trim() || "(no body)";
+  const subtaskList = input.subtasks
+    .map((task) => `- id: ${task.id}\n  title: ${task.title}\n  summary: ${task.summary}`)
+    .join("\n");
+  return `${LLM_INSTRUCTIONS}
+
+Issue title: ${input.issueTitle}
+
+Issue body:
+"""
+${truncate(body, MAX_BODY_CHARS)}
+"""
+
+Subtasks (verify each one):
+${subtaskList}
+
+Pull request diff:
+"""
+${truncate(input.prDiff, MAX_DIFF_CHARS)}
+"""
+
+JSON array output:`;
+}
+
+function extractJsonArray(text: string): unknown[] | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // fall through to bracket extraction
+  }
+
+  const firstBracket = trimmed.indexOf("[");
+  const lastBracket = trimmed.lastIndexOf("]");
+  if (firstBracket === -1 || lastBracket === -1 || lastBracket <= firstBracket) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed.slice(firstBracket, lastBracket + 1));
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeStatus(raw: unknown): IssueSubtaskStatus | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim().toLowerCase();
+  if (value === "done" || value === "pending" || value === "deferred" || value === "skipped") {
+    return value as IssueSubtaskStatus;
+  }
+  if (value === "addressed" || value === "complete" || value === "completed" || value === "fixed") {
+    return "done";
+  }
+  if (value === "missing" || value === "not_addressed" || value === "todo" || value === "open") {
+    return "pending";
+  }
+  return null;
+}
+
+function mergeAgentResults(
+  current: IssueSubtask[],
+  raw: unknown[],
+): IssueSubtask[] {
+  const byId = new Map<string, { status: IssueSubtaskStatus; reason: string | null }>();
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as { id?: unknown; status?: unknown; reason?: unknown };
+    if (typeof candidate.id !== "string") continue;
+    const status = normalizeStatus(candidate.status);
+    if (!status) continue;
+    const reason = typeof candidate.reason === "string" ? candidate.reason.trim().slice(0, 200) : null;
+    byId.set(candidate.id, { status, reason: reason && reason.length > 0 ? reason : null });
+  }
+
+  return current.map((task) => {
+    const verdict = byId.get(task.id);
+    if (!verdict) return task;
+    return {
+      ...task,
+      status: verdict.status,
+      statusReason: verdict.reason ?? task.statusReason ?? null,
+    };
+  });
+}
+
+export async function verifySubtasksAgainstPr(
+  input: VerifyInput,
+  deps?: Partial<VerifyDependencies>,
+): Promise<VerifyResult> {
+  if (input.subtasks.length === 0) {
+    return { subtasks: [], doneCount: 0, totalCount: 0 };
+  }
+
+  const runOneShot = deps?.runOneShot ?? runAgentOneShot;
+  let workCwd: string | null = null;
+  try {
+    workCwd = await mkdtemp(path.join(tmpdir(), "patchdeck-verify-"));
+    const result = await runOneShot({
+      agent: input.agent,
+      prompt: buildVerifyPrompt(input),
+      cwd: workCwd,
+      settings: input.settings,
+      timeoutMs: input.timeoutMs ?? 45000,
+    });
+
+    if (result.code !== 0) {
+      log.info(
+        { agent: input.agent, code: result.code, stderr: result.stderr.slice(0, 200) },
+        "issue verify agent exited non-zero; leaving subtasks unchanged",
+      );
+      return { subtasks: input.subtasks, doneCount: countDone(input.subtasks), totalCount: input.subtasks.length };
+    }
+
+    const parsed = extractJsonArray(result.stdout);
+    if (!parsed) {
+      log.info({ agent: input.agent }, "issue verify agent returned non-JSON; leaving subtasks unchanged");
+      return { subtasks: input.subtasks, doneCount: countDone(input.subtasks), totalCount: input.subtasks.length };
+    }
+
+    const merged = mergeAgentResults(input.subtasks, parsed);
+    return { subtasks: merged, doneCount: countDone(merged), totalCount: merged.length };
+  } catch (error) {
+    log.info(
+      { agent: input.agent, err: error instanceof Error ? error.message : String(error) },
+      "issue verify threw; leaving subtasks unchanged",
+    );
+    return { subtasks: input.subtasks, doneCount: countDone(input.subtasks), totalCount: input.subtasks.length };
+  } finally {
+    if (workCwd) {
+      try {
+        await rm(workCwd, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
+function countDone(subtasks: IssueSubtask[]): number {
+  return subtasks.reduce((sum, task) => sum + (task.status === "done" ? 1 : 0), 0);
+}

--- a/server/issueWorkAgent.test.ts
+++ b/server/issueWorkAgent.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildIssueWorkPrompt, extractIssueWorkSummary, runIssueWorkRepair } from "./issueWorkAgent";
+import { buildIssueWorkPrompt, extractBugFiles, extractBugStatuses, extractIssueWorkSummary, parsePorcelainPaths, runIssueWorkRepair } from "./issueWorkAgent";
+import type { IssueSubtask } from "@shared/schema";
 
 test("buildIssueWorkPrompt includes the issue context and verification instructions", () => {
   const prompt = buildIssueWorkPrompt({
@@ -135,4 +136,301 @@ test("runIssueWorkRepair commits, pushes, and verifies the issue branch", async 
   assert.match(agentPrompt, /Follow the repo checklist\./);
   assert.match(agentPrompt, /pull_request_template\.md/);
   assert.match(extractIssueWorkSummary("ISSUE_WORK_SUMMARY: fixed the toggle"), /fixed the toggle/);
+});
+
+const SAMPLE_SUBTASKS: IssueSubtask[] = [
+  { id: "bug-1", title: "Verifier exit code inverted", summary: "Treats 0 as the only pass.", status: "pending" },
+  { id: "bug-2", title: "Preference overrides plan", summary: "Falls back to preference silently.", status: "pending" },
+];
+
+test("buildIssueWorkPrompt enumerates bugs and demands BUG_STATUS markers when subtasks present", () => {
+  const prompt = buildIssueWorkPrompt({
+    repo: "acme/widgets",
+    issueNumber: 42,
+    issueTitle: "Five verifier bugs",
+    issueUrl: "https://example.test/42",
+    issueBody: "lots of bugs",
+    labels: [],
+    author: "alice",
+    baseBranch: "main",
+    agent: "claude",
+    subtasks: SAMPLE_SUBTASKS,
+  });
+
+  assert.match(prompt, /multiple distinct bugs/);
+  assert.match(prompt, /\[bug-1\] Verifier exit code inverted/);
+  assert.match(prompt, /\[bug-2\] Preference overrides plan/);
+  assert.match(prompt, /BUG_STATUS_<bug-id>/);
+  assert.match(prompt, /Emit one BUG_STATUS_<bug-id>/);
+});
+
+test("buildIssueWorkPrompt omits multi-bug instructions when subtasks <2", () => {
+  const prompt = buildIssueWorkPrompt({
+    repo: "acme/widgets",
+    issueNumber: 42,
+    issueTitle: "Single bug",
+    issueUrl: "https://example.test/42",
+    issueBody: "one bug",
+    labels: [],
+    author: "alice",
+    baseBranch: "main",
+    agent: "claude",
+    subtasks: [SAMPLE_SUBTASKS[0]],
+  });
+
+  assert.doesNotMatch(prompt, /multiple distinct bugs/);
+  assert.doesNotMatch(prompt, /BUG_STATUS_/);
+});
+
+test("extractBugStatuses applies markers from stdout, preserves un-marked bugs as pending", () => {
+  const stdout = [
+    "Some output…",
+    "BUG_STATUS_bug-1: done — replaced exit-code check with explicit success list.",
+    "ISSUE_WORK_SUMMARY: fixed two bugs",
+  ].join("\n");
+
+  const updated = extractBugStatuses(stdout, SAMPLE_SUBTASKS);
+  assert.equal(updated.length, 2);
+  assert.equal(updated[0].status, "done");
+  assert.equal(updated[0].statusReason, "replaced exit-code check with explicit success list.");
+  assert.equal(updated[1].status, "pending");
+  assert.equal(updated[1].statusReason ?? null, null);
+});
+
+test("extractBugStatuses accepts skipped and deferred statuses with ASCII dash", () => {
+  const stdout = [
+    "BUG_STATUS_bug-1: skipped - intentional no-op for safety gate.",
+    "BUG_STATUS_bug-2: deferred — needs instrumentation in the dispatch loop.",
+  ].join("\n");
+
+  const updated = extractBugStatuses(stdout, SAMPLE_SUBTASKS);
+  assert.equal(updated[0].status, "skipped");
+  assert.equal(updated[0].statusReason, "intentional no-op for safety gate.");
+  assert.equal(updated[1].status, "deferred");
+  assert.match(updated[1].statusReason ?? "", /instrumentation/);
+});
+
+test("extractBugFiles parses comma-separated file lists per bug", () => {
+  const stdout = [
+    "BUG_FILES_bug-1: server/verifier.ts, server/exitCodes.ts",
+    `BUG_FILES_bug-2: "server/preference.ts"`,
+    "BUG_FILES_bug-3: ",
+  ].join("\n");
+
+  const files = extractBugFiles(stdout);
+  assert.deepEqual(files.get("bug-1"), ["server/verifier.ts", "server/exitCodes.ts"]);
+  assert.deepEqual(files.get("bug-2"), ["server/preference.ts"]);
+  assert.equal(files.has("bug-3"), false);
+});
+
+test("parsePorcelainPaths handles modified, added, untracked, and renamed files", () => {
+  const paths = parsePorcelainPaths([
+    "M server/verifier.ts",
+    "?? newfile.ts",
+    "A  server/added.ts",
+    "R  old/path.ts -> new/path.ts",
+  ]);
+  assert.deepEqual(paths, [
+    "server/verifier.ts",
+    "newfile.ts",
+    "server/added.ts",
+    "new/path.ts",
+  ]);
+});
+
+test("extractBugStatuses ignores unknown bug ids and invalid statuses", () => {
+  const stdout = [
+    "BUG_STATUS_bug-99: done — never existed",
+    "BUG_STATUS_bug-1: wat — not a valid status",
+  ].join("\n");
+
+  const updated = extractBugStatuses(stdout, SAMPLE_SUBTASKS);
+  assert.equal(updated[0].status, "pending");
+  assert.equal(updated[1].status, "pending");
+});
+
+type GitCall = { args: string[] };
+
+function buildMultiBugDeps(options: {
+  porcelainStdout: string;
+  agentStdout: string;
+  gitCalls: GitCall[];
+}) {
+  let branch = "";
+  return {
+    deps: {
+      preparePrWorktree: async () => ({
+        repoCacheDir: "/tmp/repo-cache",
+        worktreePath: "/tmp/worktree",
+      }),
+      removePrWorktree: async () => undefined,
+      applyFixesWithAgent: async () => ({
+        code: 0,
+        stdout: options.agentStdout,
+        stderr: "",
+      }),
+      readFile: async () => {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      },
+      runCommand: async (command: string, args: string[]) => {
+        if (command !== "git") {
+          throw new Error(`Unexpected command: ${command}`);
+        }
+        options.gitCalls.push({ args });
+        const key = args.join(" ");
+
+        if (args[2] === "checkout" && args[3] === "-b") {
+          branch = args[4]!;
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args[0] === "config") {
+          return { stdout: args[1] === "--get" ? "set\n" : "", stderr: "", code: 0 };
+        }
+        if (key === "-C /tmp/worktree status --porcelain") {
+          return { stdout: options.porcelainStdout, stderr: "", code: 0 };
+        }
+        if (args[2] === "add" || args[2] === "commit") {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (key === "-C /tmp/worktree rev-parse HEAD") {
+          return { stdout: "abc123\n", stderr: "", code: 0 };
+        }
+        if (key === `-C /tmp/worktree push origin HEAD:${branch}`) {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (key === `-C /tmp/repo-cache fetch origin ${branch}`) {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (key === "-C /tmp/repo-cache rev-parse FETCH_HEAD") {
+          return { stdout: "abc123\n", stderr: "", code: 0 };
+        }
+        throw new Error(`Unexpected git args: ${key}`);
+      },
+    },
+  };
+}
+
+const TWO_BUG_SUBTASKS: IssueSubtask[] = [
+  { id: "bug-1", title: "Exit code inverted", summary: "x", status: "pending" },
+  { id: "bug-2", title: "Preference overrides plan", summary: "x", status: "pending" },
+];
+
+test("runIssueWorkRepair makes one commit per bug when BUG_FILES markers are present", async () => {
+  const gitCalls: GitCall[] = [];
+  const { deps } = buildMultiBugDeps({
+    porcelainStdout: " M server/verifier.ts\n M server/preference.ts\n",
+    agentStdout: [
+      "BUG_STATUS_bug-1: done — fixed exit code logic",
+      "BUG_FILES_bug-1: server/verifier.ts",
+      "BUG_STATUS_bug-2: done — read plan first",
+      "BUG_FILES_bug-2: server/preference.ts",
+      "ISSUE_WORK_SUMMARY: two fixes",
+    ].join("\n"),
+    gitCalls,
+  });
+
+  const result = await runIssueWorkRepair({
+    repo: "acme/widgets",
+    issueNumber: 42,
+    issueTitle: "Verifier bugs",
+    issueUrl: "https://example.test/42",
+    issueBody: "lots of bugs",
+    labels: [],
+    author: "alice",
+    baseBranch: "main",
+    repoCloneUrl: "https://example.test/acme/widgets.git",
+    agent: "claude",
+    subtasks: TWO_BUG_SUBTASKS,
+    dependencies: deps,
+  });
+
+  assert.equal(result.accepted, true);
+  const commitCalls = gitCalls.filter((c) => c.args[2] === "commit");
+  assert.equal(commitCalls.length, 2);
+  assert.match(commitCalls[0].args[4]!, /^fix\(bug-1\): Exit code inverted/);
+  assert.match(commitCalls[1].args[4]!, /^fix\(bug-2\): Preference overrides plan/);
+
+  const addCalls = gitCalls.filter((c) => c.args[2] === "add");
+  assert.equal(addCalls.length, 2);
+  assert.ok(addCalls[0].args.includes("server/verifier.ts"));
+  assert.ok(addCalls[1].args.includes("server/preference.ts"));
+  assert.equal(result.subtasks?.[0].status, "done");
+});
+
+test("runIssueWorkRepair uses first-claim-wins on overlap and catch-all for orphans", async () => {
+  const gitCalls: GitCall[] = [];
+  const { deps } = buildMultiBugDeps({
+    porcelainStdout: " M server/shared.ts\n M server/other.ts\n M server/orphan.ts\n",
+    agentStdout: [
+      "BUG_STATUS_bug-1: done — first claim",
+      "BUG_FILES_bug-1: server/shared.ts, server/other.ts",
+      "BUG_STATUS_bug-2: done — overlapping claim",
+      "BUG_FILES_bug-2: server/shared.ts",
+      "ISSUE_WORK_SUMMARY: overlap test",
+    ].join("\n"),
+    gitCalls,
+  });
+
+  await runIssueWorkRepair({
+    repo: "acme/widgets",
+    issueNumber: 42,
+    issueTitle: "Overlap",
+    issueUrl: "https://example.test/42",
+    issueBody: "x",
+    labels: [],
+    author: "alice",
+    baseBranch: "main",
+    repoCloneUrl: "https://example.test/acme/widgets.git",
+    agent: "claude",
+    subtasks: TWO_BUG_SUBTASKS,
+    dependencies: deps,
+  });
+
+  const commitMessages = gitCalls.filter((c) => c.args[2] === "commit").map((c) => c.args[4]!);
+  // bug-1 takes both shared.ts and other.ts; bug-2's only claim (shared.ts) was taken by bug-1
+  // so bug-2 makes no commit. orphan.ts goes to the catch-all.
+  assert.equal(commitMessages.length, 2);
+  assert.match(commitMessages[0], /^fix\(bug-1\)/);
+  assert.match(commitMessages[1], /remaining changes/);
+
+  const bug1Add = gitCalls.find(
+    (c) => c.args[2] === "add" && c.args.includes("server/shared.ts") && c.args.includes("server/other.ts"),
+  );
+  assert.ok(bug1Add, "bug-1 commit should stage both shared.ts and other.ts");
+});
+
+test("runIssueWorkRepair falls back to single commit when no BUG_FILES markers", async () => {
+  const gitCalls: GitCall[] = [];
+  const { deps } = buildMultiBugDeps({
+    porcelainStdout: " M server/something.ts\n",
+    agentStdout: [
+      "BUG_STATUS_bug-1: done — did it",
+      "BUG_STATUS_bug-2: done — also did it",
+      "ISSUE_WORK_SUMMARY: no files marked",
+    ].join("\n"),
+    gitCalls,
+  });
+
+  const result = await runIssueWorkRepair({
+    repo: "acme/widgets",
+    issueNumber: 42,
+    issueTitle: "No markers",
+    issueUrl: "https://example.test/42",
+    issueBody: "x",
+    labels: [],
+    author: "alice",
+    baseBranch: "main",
+    repoCloneUrl: "https://example.test/acme/widgets.git",
+    agent: "claude",
+    subtasks: TWO_BUG_SUBTASKS,
+    dependencies: deps,
+  });
+
+  assert.equal(result.accepted, true);
+  const commitCalls = gitCalls.filter((c) => c.args[2] === "commit");
+  assert.equal(commitCalls.length, 1);
+  assert.equal(commitCalls[0].args[4], "fix(issue): No markers");
+  const addCalls = gitCalls.filter((c) => c.args[2] === "add");
+  assert.equal(addCalls.length, 1);
+  assert.equal(addCalls[0].args[3], "-A");
 });

--- a/server/issueWorkAgent.ts
+++ b/server/issueWorkAgent.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import type { AgentRuntimeSettings, CodingAgent, CommandResult } from "./agentRunner";
 import { applyFixesWithAgent, runCommand, summarizeCommandResult } from "./agentRunner";
 import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
+import type { IssueSubtask, IssueSubtaskStatus } from "@shared/schema";
 import path from "node:path";
 
 const DEFAULT_GIT_USER_NAME = "PR Babysitter";
@@ -19,6 +20,7 @@ export type IssueWorkPromptInput = {
   agent: CodingAgent;
   agentSettings?: AgentRuntimeSettings;
   contributionGuidance?: string | null;
+  subtasks?: IssueSubtask[];
 };
 
 export type IssueWorkRepairInput = IssueWorkPromptInput & {
@@ -32,6 +34,7 @@ export type IssueWorkRepairResult = {
   summary: string;
   fixBranch: string;
   agentResult: CommandResult;
+  subtasks?: IssueSubtask[];
 };
 
 export type IssueWorkRepairDependencies = {
@@ -87,10 +90,54 @@ export function buildIssueWorkPrompt(input: IssueWorkPromptInput): string {
         "- Use the concise issue-reply and PR-body templates below.",
       ].join("\n");
 
+  const hasSubtasks = (input.subtasks?.length ?? 0) >= 2;
+  const subtaskSection = hasSubtasks
+    ? [
+        "",
+        "This issue describes multiple distinct bugs. Address each one separately:",
+        ...input.subtasks!.map((task, idx) =>
+          [
+            `${idx + 1}. [${task.id}] ${task.title}`,
+            task.summary ? `   ${task.summary}` : null,
+          ].filter((line): line is string => Boolean(line)).join("\n"),
+        ),
+        "",
+        "For each bug above, emit exactly one status line in this format (one line per bug):",
+        "BUG_STATUS_<bug-id>: <done|skipped|deferred> — <one short sentence>",
+        "Use `done` if you applied a fix, `skipped` if intentionally not fixed (explain why), `deferred` if it needs more investigation.",
+        "Example: BUG_STATUS_bug-1: done — replaced exit-code check with explicit success-code list.",
+        "",
+        "For each bug you mark `done`, also emit one line listing the repo-relative files you changed for THAT bug:",
+        "BUG_FILES_<bug-id>: path/one.ts, path/two.ts",
+        "Example: BUG_FILES_bug-1: server/verifier.ts, server/exitCodes.ts",
+        "List each file under the bug that primarily owns it. If a file truly spans multiple bugs, list it only under the first bug — the app will commit files first-claim-wins.",
+      ].join("\n")
+    : "";
+
+  const instructions = hasSubtasks
+    ? [
+        "Instructions:",
+        "1. Inspect each listed bug and the repository to understand the required fixes.",
+        "2. Address each bug with the smallest change that resolves it. Commit separation is handled by the app — leave all edits unstaged.",
+        "3. Run focused verification across all bugs before finishing.",
+        "4. Emit one BUG_STATUS_<bug-id>: ... line for every bug listed above.",
+        "5. Do not run git commit or git push.",
+        "6. Leave the fix branch checked out with your edits in the worktree.",
+      ].join("\n")
+    : [
+        "Instructions:",
+        "1. Inspect the issue and the repository to understand the required fix.",
+        "2. Make the minimal code change needed to resolve the issue.",
+        "3. Run focused verification before finishing.",
+        "4. Do not run git commit or git push.",
+        "5. Leave the fix branch checked out with your edits in the worktree.",
+      ].join("\n");
+
   return [
     "You are fixing a GitHub issue in this repository.",
-    "Make the smallest change that fully addresses the issue.",
-    "Stay within the scope of the issue title and body.",
+    hasSubtasks
+      ? "Address every listed bug below. Stay within the scope of the issue title and body."
+      : "Make the smallest change that fully addresses the issue.\nStay within the scope of the issue title and body.",
     "Run the most relevant verification command(s) you can justify from the repo.",
     "Leave any file edits unstaged and uncommitted. The app will stage, commit, push, and open the PR.",
     "When a repository contribution file exists, follow it exactly.",
@@ -111,6 +158,7 @@ export function buildIssueWorkPrompt(input: IssueWorkPromptInput): string {
     "```",
     "At the end of your response, include exactly one line in this format:",
     "ISSUE_WORK_SUMMARY: <one short sentence describing the fix and verification>",
+    subtaskSection,
     "",
     `Repository: ${input.repo}`,
     `Issue: #${input.issueNumber}`,
@@ -126,13 +174,68 @@ export function buildIssueWorkPrompt(input: IssueWorkPromptInput): string {
     body,
     "```",
     "",
-    "Instructions:",
-    "1. Inspect the issue and the repository to understand the required fix.",
-    "2. Make the minimal code change needed to resolve the issue.",
-    "3. Run focused verification before finishing.",
-    "4. Do not run git commit or git push.",
-    "5. Leave the fix branch checked out with your edits in the worktree.",
+    instructions,
   ].join("\n");
+}
+
+const BUG_STATUS_PATTERN = /^BUG_STATUS_([A-Za-z0-9_-]+):\s*(done|skipped|deferred)\s*(?:[—\-:]\s*(.+))?$/im;
+const BUG_FILES_PATTERN = /^BUG_FILES_([A-Za-z0-9_-]+):\s*(.+)$/i;
+const PORCELAIN_PATH_PATTERN = /^[?ACDMRTU!]{1,2}\s+(.*)$/;
+
+export function extractBugFiles(stdout: string): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = line.trim().match(BUG_FILES_PATTERN);
+    if (!match) continue;
+    const [, id, rawList] = match;
+    const files = rawList
+      .split(",")
+      .map((entry) => entry.trim().replace(/^["'`]|["'`]$/g, ""))
+      .filter(Boolean);
+    if (files.length > 0) {
+      result.set(id, files);
+    }
+  }
+  return result;
+}
+
+export function parsePorcelainPaths(statusLines: string[]): string[] {
+  const paths: string[] = [];
+  for (const line of statusLines) {
+    const match = line.match(PORCELAIN_PATH_PATTERN);
+    if (!match) continue;
+    const rest = match[1];
+    const renameIdx = rest.indexOf(" -> ");
+    paths.push(renameIdx >= 0 ? rest.slice(renameIdx + 4) : rest);
+  }
+  return paths;
+}
+
+export function extractBugStatuses(
+  stdout: string,
+  subtasks: IssueSubtask[],
+): IssueSubtask[] {
+  if (subtasks.length === 0) return subtasks;
+
+  const lines = stdout.split(/\r?\n/);
+  const byId = new Map<string, { status: IssueSubtaskStatus; reason: string | null }>();
+  for (const line of lines) {
+    const match = line.trim().match(BUG_STATUS_PATTERN);
+    if (!match) continue;
+    const [, rawId, rawStatus, rawReason] = match;
+    const status = rawStatus.toLowerCase() as IssueSubtaskStatus;
+    if (status !== "done" && status !== "skipped" && status !== "deferred") continue;
+    byId.set(rawId, {
+      status,
+      reason: rawReason ? rawReason.trim().slice(0, 500) : null,
+    });
+  }
+
+  return subtasks.map((task) => {
+    const update = byId.get(task.id);
+    if (!update) return task;
+    return { ...task, status: update.status, statusReason: update.reason };
+  });
 }
 
 export function extractIssueWorkSummary(stdout: string): string {
@@ -178,6 +281,89 @@ async function readFetchedHeadSha(
   }
 
   return result.stdout.trim();
+}
+
+type CommitFailureReason = { reason: string };
+
+async function commitFiles(
+  deps: IssueWorkRepairDependencies,
+  worktreePath: string,
+  filesToStage: "all" | string[],
+  message: string,
+): Promise<CommitFailureReason | null> {
+  const addArgs = filesToStage === "all"
+    ? ["-C", worktreePath, "add", "-A"]
+    : ["-C", worktreePath, "add", "--", ...filesToStage];
+  const addResult = await deps.runCommand("git", addArgs, { timeoutMs: 30000 });
+  if (addResult.code !== 0) {
+    return { reason: `git add failed: ${addResult.stderr || addResult.stdout}` };
+  }
+
+  const commitResult = await deps.runCommand(
+    "git",
+    ["-C", worktreePath, "commit", "-m", message],
+    { timeoutMs: 60000 },
+  );
+  if (commitResult.code !== 0) {
+    return { reason: `git commit failed: ${commitResult.stderr || commitResult.stdout}` };
+  }
+
+  return null;
+}
+
+async function commitWorktreeChanges(
+  deps: IssueWorkRepairDependencies,
+  params: {
+    worktreePath: string;
+    issueTitle: string;
+    statusLines: string[];
+    subtasks?: IssueSubtask[];
+    agentStdout: string;
+  },
+): Promise<CommitFailureReason | null> {
+  const { worktreePath, issueTitle, statusLines, subtasks, agentStdout } = params;
+  const fallbackMessage = `fix(issue): ${issueTitle}`;
+
+  const doneSubtasks = subtasks?.filter((task) => task.status === "done") ?? [];
+  const bugFiles = doneSubtasks.length > 0 ? extractBugFiles(agentStdout) : new Map<string, string[]>();
+  const hasFileMarkers = Array.from(bugFiles.values()).some((files) => files.length > 0);
+
+  if (doneSubtasks.length === 0 || !hasFileMarkers) {
+    return commitFiles(deps, worktreePath, "all", fallbackMessage);
+  }
+
+  const changedPaths = parsePorcelainPaths(statusLines);
+  const remaining = new Set(changedPaths);
+  let perBugCommits = 0;
+
+  for (const task of doneSubtasks) {
+    const claimed = (bugFiles.get(task.id) ?? []).filter((file) => remaining.has(file));
+    if (claimed.length === 0) continue;
+
+    const message = [
+      `fix(${task.id}): ${task.title}`,
+      task.statusReason ? `\n${task.statusReason}` : "",
+    ].join("");
+
+    const failure = await commitFiles(deps, worktreePath, claimed, message);
+    if (failure) return failure;
+
+    for (const file of claimed) remaining.delete(file);
+    perBugCommits += 1;
+  }
+
+  if (remaining.size > 0) {
+    const catchAllMessage = perBugCommits > 0
+      ? `${fallbackMessage} — remaining changes`
+      : fallbackMessage;
+    return commitFiles(deps, worktreePath, "all", catchAllMessage);
+  }
+
+  if (perBugCommits === 0) {
+    return { reason: "no committable changes after per-bug grouping" };
+  }
+
+  return null;
 }
 
 async function readGitStatusPorcelain(
@@ -295,6 +481,7 @@ export async function runIssueWorkRepair(
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,
+        subtasks: input.subtasks,
       };
     }
 
@@ -306,36 +493,28 @@ export async function runIssueWorkRepair(
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,
+        subtasks: input.subtasks,
       };
     }
 
-    const addResult = await deps.runCommand(
-      "git",
-      ["-C", worktreePath, "add", "-A"],
-      { timeoutMs: 30000 },
-    );
-    if (addResult.code !== 0) {
+    const updatedSubtasks = input.subtasks
+      ? extractBugStatuses(agentResult.stdout, input.subtasks)
+      : undefined;
+    const commitFailure = await commitWorktreeChanges(deps, {
+      worktreePath,
+      issueTitle: input.issueTitle,
+      statusLines,
+      subtasks: updatedSubtasks,
+      agentStdout: agentResult.stdout,
+    });
+    if (commitFailure) {
       return {
         accepted: false,
-        rejectionReason: `git add failed: ${addResult.stderr || addResult.stdout}`,
+        rejectionReason: commitFailure.reason,
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,
-      };
-    }
-
-    const commitResult = await deps.runCommand(
-      "git",
-      ["-C", worktreePath, "commit", "-m", `fix(issue): ${input.issueTitle}`],
-      { timeoutMs: 60000 },
-    );
-    if (commitResult.code !== 0) {
-      return {
-        accepted: false,
-        rejectionReason: `git commit failed: ${commitResult.stderr || commitResult.stdout}`,
-        summary: extractIssueWorkSummary(agentResult.stdout),
-        fixBranch,
-        agentResult,
+        subtasks: updatedSubtasks ?? input.subtasks,
       };
     }
 
@@ -352,6 +531,7 @@ export async function runIssueWorkRepair(
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,
+        subtasks: input.subtasks,
       };
     }
 
@@ -367,6 +547,7 @@ export async function runIssueWorkRepair(
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,
+        subtasks: input.subtasks,
       };
     }
 
@@ -378,6 +559,7 @@ export async function runIssueWorkRepair(
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,
+        subtasks: input.subtasks,
       };
     }
 
@@ -387,6 +569,7 @@ export async function runIssueWorkRepair(
       summary: extractIssueWorkSummary(agentResult.stdout),
       fixBranch,
       agentResult,
+      subtasks: updatedSubtasks,
     };
   } finally {
     await deps.removePrWorktree({

--- a/server/memoryStorage.test.ts
+++ b/server/memoryStorage.test.ts
@@ -175,18 +175,15 @@ describe("MemStorage", () => {
       assert.equal(prs[0].title, "Active");
     });
 
-    it("sorts by addedAt descending", async (t) => {
-      t.mock.timers.enable({ apis: ["Date"], now: new Date("2024-01-01T00:00:00.000Z") });
-
-      await storage.addPR(makePRInput({ title: "First" }));
-      t.mock.timers.tick(100);
-      await storage.addPR(makePRInput({ title: "Second" }));
+    it("sorts by number descending", async () => {
+      await storage.addPR(makePRInput({ title: "First", number: 10 }));
+      await storage.addPR(makePRInput({ title: "Second", number: 20 }));
 
       const prs = await storage.getPRs();
-      // Most recent first
       assert.equal(prs[0].title, "Second");
       assert.equal(prs[1].title, "First");
-      assert.ok(new Date(prs[0].addedAt).getTime() > new Date(prs[1].addedAt).getTime());
+      assert.equal(prs[0].number, 20);
+      assert.equal(prs[1].number, 10);
     });
   });
 

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -9,12 +9,14 @@ import type {
   DeploymentHealingSession,
   DeploymentHealingState,
   IssueEvaluation,
+  IssueSubtaskSet,
   LogEntry,
   FailureFingerprint,
   HealingAttempt,
   HealingAttemptStatus,
   NewPR,
   PR,
+  PRSummary,
   PRQuestion,
   HealingSession,
   HealingSessionState,
@@ -31,6 +33,7 @@ import {
   applyHealingAttemptUpdate,
   applyHealingSessionUpdate,
   applyIssueEvaluationUpdate,
+  applyIssueSubtaskSetUpdate,
   applyPRQuestionUpdate,
   applyPRUpdate,
   applyReleaseRunUpdate,
@@ -44,13 +47,14 @@ import {
   createHealingAttempt,
   createHealingSession,
   createIssueEvaluation,
+  createIssueSubtaskSet,
   createPR,
   createPRQuestion,
   createReleaseRun,
   createSocialChangelog,
   touchAgentRun,
 } from "@shared/models";
-import type { IStorage } from "./storage";
+import type { IStorage, StoredIssueRecord } from "./storage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 
 export class MemStorage implements IStorage {
@@ -74,6 +78,8 @@ export class MemStorage implements IStorage {
   private deploymentHealingSessions: Map<string, DeploymentHealingSession> = new Map();
   private repoSettings: Map<string, WatchedRepo> = new Map();
   private issueEvaluations: Map<string, IssueEvaluation> = new Map();
+  private issueSubtaskSets: Map<string, IssueSubtaskSet> = new Map();
+  private syncedIssues: Map<string, StoredIssueRecord> = new Map();
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -115,20 +121,39 @@ export class MemStorage implements IStorage {
     };
   }
 
+  private toPRSummary(pr: PR): PRSummary {
+    const { feedbackItems: _feedbackItems, ...summary } = pr;
+    return summary;
+  }
+
   async getPRs(): Promise<PR[]> {
     return Array.from(this.prs.values())
       .filter((pr) => pr.status !== "archived")
-      .sort((a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime());
+      .sort((a, b) => b.number - a.number);
   }
 
   async getArchivedPRs(): Promise<PR[]> {
     return Array.from(this.prs.values())
       .filter((pr) => pr.status === "archived")
-      .sort((a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime());
+      .sort((a, b) => b.number - a.number);
   }
 
   async getPR(id: string): Promise<PR | undefined> {
     return this.prs.get(id);
+  }
+
+  async getPRSummaries(): Promise<PRSummary[]> {
+    return Array.from(this.prs.values())
+      .filter((pr) => pr.status !== "archived")
+      .sort((a, b) => b.number - a.number)
+      .map((pr) => this.toPRSummary(pr));
+  }
+
+  async getArchivedPRSummaries(): Promise<PRSummary[]> {
+    return Array.from(this.prs.values())
+      .filter((pr) => pr.status === "archived")
+      .sort((a, b) => b.number - a.number)
+      .map((pr) => this.toPRSummary(pr));
   }
 
   async getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined> {
@@ -294,6 +319,85 @@ export class MemStorage implements IStorage {
       : createIssueEvaluation(evaluation);
     this.issueEvaluations.set(next.targetId, next);
     return { ...next, safetyFlags: [...next.safetyFlags], recommendedLabels: [...next.recommendedLabels] };
+  }
+
+  async getIssueSubtasks(targetId: string): Promise<IssueSubtaskSet | undefined> {
+    const set = this.issueSubtaskSets.get(targetId);
+    return set ? { ...set, subtasks: set.subtasks.map((task) => ({ ...task })) } : undefined;
+  }
+
+  async upsertIssueSubtasks(
+    input: Omit<IssueSubtaskSet, "analyzedAt" | "updatedAt"> & { analyzedAt?: string },
+  ): Promise<IssueSubtaskSet> {
+    const existing = this.issueSubtaskSets.get(input.targetId);
+    const next = existing
+      ? applyIssueSubtaskSetUpdate(existing, { ...input, analyzedAt: input.analyzedAt ?? existing.analyzedAt })
+      : createIssueSubtaskSet(input);
+    this.issueSubtaskSets.set(next.targetId, next);
+    return { ...next, subtasks: next.subtasks.map((task) => ({ ...task })) };
+  }
+
+  async markRepoIssuesStale(repo: string): Promise<void> {
+    for (const [key, record] of Array.from(this.syncedIssues.entries())) {
+      if (record.repo !== repo) continue;
+      this.syncedIssues.set(key, { ...record, isOpen: false });
+    }
+  }
+
+  async upsertSyncedIssues(repo: string, issues: StoredIssueRecord["payload"][], seenAt: string): Promise<void> {
+    for (const issue of issues) {
+      const key = `${repo}#${issue.number}`;
+      const existing = this.syncedIssues.get(key);
+      if (existing?.isWorked) {
+        continue;
+      }
+      this.syncedIssues.set(key, {
+        repo,
+        number: issue.number,
+        payload: { ...issue },
+        isOpen: true,
+        isWorked: existing?.isWorked ?? false,
+        firstSeenAt: existing?.firstSeenAt ?? seenAt,
+        lastSeenAt: seenAt,
+      });
+    }
+  }
+
+  async listSyncedIssues(input: { repos: string[]; limit: number; offset: number; includeWorked?: boolean }): Promise<{ items: StoredIssueRecord[]; hasMore: boolean }> {
+    const repos = new Set(input.repos.map((repo) => repo.toLowerCase()));
+    const includeWorked = input.includeWorked ?? false;
+    const all = Array.from(this.syncedIssues.values())
+      .filter((record) => record.isOpen && repos.has(record.repo.toLowerCase()) && (includeWorked || !record.isWorked))
+      .sort((a, b) => b.number - a.number);
+    const items = all.slice(input.offset, input.offset + input.limit).map((record) => structuredClone(record));
+    return { items, hasMore: input.offset + items.length < all.length };
+  }
+
+  async listSyncedIssueCounts(input: { repos: string[]; includeWorked?: boolean }): Promise<{ totalCount: number; repoTotals: Record<string, number> }> {
+    const repos = new Set(input.repos.map((repo) => repo.toLowerCase()));
+    const includeWorked = input.includeWorked ?? false;
+    const repoTotals: Record<string, number> = {};
+    let totalCount = 0;
+    for (const record of Array.from(this.syncedIssues.values())) {
+      if (!record.isOpen) continue;
+      if (!repos.has(record.repo.toLowerCase())) continue;
+      if (!includeWorked && record.isWorked) continue;
+      repoTotals[record.repo] = (repoTotals[record.repo] ?? 0) + 1;
+      totalCount += 1;
+    }
+    return { totalCount, repoTotals };
+  }
+
+  async getSyncedIssue(repo: string, number: number): Promise<StoredIssueRecord | undefined> {
+    const record = this.syncedIssues.get(`${repo}#${number}`);
+    return record ? structuredClone(record) : undefined;
+  }
+
+  async markSyncedIssueWorked(repo: string, number: number): Promise<void> {
+    const key = `${repo}#${number}`;
+    const existing = this.syncedIssues.get(key);
+    if (!existing) return;
+    this.syncedIssues.set(key, { ...existing, isWorked: true });
   }
 
   private syncRepoSettings(): void {

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { Config } from "@shared/schema";
 import { buildOctokit } from "./github";
-import { clearRateLimited, getRateLimitState } from "./rateLimitState";
+import { clearRateLimitStateForTests, clearRateLimited, getRateLimitState } from "./rateLimitState";
 
 const config: Config = {
   githubTokens: [],
@@ -31,7 +31,7 @@ const config: Config = {
   ignoredBots: [],
 };
 
-test.beforeEach(() => clearRateLimited());
+test.beforeEach(() => clearRateLimitStateForTests());
 
 test("octokit hook spaces concurrent REST requests under GitHub secondary limits", async () => {
   const requestStartedAt: number[] = [];

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -1,13 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { clearRateLimited, getRateLimitState, markRateLimited } from "./rateLimitState";
+import { clearRateLimitStateForTests, clearRateLimited, getRateLimitState, markRateLimited } from "./rateLimitState";
 
-test.beforeEach(() => clearRateLimited());
+test.beforeEach(() => clearRateLimitStateForTests());
 
 test("getRateLimitState reports unlimited by default", () => {
   const state = getRateLimitState();
   assert.equal(state.limited, false);
   assert.equal(state.resetAt, null);
+  assert.equal(state.recentlyLimited, false);
+  assert.equal(state.lastLimitedAt, null);
 });
 
 test("markRateLimited with unix seconds sets a future reset", () => {
@@ -18,6 +20,8 @@ test("markRateLimited with unix seconds sets a future reset", () => {
   assert.equal(state.limited, true);
   assert.ok(state.resetAt);
   assert.equal(state.resetAt!.getTime(), reset * 1000);
+  assert.equal(state.recentlyLimited, true);
+  assert.ok(state.lastLimitedAt);
 });
 
 test("markRateLimited with no reset falls back to a 60s gate", () => {
@@ -31,6 +35,7 @@ test("markRateLimited with no reset falls back to a 60s gate", () => {
   // Reset should be roughly +60s from when we marked it.
   assert.ok(state.resetAt!.getTime() >= before + 59_500);
   assert.ok(state.resetAt!.getTime() <= after + 60_500);
+  assert.equal(state.recentlyLimited, true);
 });
 
 test("markRateLimited extends but never shortens an active gate", () => {
@@ -47,4 +52,5 @@ test("clearRateLimited resets the gate", () => {
   markRateLimited(Math.floor(Date.now() / 1000) + 600);
   clearRateLimited();
   assert.equal(getRateLimitState().limited, false);
+  assert.equal(getRateLimitState().recentlyLimited, true);
 });

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -5,9 +5,13 @@ const log = childLogger("rateLimit");
 export type RateLimitSnapshot = {
   limited: boolean;
   resetAt: Date | null;
+  recentlyLimited: boolean;
+  lastLimitedAt: Date | null;
 };
 
 let resetAt: Date | null = null;
+let lastLimitedAt: Date | null = null;
+const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
 export function markRateLimited(reset: Date | number | undefined): Date {
   let parsed: Date | null = null;
@@ -32,19 +36,22 @@ export function markRateLimited(reset: Date | number | undefined): Date {
       "GitHub rate limit reached; gating further requests until reset",
     );
   }
+  lastLimitedAt = new Date();
 
   return resetAt;
 }
 
 export function getRateLimitState(): RateLimitSnapshot {
+  const now = Date.now();
+  const recentlyLimited = lastLimitedAt !== null && (now - lastLimitedAt.getTime()) <= RECENT_RATE_LIMIT_WINDOW_MS;
   if (!resetAt) {
-    return { limited: false, resetAt: null };
+    return { limited: false, resetAt: null, recentlyLimited, lastLimitedAt };
   }
-  if (resetAt.getTime() <= Date.now()) {
+  if (resetAt.getTime() <= now) {
     resetAt = null;
-    return { limited: false, resetAt: null };
+    return { limited: false, resetAt: null, recentlyLimited, lastLimitedAt };
   }
-  return { limited: true, resetAt };
+  return { limited: true, resetAt, recentlyLimited, lastLimitedAt };
 }
 
 export function clearRateLimited(): void {
@@ -52,4 +59,9 @@ export function clearRateLimited(): void {
     log.info({}, "GitHub rate limit cleared by a successful request");
     resetAt = null;
   }
+}
+
+export function clearRateLimitStateForTests(): void {
+  resetAt = null;
+  lastLimitedAt = null;
 }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -229,9 +229,16 @@ test("GET /api/github-rate-limit reports the current reset time", async () => {
     const response = await fetch(`${harness.baseUrl}/api/github-rate-limit`);
     assert.equal(response.status, 200);
 
-    const body = await response.json() as { limited: boolean; resetAt: string | null };
+    const body = await response.json() as {
+      limited: boolean;
+      resetAt: string | null;
+      recentlyLimited: boolean;
+      lastLimitedAt: string | null;
+    };
     assert.equal(body.limited, true);
     assert.equal(body.resetAt, resetAt.toISOString());
+    assert.equal(body.recentlyLimited, true);
+    assert.ok(body.lastLimitedAt);
   } finally {
     clearRateLimited();
     await harness.close();
@@ -504,7 +511,7 @@ test("POST /api/prs/:id/feedback/:feedbackId/retry reports drain reason and does
   }
 });
 
-test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () => {
+test("POST /api/repos/sync runs immediate sync without queueing sync_watched_repos", async () => {
   const harness = await createHarness();
 
   try {
@@ -520,9 +527,7 @@ test("POST /api/repos/sync enqueues a durable sync_watched_repos job", async () 
       kind: "sync_watched_repos",
       status: "queued",
     });
-    assert.equal(jobs.length, 1);
-    assert.equal(jobs[0].targetId, "runtime:1");
-    assert.equal(jobs[0].dedupeKey, "sync_watched_repos");
+    assert.equal(jobs.length, 0);
   } finally {
     await harness.close();
   }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -241,6 +241,19 @@ export async function registerRoutes(
   dependencies: RouteDependencies = {},
 ): Promise<Server> {
   const runtime = dependencies.runtime ?? createAppRuntime(dependencies);
+  const PR_DETAIL_CACHE_TTL_MS = 2_000;
+  const PR_DETAIL_CACHE_MAX_ENTRIES = 200;
+  const prDetailCache = new Map<string, {
+    expiresAt: number;
+    value: NonNullable<Awaited<ReturnType<AppRuntime["getPR"]>>>;
+  }>();
+  const invalidatePrDetailCache = (prId?: string): void => {
+    if (prId) {
+      prDetailCache.delete(prId);
+      return;
+    }
+    prDetailCache.clear();
+  };
   const appUpdateChecker = dependencies.appUpdateChecker ?? createAppUpdateChecker();
   const testGitHubTokensFn = dependencies.testGitHubTokensFn ?? testGitHubTokens;
   await runtime.start();
@@ -258,6 +271,8 @@ export async function registerRoutes(
     res.json({
       limited: state.limited,
       resetAt: state.resetAt ? state.resetAt.toISOString() : null,
+      recentlyLimited: state.recentlyLimited,
+      lastLimitedAt: state.lastLimitedAt ? state.lastLimitedAt.toISOString() : null,
     });
   });
 
@@ -426,7 +441,9 @@ export async function registerRoutes(
 
   app.post("/api/repos/sync", async (_req, res) => {
     try {
-      res.json(await runtime.syncRepos());
+      const result = await runtime.syncRepos();
+      invalidatePrDetailCache();
+      res.json(result);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -450,9 +467,30 @@ export async function registerRoutes(
   });
 
   app.get("/api/prs/:id", async (req, res) => {
+    const now = Date.now();
+    const cached = prDetailCache.get(req.params.id);
+    if (cached && cached.expiresAt > now) {
+      return res.json(cached.value);
+    }
+
     const pr = await runtime.getPR(req.params.id);
     if (!pr) {
       return res.status(404).json({ error: "PR not found" });
+    }
+
+    prDetailCache.set(req.params.id, {
+      value: pr,
+      expiresAt: now + PR_DETAIL_CACHE_TTL_MS,
+    });
+    if (prDetailCache.size > PR_DETAIL_CACHE_MAX_ENTRIES) {
+      for (const [id, entry] of Array.from(prDetailCache.entries())) {
+        if (entry.expiresAt <= now || prDetailCache.size > PR_DETAIL_CACHE_MAX_ENTRIES) {
+          prDetailCache.delete(id);
+        }
+        if (prDetailCache.size <= PR_DETAIL_CACHE_MAX_ENTRIES) {
+          break;
+        }
+      }
     }
 
     res.json(pr);
@@ -460,7 +498,9 @@ export async function registerRoutes(
 
   app.post("/api/prs", async (req, res) => {
     try {
-      res.status(201).json(await runtime.addPR(req.body?.url));
+      const pr = await runtime.addPR(req.body?.url);
+      invalidatePrDetailCache(pr.id);
+      res.status(201).json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -468,7 +508,9 @@ export async function registerRoutes(
 
   app.delete("/api/prs/:id", async (req, res) => {
     try {
-      res.json(await runtime.removePR(req.params.id));
+      const result = await runtime.removePR(req.params.id);
+      invalidatePrDetailCache(req.params.id);
+      res.json(result);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -477,7 +519,9 @@ export async function registerRoutes(
   app.patch("/api/prs/:id/watch", async (req, res) => {
     try {
       const { enabled } = z.object({ enabled: z.boolean() }).parse(req.body);
-      res.json(await runtime.setPRWatchEnabled(req.params.id, enabled));
+      const pr = await runtime.setPRWatchEnabled(req.params.id, enabled);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -485,7 +529,9 @@ export async function registerRoutes(
 
   app.post("/api/prs/:id/fetch", async (req, res) => {
     try {
-      res.json(await runtime.fetchPRFeedback(req.params.id));
+      const pr = await runtime.fetchPRFeedback(req.params.id);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -493,7 +539,9 @@ export async function registerRoutes(
 
   app.post("/api/prs/:id/triage", async (req, res) => {
     try {
-      res.json(await runtime.triagePR(req.params.id));
+      const pr = await runtime.triagePR(req.params.id);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -501,7 +549,9 @@ export async function registerRoutes(
 
   app.post("/api/prs/:id/apply", async (req, res) => {
     try {
-      res.json(await runtime.applyPR(req.params.id));
+      const pr = await runtime.applyPR(req.params.id);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -509,7 +559,9 @@ export async function registerRoutes(
 
   app.post("/api/prs/:id/babysit", async (req, res) => {
     try {
-      res.json(await runtime.babysitPR(req.params.id));
+      const pr = await runtime.babysitPR(req.params.id);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -521,7 +573,9 @@ export async function registerRoutes(
         decision: z.enum(["accept", "reject", "flag"]),
       }).parse(req.body);
 
-      res.json(await runtime.setFeedbackDecision(req.params.id, req.params.feedbackId, decision));
+      const pr = await runtime.setFeedbackDecision(req.params.id, req.params.feedbackId, decision);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -529,7 +583,9 @@ export async function registerRoutes(
 
   app.post("/api/prs/:id/feedback/:feedbackId/retry", async (req, res) => {
     try {
-      res.json(await runtime.retryFeedback(req.params.id, req.params.feedbackId));
+      const pr = await runtime.retryFeedback(req.params.id, req.params.feedbackId);
+      invalidatePrDetailCache(req.params.id);
+      res.json(pr);
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }
@@ -641,6 +697,19 @@ export async function registerRoutes(
       }).parse(req.body);
 
       res.status(201).json(await runtime.evaluateIssue(payload.repo, payload.number));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
+  app.post("/api/issues/verify", async (req, res) => {
+    try {
+      const payload = z.object({
+        repo: z.string().min(1),
+        number: z.number().int().positive(),
+      }).parse(req.body);
+
+      res.status(201).json(await runtime.verifyIssueWork(payload.repo, payload.number));
     } catch (error: unknown) {
       sendAppAwareError(res, error);
     }

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -13,6 +13,8 @@ import type {
   DeploymentHealingSession,
   DeploymentHealingState,
   IssueEvaluation,
+  IssueSubtask,
+  IssueSubtaskSet,
   DeploymentPlatform,
   FeedbackItem,
   FailureFingerprint,
@@ -21,6 +23,7 @@ import type {
   HealingAttemptStatus,
   NewPR,
   PR,
+  PRSummary,
   PRQuestion,
   HealingSession,
   HealingSessionState,
@@ -37,6 +40,7 @@ import {
   applyHealingAttemptUpdate,
   applyHealingSessionUpdate,
   applyIssueEvaluationUpdate,
+  applyIssueSubtaskSetUpdate,
   applyPRQuestionUpdate,
   applyPRUpdate,
   applyReleaseRunUpdate,
@@ -50,12 +54,13 @@ import {
   createHealingAttempt,
   createHealingSession,
   createIssueEvaluation,
+  createIssueSubtaskSet,
   createPR,
   createPRQuestion,
   createReleaseRun,
   createSocialChangelog,
 } from "@shared/models";
-import type { IStorage } from "./storage";
+import type { IStorage, StoredIssueRecord } from "./storage";
 import { getCodeFactoryPaths } from "./paths";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 import { appendLogFile } from "./logFiles";
@@ -273,6 +278,26 @@ type IssueEvaluationRow = {
   marker_comment_id: number | null;
   created_at: string;
   updated_at: string;
+};
+
+type IssueSubtaskSetRow = {
+  target_id: string;
+  repo: string;
+  issue_number: number;
+  subtasks_json: string;
+  analyzed_body_hash: string;
+  analyzed_at: string;
+  updated_at: string;
+};
+
+type SyncedIssueRow = {
+  repo: string;
+  issue_number: number;
+  payload_json: string;
+  is_open: number;
+  is_worked: number;
+  first_seen_at: string;
+  last_seen_at: string;
 };
 
 type SocialChangelogRow = {
@@ -693,6 +718,27 @@ export class SqliteStorage implements IStorage {
         updated_at TEXT NOT NULL
       );
 
+      CREATE TABLE IF NOT EXISTS synced_issues (
+        repo TEXT NOT NULL,
+        issue_number INTEGER NOT NULL,
+        payload_json TEXT NOT NULL,
+        is_open INTEGER NOT NULL DEFAULT 1,
+        is_worked INTEGER NOT NULL DEFAULT 0,
+        first_seen_at TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL,
+        PRIMARY KEY(repo, issue_number)
+      );
+
+      CREATE TABLE IF NOT EXISTS issue_subtasks (
+        target_id TEXT PRIMARY KEY,
+        repo TEXT NOT NULL,
+        issue_number INTEGER NOT NULL,
+        subtasks_json TEXT NOT NULL,
+        analyzed_body_hash TEXT NOT NULL,
+        analyzed_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS pr_questions (
         id TEXT PRIMARY KEY,
         pr_id TEXT NOT NULL,
@@ -841,6 +887,7 @@ export class SqliteStorage implements IStorage {
       CREATE INDEX IF NOT EXISTS idx_background_jobs_kind_status ON background_jobs(kind, status);
       CREATE UNIQUE INDEX IF NOT EXISTS idx_background_jobs_dedupe_active ON background_jobs(dedupe_key) WHERE status IN ('queued', 'leased');
       CREATE INDEX IF NOT EXISTS idx_issue_evaluations_repo_issue ON issue_evaluations(repo, issue_number);
+      CREATE INDEX IF NOT EXISTS idx_synced_issues_open_repo_updated ON synced_issues(is_open, repo, last_seen_at);
       CREATE INDEX IF NOT EXISTS idx_pr_questions_pr_id ON pr_questions(pr_id);
       CREATE INDEX IF NOT EXISTS idx_social_changelogs_date ON social_changelogs(date);
       CREATE INDEX IF NOT EXISTS idx_healing_sessions_pr_id ON healing_sessions(pr_id);
@@ -904,6 +951,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "max_concurrent_issue_evaluations", "INTEGER NOT NULL DEFAULT 2");
     this.ensureColumn("config", "max_concurrent_issue_work", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("config", "priority_issue_authors_json", "TEXT NOT NULL DEFAULT '[]'");
+    this.ensureColumn("synced_issues", "is_worked", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
     this.ensureColumn("prs", "watch_enabled", "INTEGER NOT NULL DEFAULT 1");
     this.ensureColumn("prs", "docs_assessment_json", "TEXT");
@@ -1228,6 +1276,31 @@ export class SqliteStorage implements IStorage {
     };
   }
 
+  private parsePRSummaryRow(row: PRRow): PRSummary {
+    return {
+      id: row.id,
+      number: row.number,
+      title: row.title,
+      repo: row.repo,
+      branch: row.branch,
+      author: row.author,
+      url: row.url,
+      status: row.status,
+      accepted: row.accepted,
+      rejected: row.rejected,
+      flagged: row.flagged,
+      testsPassed: row.tests_passed === null ? null : Boolean(row.tests_passed),
+      lintPassed: row.lint_passed === null ? null : Boolean(row.lint_passed),
+      lastChecked: row.last_checked,
+      lastSyncAttemptedAt: row.last_sync_attempted_at ?? null,
+      lastSyncSucceededAt: row.last_sync_succeeded_at ?? null,
+      lastSyncError: row.last_sync_error ?? null,
+      watchEnabled: Boolean(row.watch_enabled),
+      docsAssessment: this.parseDocsAssessment(row.docs_assessment_json),
+      addedAt: row.added_at,
+    };
+  }
+
   private parseDocsAssessment(raw: string | null): PR["docsAssessment"] {
     if (!raw) {
       return null;
@@ -1306,6 +1379,39 @@ export class SqliteStorage implements IStorage {
       markerCommentId: row.marker_comment_id,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+    };
+  }
+
+  private parseIssueSubtaskSetRow(row: IssueSubtaskSetRow): IssueSubtaskSet {
+    let subtasks: IssueSubtask[] = [];
+    try {
+      const parsed = JSON.parse(row.subtasks_json);
+      if (Array.isArray(parsed)) {
+        subtasks = parsed as IssueSubtask[];
+      }
+    } catch {
+      subtasks = [];
+    }
+    return {
+      targetId: row.target_id,
+      repo: row.repo,
+      issueNumber: row.issue_number,
+      subtasks,
+      analyzedBodyHash: row.analyzed_body_hash,
+      analyzedAt: row.analyzed_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private parseSyncedIssueRow(row: SyncedIssueRow): StoredIssueRecord {
+    return {
+      repo: row.repo,
+      number: row.issue_number,
+      payload: JSON.parse(row.payload_json) as StoredIssueRecord["payload"],
+      isOpen: row.is_open === 1,
+      isWorked: row.is_worked === 1,
+      firstSeenAt: row.first_seen_at,
+      lastSeenAt: row.last_seen_at,
     };
   }
 
@@ -1515,7 +1621,7 @@ export class SqliteStorage implements IStorage {
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
-      ORDER BY datetime(added_at) DESC
+      ORDER BY number DESC
     `);
 
     const itemsByPrId = this.getFeedbackItemsForPRIds(rows.map((row) => row.id));
@@ -1529,12 +1635,36 @@ export class SqliteStorage implements IStorage {
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
-      ORDER BY datetime(added_at) DESC
+      ORDER BY number DESC
     `);
 
     const itemsByPrId = this.getFeedbackItemsForPRIds(rows.map((row) => row.id));
 
     return rows.map((row) => this.parsePRRow(row, itemsByPrId.get(row.id) || []));
+  }
+
+  async getPRSummaries(): Promise<PRSummary[]> {
+    const rows = this.all<PRRow>(`
+      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+      FROM prs
+      WHERE status != 'archived'
+      ORDER BY number DESC
+    `);
+
+    return rows.map((row) => this.parsePRSummaryRow(row));
+  }
+
+  async getArchivedPRSummaries(): Promise<PRSummary[]> {
+    const rows = this.all<PRRow>(`
+      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+      FROM prs
+      WHERE status = 'archived'
+      ORDER BY number DESC
+    `);
+
+    return rows.map((row) => this.parsePRSummaryRow(row));
   }
 
   async getPR(id: string): Promise<PR | undefined> {
@@ -1970,6 +2100,152 @@ export class SqliteStorage implements IStorage {
     });
 
     return next;
+  }
+
+  async getIssueSubtasks(targetId: string): Promise<IssueSubtaskSet | undefined> {
+    const row = this.get<IssueSubtaskSetRow>(`
+      SELECT target_id, repo, issue_number, subtasks_json,
+             analyzed_body_hash, analyzed_at, updated_at
+      FROM issue_subtasks
+      WHERE target_id = ?
+    `, targetId);
+
+    return row ? this.parseIssueSubtaskSetRow(row) : undefined;
+  }
+
+  async upsertIssueSubtasks(
+    input: Omit<IssueSubtaskSet, "analyzedAt" | "updatedAt"> & { analyzedAt?: string },
+  ): Promise<IssueSubtaskSet> {
+    const existing = await this.getIssueSubtasks(input.targetId);
+    const next = existing
+      ? applyIssueSubtaskSetUpdate(existing, { ...input, analyzedAt: input.analyzedAt ?? existing.analyzedAt })
+      : createIssueSubtaskSet(input);
+
+    this.withWriteTransaction(() => {
+      this.run(
+        `
+          INSERT INTO issue_subtasks (
+            target_id, repo, issue_number, subtasks_json,
+            analyzed_body_hash, analyzed_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(target_id) DO UPDATE SET
+            repo = excluded.repo,
+            issue_number = excluded.issue_number,
+            subtasks_json = excluded.subtasks_json,
+            analyzed_body_hash = excluded.analyzed_body_hash,
+            analyzed_at = excluded.analyzed_at,
+            updated_at = excluded.updated_at
+        `,
+        next.targetId,
+        next.repo,
+        next.issueNumber,
+        JSON.stringify(next.subtasks),
+        next.analyzedBodyHash,
+        next.analyzedAt,
+        next.updatedAt,
+      );
+    });
+
+    return next;
+  }
+
+  async markRepoIssuesStale(repo: string): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run("UPDATE synced_issues SET is_open = 0 WHERE repo = ?", repo);
+    });
+  }
+
+  async upsertSyncedIssues(repo: string, issues: StoredIssueRecord["payload"][], seenAt: string): Promise<void> {
+    this.withWriteTransaction(() => {
+      for (const issue of issues) {
+        this.run(
+          `
+            INSERT INTO synced_issues (repo, issue_number, payload_json, is_open, is_worked, first_seen_at, last_seen_at)
+            VALUES (?, ?, ?, 1, 0, ?, ?)
+            ON CONFLICT(repo, issue_number) DO UPDATE SET
+              payload_json = excluded.payload_json,
+              is_open = 1,
+              last_seen_at = excluded.last_seen_at
+            WHERE synced_issues.is_worked = 0
+          `,
+          repo,
+          issue.number,
+          JSON.stringify(issue),
+          seenAt,
+          seenAt,
+        );
+      }
+    });
+  }
+
+  async listSyncedIssues(input: { repos: string[]; limit: number; offset: number; includeWorked?: boolean }): Promise<{ items: StoredIssueRecord[]; hasMore: boolean }> {
+    if (input.repos.length === 0) {
+      return { items: [], hasMore: false };
+    }
+    const placeholders = input.repos.map(() => "?").join(", ");
+    const includeWorked = input.includeWorked ?? false;
+    const rows = this.all<SyncedIssueRow>(
+      `
+        SELECT repo, issue_number, payload_json, is_open, is_worked, first_seen_at, last_seen_at
+        FROM synced_issues
+        WHERE is_open = 1 AND repo IN (${placeholders}) AND (? = 1 OR is_worked = 0)
+        ORDER BY issue_number DESC
+        LIMIT ? OFFSET ?
+      `,
+      ...input.repos,
+      includeWorked ? 1 : 0,
+      input.limit + 1,
+      input.offset,
+    );
+    const hasMore = rows.length > input.limit;
+    const items = rows.slice(0, input.limit).map((row) => this.parseSyncedIssueRow(row));
+    return { items, hasMore };
+  }
+
+  async listSyncedIssueCounts(input: { repos: string[]; includeWorked?: boolean }): Promise<{ totalCount: number; repoTotals: Record<string, number> }> {
+    if (input.repos.length === 0) {
+      return { totalCount: 0, repoTotals: {} };
+    }
+    const placeholders = input.repos.map(() => "?").join(", ");
+    const includeWorked = input.includeWorked ?? false;
+    const rows = this.all<{ repo: string; count: number }>(
+      `
+        SELECT repo, COUNT(*) as count
+        FROM synced_issues
+        WHERE is_open = 1 AND repo IN (${placeholders}) AND (? = 1 OR is_worked = 0)
+        GROUP BY repo
+      `,
+      ...input.repos,
+      includeWorked ? 1 : 0,
+    );
+    const repoTotals: Record<string, number> = {};
+    let totalCount = 0;
+    for (const row of rows) {
+      const count = Number(row.count) || 0;
+      repoTotals[row.repo] = count;
+      totalCount += count;
+    }
+    return { totalCount, repoTotals };
+  }
+
+  async getSyncedIssue(repo: string, number: number): Promise<StoredIssueRecord | undefined> {
+    const row = this.get<SyncedIssueRow>(
+      `
+        SELECT repo, issue_number, payload_json, is_open, is_worked, first_seen_at, last_seen_at
+        FROM synced_issues
+        WHERE repo = ? AND issue_number = ? AND is_open = 1
+      `,
+      repo,
+      number,
+    );
+    return row ? this.parseSyncedIssueRow(row) : undefined;
+  }
+
+  async markSyncedIssueWorked(repo: string, number: number): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run("UPDATE synced_issues SET is_worked = 1 WHERE repo = ? AND issue_number = ?", repo, number);
+    });
   }
 
   async getHealingSession(id: string): Promise<HealingSession | undefined> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9,6 +9,7 @@ import type {
   DeploymentHealingSession,
   DeploymentHealingState,
   IssueEvaluation,
+  IssueSubtaskSet,
   LogEntry,
   FailureFingerprint,
   HealingAttempt,
@@ -17,6 +18,7 @@ import type {
   HealingSessionState,
   NewPR,
   PR,
+  PRSummary,
   PRQuestion,
   ReleaseRun,
   ReleaseRunStatus,
@@ -27,10 +29,36 @@ import type {
 export { MemStorage } from "./memoryStorage";
 import { SqliteStorage } from "./sqliteStorage";
 
+export type StoredIssueRecord = {
+  repo: string;
+  number: number;
+  payload: {
+    number: number;
+    title: string;
+    body: string | null;
+    bodyHtml: string | null;
+    url: string;
+    repoFullName: string;
+    repoCloneUrl: string;
+    author: string;
+    labels: string[];
+    assignees: string[];
+    comments: number;
+    createdAt: string;
+    updatedAt: string;
+  };
+  isOpen: boolean;
+  isWorked: boolean;
+  firstSeenAt: string;
+  lastSeenAt: string;
+};
+
 export interface IStorage {
   // PRs
   getPRs(): Promise<PR[]>;
   getArchivedPRs(): Promise<PR[]>;
+  getPRSummaries(): Promise<PRSummary[]>;
+  getArchivedPRSummaries(): Promise<PRSummary[]>;
   getPR(id: string): Promise<PR | undefined>;
   getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined>;
   addPR(pr: NewPR): Promise<PR>;
@@ -75,6 +103,14 @@ export interface IStorage {
   updateRepoSettings(repo: string, updates: Partial<Omit<WatchedRepo, "repo">>): Promise<WatchedRepo>;
   getIssueEvaluation(targetId: string): Promise<IssueEvaluation | undefined>;
   upsertIssueEvaluation(evaluation: Omit<IssueEvaluation, "createdAt" | "updatedAt">): Promise<IssueEvaluation>;
+  getIssueSubtasks(targetId: string): Promise<IssueSubtaskSet | undefined>;
+  upsertIssueSubtasks(set: Omit<IssueSubtaskSet, "analyzedAt" | "updatedAt"> & { analyzedAt?: string }): Promise<IssueSubtaskSet>;
+  markRepoIssuesStale(repo: string): Promise<void>;
+  upsertSyncedIssues(repo: string, issues: StoredIssueRecord["payload"][], seenAt: string): Promise<void>;
+  listSyncedIssues(input: { repos: string[]; limit: number; offset: number; includeWorked?: boolean }): Promise<{ items: StoredIssueRecord[]; hasMore: boolean }>;
+  listSyncedIssueCounts(input: { repos: string[]; includeWorked?: boolean }): Promise<{ totalCount: number; repoTotals: Record<string, number> }>;
+  getSyncedIssue(repo: string, number: number): Promise<StoredIssueRecord | undefined>;
+  markSyncedIssueWorked(repo: string, number: number): Promise<void>;
 
   // CI healing
   getHealingSession(id: string): Promise<HealingSession | undefined>;

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -5,6 +5,7 @@ import {
   backgroundJobSchema,
   issueSchema,
   issueEvaluationSchema,
+  issueSubtaskSetSchema,
   configSchema,
   deploymentHealingSessionSchema,
   feedbackItemSchema,
@@ -23,6 +24,7 @@ import type {
   BackgroundJob,
   Issue,
   IssueEvaluation,
+  IssueSubtaskSet,
   Config,
   CheckSnapshot,
   DeploymentHealingSession,
@@ -198,6 +200,29 @@ export function applyIssueEvaluationUpdate(
     ...updates,
     targetId: existing.targetId,
     createdAt: existing.createdAt,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function createIssueSubtaskSet(
+  data: Omit<IssueSubtaskSet, "analyzedAt" | "updatedAt"> & { analyzedAt?: string },
+): IssueSubtaskSet {
+  const now = new Date().toISOString();
+  return issueSubtaskSetSchema.parse({
+    ...data,
+    analyzedAt: data.analyzedAt ?? now,
+    updatedAt: now,
+  });
+}
+
+export function applyIssueSubtaskSetUpdate(
+  existing: IssueSubtaskSet,
+  updates: Partial<IssueSubtaskSet>,
+): IssueSubtaskSet {
+  return issueSubtaskSetSchema.parse({
+    ...existing,
+    ...updates,
+    targetId: existing.targetId,
     updatedAt: new Date().toISOString(),
   });
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -80,6 +80,11 @@ export const prSchema = z.object({
 });
 export type PR = z.infer<typeof prSchema>;
 
+export const prSummarySchema = prSchema.omit({
+  feedbackItems: true,
+});
+export type PRSummary = z.infer<typeof prSummarySchema>;
+
 export const newPRSchema = prSchema.omit({
   id: true,
   addedAt: true,
@@ -135,6 +140,7 @@ export const backgroundJobKindEnum = z.enum([
   "process_release_run",
   "answer_pr_question",
   "evaluate_issue",
+  "verify_issue",
   "work_issue",
   "generate_social_changelog",
   "heal_deployment",
@@ -209,6 +215,18 @@ export type IssueWorkStage = z.infer<typeof issueWorkStageEnum>;
 export const issueEvaluationStatusEnum = z.enum(["approved", "blocked", "needs_review"]);
 export type IssueEvaluationStatus = z.infer<typeof issueEvaluationStatusEnum>;
 
+export const issueSubtaskStatusEnum = z.enum(["pending", "done", "skipped", "deferred"]);
+export type IssueSubtaskStatus = z.infer<typeof issueSubtaskStatusEnum>;
+
+export const issueSubtaskSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  summary: z.string(),
+  status: issueSubtaskStatusEnum,
+  statusReason: z.string().nullable().optional(),
+});
+export type IssueSubtask = z.infer<typeof issueSubtaskSchema>;
+
 export const issueSchema = z.object({
   id: z.string(),
   number: z.number(),
@@ -247,6 +265,7 @@ export const issueSchema = z.object({
   evaluationSafetyFlags: z.array(z.string()).optional(),
   evaluationRecommendedLabels: z.array(z.string()).optional(),
   evaluationUpdatedAt: z.string().nullable().optional(),
+  subtasks: z.array(issueSubtaskSchema).nullable().optional(),
 });
 export type Issue = z.infer<typeof issueSchema>;
 
@@ -256,6 +275,8 @@ export const issueListPageSchema = z.object({
   offset: z.number().int().nonnegative(),
   nextOffset: z.number().int().nonnegative().nullable(),
   hasMore: z.boolean(),
+  totalCount: z.number().int().nonnegative(),
+  repoTotals: z.record(z.string(), z.number().int().nonnegative()),
   fetchedAt: z.string(),
   staleAt: z.string(),
 });
@@ -275,6 +296,17 @@ export const issueEvaluationSchema = z.object({
   updatedAt: z.string(),
 });
 export type IssueEvaluation = z.infer<typeof issueEvaluationSchema>;
+
+export const issueSubtaskSetSchema = z.object({
+  targetId: z.string(),
+  repo: z.string(),
+  issueNumber: z.number().int().positive(),
+  subtasks: z.array(issueSubtaskSchema),
+  analyzedBodyHash: z.string(),
+  analyzedAt: z.string(),
+  updatedAt: z.string(),
+});
+export type IssueSubtaskSet = z.infer<typeof issueSubtaskSetSchema>;
 
 export const operatorWarningSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
## Summary
- add repo-fair incremental sync scheduling with backoff for large watched repositories
- split PR list projection from PR detail payload to reduce list polling cost
- add short-lived PR detail route cache with mutation-triggered invalidation
- include issue sync/workflow robustness updates and supporting tests

## Verification
- npm run check
- npm run test -- server/routes.test.ts server/appRuntime.test.ts
- npm run test -- server/babysitter.test.ts