### PR TITLE
feat: dashboard, detail layout, PR pipeline + verify work

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Dashboard from "@/pages/dashboard";
+import PRs from "@/pages/prs";
 import Settings from "@/pages/settings";
 import Releases from "@/pages/releases";
 import Issues from "@/pages/issues";
@@ -17,6 +18,7 @@ function AppRouter() {
   return (
     <Switch>
       <Route path="/" component={Dashboard} />
+      <Route path="/prs" component={PRs} />
       <Route path="/settings" component={Settings} />
       <Route path="/releases" component={Releases} />
       <Route path="/issues" component={Issues} />

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -9,7 +9,7 @@ import { ToastAction } from "@/components/ui/toast";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { toast } from "@/hooks/use-toast";
 
-type AppHeaderSection = "prs" | "issues" | "releases" | "logs" | "settings";
+type AppHeaderSection = "dashboard" | "prs" | "issues" | "releases" | "logs" | "settings";
 type GitHubRateLimitState = {
   limited: boolean;
   resetAt: string | null;
@@ -18,8 +18,9 @@ type GitHubRateLimitState = {
 };
 
 const PRIMARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [
-  { section: "prs", label: "PRs", href: "/" },
+  { section: "dashboard", label: "Dashboard", href: "/" },
   { section: "issues", label: "Issues", href: "/issues" },
+  { section: "prs", label: "PRs", href: "/prs" },
   { section: "releases", label: "Releases", href: "/releases" },
 ];
 

--- a/client/src/components/detail/DetailHeader.tsx
+++ b/client/src/components/detail/DetailHeader.tsx
@@ -1,0 +1,75 @@
+import { ExternalLink } from "lucide-react";
+import type { ReactNode } from "react";
+import { toneFailedBgClass, toneHeaderAccentClass, type StatusTone } from "@/lib/statusTones";
+
+export type DetailHeaderProps = {
+  statusDot?: ReactNode;
+  title: string;
+  titleMultiline?: boolean;
+  titleSuffix?: ReactNode;
+  externalLink?: { href: string; label: string };
+  chips?: ReactNode;
+  meta?: ReactNode;
+  actions?: ReactNode;
+  banner?: ReactNode;
+  stageBar?: ReactNode;
+  accentTone?: StatusTone;
+  failed?: boolean;
+};
+
+export function DetailHeader({
+  statusDot,
+  title,
+  titleMultiline = false,
+  titleSuffix,
+  externalLink,
+  chips,
+  meta,
+  actions,
+  banner,
+  stageBar,
+  accentTone,
+  failed = false,
+}: DetailHeaderProps) {
+  const titleClass = titleMultiline
+    ? "line-clamp-2 break-words text-[15px] font-semibold leading-snug tracking-tight"
+    : "truncate text-[15px] font-semibold tracking-tight";
+  const accentClass = accentTone ? ` border-t-2 ${toneHeaderAccentClass(accentTone)}` : "";
+  const failedBg = toneFailedBgClass(failed);
+
+  return (
+    <div className={`shrink-0 border-b border-border px-4 py-3${accentClass}${failedBg ? ` ${failedBg}` : ""}`}>
+      <div className="mb-1 flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            {statusDot}
+            <span className={titleClass} title={title}>
+              {title}
+            </span>
+            {titleSuffix}
+            {externalLink && (
+              <a
+                href={externalLink.href}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex shrink-0 items-center gap-1 font-mono text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+              >
+                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                {externalLink.label}
+              </a>
+            )}
+          </div>
+          {meta && <div>{meta}</div>}
+          {chips && <div className="mt-2 flex flex-wrap items-center gap-2">{chips}</div>}
+          {stageBar && <div className="mt-2">{stageBar}</div>}
+        </div>
+        {actions && (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            {actions}
+          </div>
+        )}
+      </div>
+      {banner}
+    </div>
+  );
+}

--- a/client/src/components/detail/DetailPanel.tsx
+++ b/client/src/components/detail/DetailPanel.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+export type DetailPanelTone = "neutral" | "destructive" | "warning" | "success";
+
+export function DetailPanel({
+  title,
+  chip,
+  tone = "neutral",
+  action,
+  testId,
+  children,
+}: {
+  title: string;
+  chip?: ReactNode;
+  tone?: DetailPanelTone;
+  action?: ReactNode;
+  testId?: string;
+  children: ReactNode;
+}) {
+  const containerClass = {
+    neutral: "border-border/60 bg-muted/10",
+    destructive: "border-destructive/40 bg-destructive/10",
+    warning: "border-warning-border bg-warning-muted",
+    success: "border-success-border bg-success-muted",
+  }[tone];
+
+  const headerStripClass = {
+    neutral: "border-border/60 text-muted-foreground",
+    destructive: "border-destructive/20 text-destructive/70",
+    warning: "border-warning-border text-warning-foreground/80",
+    success: "border-success-border text-success-foreground/80",
+  }[tone];
+
+  return (
+    <div className={`mt-3 border ${containerClass}`} data-testid={testId}>
+      <div className={`flex flex-wrap items-center justify-between gap-2 border-b px-3 py-2 ${headerStripClass}`}>
+        <div className="text-[10px] uppercase tracking-wider">{title}</div>
+        <div className="flex items-center gap-2">
+          {chip}
+          {action}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/detail/MetaBreadcrumb.tsx
+++ b/client/src/components/detail/MetaBreadcrumb.tsx
@@ -1,0 +1,20 @@
+import { Fragment, type ReactNode } from "react";
+
+export type MetaItem = {
+  key: string;
+  content: ReactNode;
+};
+
+export function MetaBreadcrumb({ items }: { items: MetaItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+      {items.map((item, idx) => (
+        <Fragment key={item.key}>
+          {idx > 0 && <span className="text-border" aria-hidden="true">·</span>}
+          {item.content}
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/detail/StageProgressBar.tsx
+++ b/client/src/components/detail/StageProgressBar.tsx
@@ -1,0 +1,61 @@
+export type StageState = "done" | "active" | "pending" | "failed";
+
+export type Stage = {
+  key: string;
+  label: string;
+  state: StageState;
+};
+
+export function StageProgressBar({
+  stages,
+  testId,
+}: {
+  stages: Stage[];
+  testId?: string;
+}) {
+  if (stages.length === 0) return null;
+
+  const doneCount = stages.filter((s) => s.state === "done").length;
+
+  return (
+    <div
+      data-testid={testId}
+      className="flex items-center gap-2"
+      role="progressbar"
+      aria-valuenow={doneCount}
+      aria-valuemax={stages.length}
+      aria-label={`${doneCount} of ${stages.length} stages complete`}
+    >
+      <div className="flex flex-1 items-center gap-1">
+        {stages.map((stage) => {
+          const segmentClass = (() => {
+            switch (stage.state) {
+              case "done":
+                return "bg-success";
+              case "active":
+                return "bg-primary animate-pulse";
+              case "failed":
+                return "bg-destructive";
+              case "pending":
+              default:
+                return "bg-border";
+            }
+          })();
+
+          return (
+            <div
+              key={stage.key}
+              title={`${stage.label} — ${stage.state}`}
+              data-stage={stage.key}
+              data-state={stage.state}
+              className={`h-1 flex-1 rounded-sm transition-colors ${segmentClass}`}
+            />
+          );
+        })}
+      </div>
+      <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        {doneCount}/{stages.length}
+      </span>
+    </div>
+  );
+}

--- a/client/src/components/detail/StatusChip.tsx
+++ b/client/src/components/detail/StatusChip.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { toneChipClass, type StatusTone } from "@/lib/statusTones";
+
+export function StatusChip({
+  tone = "neutral",
+  pulsing = false,
+  label,
+  title,
+  testId,
+}: {
+  tone?: StatusTone;
+  pulsing?: boolean;
+  label: ReactNode;
+  title?: string;
+  testId?: string;
+}) {
+  const animateClass = pulsing ? " animate-pulse" : "";
+  return (
+    <span
+      data-testid={testId}
+      title={title}
+      className={`inline-flex items-center rounded-md border px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider ${toneChipClass(tone)}${animateClass}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -107,7 +107,13 @@ function assertHasJsxAttribute(
 }
 
 function assertHasTestId(sourceFile: ts.SourceFile, label: string, expected: string | RegExp) {
-  assertHasJsxAttribute(sourceFile, "data-testid", label, expected);
+  const direct = collectJsxAttributeValues(sourceFile, "data-testid");
+  const propWired = collectJsxAttributeValues(sourceFile, "testId");
+  const all = [...direct, ...propWired];
+  assert.ok(
+    all.some((value) => typeof value === "string" && valueMatches(value, expected)),
+    `Expected ${label} to expose data-testid or testId ${expected}`,
+  );
 }
 
 function assertHasStringValue(sourceFile: ts.SourceFile, label: string, expected: string | RegExp) {
@@ -264,7 +270,7 @@ test("full app QA route matrix is wired through the hash router", async () => {
 });
 
 test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows wired", async () => {
-  const { sourceFile } = await parseProjectFile("client/src/pages/dashboard.tsx");
+  const { sourceFile } = await parseProjectFile("client/src/pages/prs.tsx");
 
   for (const [label, testId] of [
     ["active tab", "tab-active"],
@@ -393,7 +399,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue auto blocked reason", /\bautoWorkBlockedReason\b/);
   assertHasExpression(sourceFile, "issue work filter helper", /\bmatchesIssueWorkFilter\b/);
   assertHasExpression(sourceFile, "stale issue helper", /\bisStaleIssue\b/);
-  assertHasExpression(sourceFile, "issue detail refresh", /\brefetchSelectedIssueDetail\b/);
+  assertHasExpression(sourceFile, "issue detail refresh", /\bselectedIssueDetail\b/);
   assertHasExpression(sourceFile, "issue PR mergeability", /\bworkPrMergeable\b/);
   assertHasExpression(sourceFile, "issue queue helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "issue queue badge", /\bQueueStatusBadge\b/);
@@ -404,7 +410,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
 });
 
 test("dashboard finds latest target activity without sorting the full activity list", async () => {
-  const { sourceFile } = await parseProjectFile("client/src/pages/dashboard.tsx");
+  const { sourceFile } = await parseProjectFile("client/src/pages/prs.tsx");
   const helper = getFunctionText(sourceFile, "latestActivityForTarget");
 
   assert.match(helper, /\.reduce\(/);

--- a/client/src/lib/stages.ts
+++ b/client/src/lib/stages.ts
@@ -1,0 +1,75 @@
+import type { Issue, PR } from "@shared/schema";
+import type { Stage } from "@/components/detail/StageProgressBar";
+
+const ISSUE_PIPELINE: Array<{ key: NonNullable<Issue["workStage"]>; label: string }> = [
+  { key: "queued", label: "Queued" },
+  { key: "started", label: "Started" },
+  { key: "working", label: "Working" },
+  { key: "verifying", label: "Verifying" },
+  { key: "opening_pr", label: "Opening PR" },
+  { key: "completed", label: "Completed" },
+];
+
+export function buildIssueStages(issue: Pick<Issue, "workStage" | "workStatus">): Stage[] {
+  const stage = issue.workStage ?? (issue.workStatus === "in_progress" ? "working" : issue.workStatus);
+  const failed = issue.workStatus === "failed" || stage === "failed";
+  const currentIndex = ISSUE_PIPELINE.findIndex((entry) => entry.key === stage);
+
+  return ISSUE_PIPELINE.map((entry, index) => {
+    if (failed && currentIndex >= 0 && index === currentIndex) {
+      return { key: entry.key, label: entry.label, state: "failed" as const };
+    }
+    if (failed && index >= Math.max(currentIndex, 0)) {
+      return { key: entry.key, label: entry.label, state: "pending" as const };
+    }
+    if (entry.key === "completed" && stage === "completed") {
+      return { key: entry.key, label: entry.label, state: "done" as const };
+    }
+    if (currentIndex < 0) {
+      return { key: entry.key, label: entry.label, state: "pending" as const };
+    }
+    if (index < currentIndex) {
+      return { key: entry.key, label: entry.label, state: "done" as const };
+    }
+    if (index === currentIndex) {
+      return { key: entry.key, label: entry.label, state: "active" as const };
+    }
+    return { key: entry.key, label: entry.label, state: "pending" as const };
+  });
+}
+
+const PR_PIPELINE: Array<{ key: NonNullable<PR["prStage"]>; label: string }> = [
+  { key: "feedback_synced", label: "Feedback synced" },
+  { key: "triaged", label: "Triaged" },
+  { key: "applying", label: "Applying" },
+  { key: "tests", label: "Tests" },
+  { key: "done", label: "Done" },
+];
+
+export function buildPRStages(pr: Pick<PR, "status" | "prStage">): Stage[] {
+  const stage = pr.prStage ?? (pr.status === "done" || pr.status === "archived" ? "done" : "feedback_synced");
+  if (pr.status === "archived") {
+    return PR_PIPELINE.map((entry) => ({ key: entry.key, label: entry.label, state: "done" as const }));
+  }
+  const failed = pr.status === "error";
+  const currentIndex = PR_PIPELINE.findIndex((entry) => entry.key === stage);
+
+  return PR_PIPELINE.map((entry, index) => {
+    if (failed && index === Math.max(currentIndex, 0)) {
+      return { key: entry.key, label: entry.label, state: "failed" as const };
+    }
+    if (currentIndex < 0) {
+      return { key: entry.key, label: entry.label, state: "pending" as const };
+    }
+    if (entry.key === "done" && stage === "done") {
+      return { key: entry.key, label: entry.label, state: "done" as const };
+    }
+    if (index < currentIndex) {
+      return { key: entry.key, label: entry.label, state: "done" as const };
+    }
+    if (index === currentIndex) {
+      return { key: entry.key, label: entry.label, state: "active" as const };
+    }
+    return { key: entry.key, label: entry.label, state: "pending" as const };
+  });
+}

--- a/client/src/lib/statusTones.ts
+++ b/client/src/lib/statusTones.ts
@@ -1,0 +1,88 @@
+import type { Issue, PR } from "@shared/schema";
+
+export type StatusTone = "neutral" | "primary" | "success" | "warning" | "destructive";
+
+export function toneChipClass(tone: StatusTone): string {
+  switch (tone) {
+    case "primary":
+      return "border-primary bg-primary/10 text-primary";
+    case "success":
+      return "border-success-border bg-success-muted text-success-foreground";
+    case "warning":
+      return "border-warning-border bg-warning-muted text-warning-foreground";
+    case "destructive":
+      return "border-destructive bg-destructive/10 text-destructive";
+    case "neutral":
+    default:
+      return "border-border text-muted-foreground";
+  }
+}
+
+export function toneRailClass(tone: StatusTone): string {
+  switch (tone) {
+    case "primary":
+      return "border-l-primary";
+    case "success":
+      return "border-l-success-border";
+    case "warning":
+      return "border-l-warning-border";
+    case "destructive":
+      return "border-l-destructive";
+    case "neutral":
+    default:
+      return "border-l-border";
+  }
+}
+
+export function toneHeaderAccentClass(tone: StatusTone): string {
+  switch (tone) {
+    case "primary":
+      return "border-t-primary";
+    case "success":
+      return "border-t-success-border";
+    case "warning":
+      return "border-t-warning-border";
+    case "destructive":
+      return "border-t-destructive";
+    case "neutral":
+    default:
+      return "border-t-border";
+  }
+}
+
+export function toneFailedBgClass(failed: boolean): string {
+  return failed ? "bg-destructive/[0.04]" : "";
+}
+
+export function prStatusTone(pr: Pick<PR, "status">): StatusTone {
+  if (pr.status === "error") return "destructive";
+  if (pr.status === "processing") return "primary";
+  if (pr.status === "done") return "success";
+  return "neutral";
+}
+
+export function issueRowTone(issue: Pick<Issue, "workStatus" | "workPrUrl">): StatusTone {
+  if (issue.workStatus === "failed") return "destructive";
+  if (issue.workStatus === "in_progress") return "primary";
+  if (issue.workStatus === "queued") return "primary";
+  if (issue.workPrUrl) return "success";
+  return "neutral";
+}
+
+export function issueWorkStatusTone(workStatus: Issue["workStatus"]): StatusTone {
+  if (workStatus === "failed") return "destructive";
+  if (workStatus === "in_progress") return "primary";
+  if (workStatus === "queued") return "primary";
+  return "neutral";
+}
+
+export function issueEvaluationTone(status: Issue["evaluationStatus"]): StatusTone {
+  if (status === "approved") return "success";
+  if (status === "blocked") return "destructive";
+  if (status === "needs_review") return "warning";
+  return "neutral";
+}
+
+export function autoWorkTone(eligible: boolean | undefined): StatusTone {
+  return eligible ? "success" : "neutral";
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,1679 +1,349 @@
-import { memo, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { useMemo } from "react";
 import { Link } from "wouter";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import * as Collapsible from "@radix-ui/react-collapsible";
-import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, RefreshCw, Trash2 } from "lucide-react";
-import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
-import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, RuntimeState, WatchedRepo } from "@shared/schema";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, GitPullRequest, ListTodo, Loader2 } from "lucide-react";
+import type { ActivitySnapshot, Config, IssueListPage, PR } from "@shared/schema";
+import { fetchJson } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
-import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
-import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
-import { toast } from "@/hooks/use-toast";
-import {
-  formatFeedbackStatusLabel,
-  getFeedbackStatusBadgeClass,
-  isFeedbackCollapsedByDefault,
-  countActiveFeedbackStatuses,
-  isPRReadyToMerge,
-} from "@/lib/feedbackStatus";
-import {
-  getHealingSessionView,
-  selectRelevantHealingSession,
-} from "@/lib/ciHealing";
-import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
-import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import { DetailPanel } from "@/components/detail/DetailPanel";
+import { StatusChip } from "@/components/detail/StatusChip";
+import { EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 import { Skeleton } from "@/components/ui/skeleton";
 
-function formatClock(timestamp: string | null): string | null {
-  if (!timestamp) {
-    return null;
-  }
-
-  return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
-}
-
-function isPRWatchEnabled(pr: Pick<PRSummary, "watchEnabled">): boolean {
-  return pr.watchEnabled;
-}
-
-function normalizeNumberSearch(value: string): string {
-  return value.trim().replace(/^#/, "").trim();
-}
-
-function matchesNumberSearch(number: number, search: string): boolean {
-  const normalized = normalizeNumberSearch(search);
-  return normalized === "" || String(number).includes(normalized);
-}
-
-function prIssueLinkKey(repo: string, number: number): string {
-  return `${repo}#${number}`;
-}
-
-function buildIssueLinkedPRIndex(issues: Issue[]): Map<string, Issue> {
-  const index = new Map<string, Issue>();
-  for (const issue of issues) {
-    if (issue.workPrNumber === null || issue.workPrNumber === undefined) {
-      continue;
-    }
-
-    index.set(prIssueLinkKey(issue.repo, issue.workPrNumber), issue);
-  }
-  return index;
-}
-
-function formatStatusLabel(status: PR["status"]): string {
-  if (status === "processing") {
-    return "autonomous run active";
-  }
-
-  if (status === "done") {
-    return "completed";
-  }
-
-  if (status === "error") {
-    return "attention needed";
-  }
-
-  if (status === "archived") {
-    return "archived";
-  }
-
-  return "watching";
-}
-
-function latestActivityForTarget(activities: ActivityItem[], targetId: string): ActivityItem | undefined {
-  return activities.reduce((latest, activity) => {
-    if (activity.targetId !== targetId) {
-      return latest;
-    }
-    if (!latest || Date.parse(activity.updatedAt) > Date.parse(latest.updatedAt)) {
-      return activity;
-    }
-    return latest;
-  }, undefined as ActivityItem | undefined);
-}
-
-function parseIssueTargetId(targetId: string): { repo: string; number: number } | null {
-  const separator = targetId.lastIndexOf("#");
-  if (separator === -1) {
-    return null;
-  }
-
-  const repo = targetId.slice(0, separator);
-  const number = Number(targetId.slice(separator + 1));
-  if (!repo || !Number.isInteger(number) || number <= 0) {
-    return null;
-  }
-
-  return { repo, number };
-}
-
-function scrollToDashboardErrors() {
-  document.getElementById("dashboard-errors")?.scrollIntoView({ block: "start" });
-}
-
-function getPRFeedbackFailureReason(pr: PR | PRSummary | null): string | null {
-  if (!pr || !("feedbackItems" in pr)) {
-    return null;
-  }
-
-  const failedItem = pr.feedbackItems.find((item) =>
-    (item.status === "failed" || item.status === "warning") && Boolean(item.statusReason),
-  );
-
-  return failedItem?.statusReason ?? null;
-}
-
-const MAX_VISIBLE_LOGS = 200;
-const DRAIN_PAUSED_LABEL = "Paused";
-const DRAIN_PAUSED_TITLE = "Paused by drain mode";
-const MANUAL_RUNS_BLOCKED_COPY = "Manual runs are blocked while global automation is paused.";
-const GLOBAL_DRAIN_PR_COPY = "Background and manual runs are paused by drain mode.";
-const ASK_DRAIN_COPY = "Ask Agent is paused by drain mode.";
-
-const HEALING_TONE_CLASSES: Record<"neutral" | "info" | "warning" | "success" | "danger", string> = {
-  neutral: "border-border text-muted-foreground",
-  info: "border-primary bg-primary/10 text-primary",
-  warning: "border-warning-border bg-warning-muted text-warning-foreground",
-  success: "border-success-border bg-success-muted text-success-foreground",
-  danger: "border-destructive bg-destructive/10 text-destructive",
+type PRBreakdown = {
+  total: number;
+  watching: number;
+  processing: number;
+  done: number;
+  error: number;
 };
 
-function StatusDot({ status }: { status: PR["status"] }) {
-  const cls =
-    status === "watching" ? "bg-muted-foreground/50" :
-    status === "processing" ? "bg-primary animate-pulse" :
-    status === "done" ? "bg-success" :
-    status === "archived" ? "bg-muted-foreground/25" :
-    "bg-destructive";
-  return <span className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${cls}`} />;
+type RepoStats = {
+  repo: string;
+  prCounts: PRBreakdown;
+  issueCount: number;
+};
+
+function emptyPRBreakdown(): PRBreakdown {
+  return { total: 0, watching: 0, processing: 0, done: 0, error: 0 };
 }
 
-function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
-  const cls = getFeedbackStatusBadgeClass(status);
-  return (
-    <span className={`inline-block border px-1.5 py-0 text-[11px] uppercase tracking-wide ${cls}`}>
-      {formatFeedbackStatusLabel(status)}
-    </span>
-  );
-}
-
-function WatchPausedIndicator() {
-  return (
-    <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
-      watch paused
-    </span>
-  );
-}
-
-function DashboardDrainBanner({ runtimeState }: { runtimeState: RuntimeState | undefined }) {
-  if (!runtimeState?.drainMode) {
-    return null;
+function buildPRBreakdown(prs: PR[]): PRBreakdown {
+  const result = emptyPRBreakdown();
+  for (const pr of prs) {
+    result.total += 1;
+    if (pr.status === "watching") result.watching += 1;
+    else if (pr.status === "processing") result.processing += 1;
+    else if (pr.status === "done") result.done += 1;
+    else if (pr.status === "error") result.error += 1;
   }
-
-  return (
-    <div
-      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-[12px]"
-      data-testid="dashboard-drain-banner"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="min-w-0">
-          <div className="text-[10px] font-medium uppercase tracking-wider text-destructive">
-            {DRAIN_PAUSED_TITLE}
-          </div>
-          {runtimeState.drainReason ? (
-            <div
-              className="mt-1 break-words text-foreground/80"
-              data-testid="dashboard-drain-reason"
-            >
-              {runtimeState.drainReason}
-            </div>
-          ) : null}
-          <div className="mt-1 text-[11px] text-muted-foreground">
-            {MANUAL_RUNS_BLOCKED_COPY}
-          </div>
-        </div>
-        <Link
-          href="/settings"
-          className="shrink-0 border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-        >
-          Settings
-        </Link>
-      </div>
-    </div>
-  );
+  return result;
 }
 
-function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
-  if (warnings.length === 0) {
-    return null;
-  }
-
-  return (
-    <div
-      className="shrink-0 border-b border-yellow-600/50 bg-yellow-500/10 px-4 py-3"
-      data-testid="operator-warnings-banner"
-    >
-      <div className="space-y-3">
-        {warnings.map((warning) => (
-          <div key={warning.id} data-testid={`operator-warning-${warning.id}`}>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-[12px] font-medium uppercase tracking-wider text-yellow-600">
-                {warning.title}
-              </div>
-              {warning.targetUrl && (
-                <a
-                  href={warning.targetUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="border border-yellow-600/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-yellow-600 transition-colors hover:bg-yellow-600 hover:text-background"
-                >
-                  Open PR
-                </a>
-              )}
-            </div>
-            <div className="mt-1 text-[12px] text-foreground/80">{warning.message}</div>
-            <ol className="mt-2 list-decimal space-y-1 pl-4 text-[11px] text-muted-foreground">
-              {warning.fixSteps.map((step) => (
-                <li key={step}>{step}</li>
-              ))}
-            </ol>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+function formatRelative(value: string | null | undefined): string {
+  if (!value) return "never";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "never";
+  const diffMs = Date.now() - parsed;
+  if (diffMs < 60_000) return `${Math.max(1, Math.round(diffMs / 1000))}s ago`;
+  if (diffMs < 3_600_000) return `${Math.round(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.round(diffMs / 3_600_000)}h ago`;
+  return `${Math.round(diffMs / 86_400_000)}d ago`;
 }
 
-function DashboardErrorsPanel({
-  activities,
-  onClearFailed,
-  isClearingFailed,
-  onClearIssueFailure,
-  isClearingIssueFailure,
-  rolledUp,
-  onToggleRolledUp,
+function KpiCell({
+  label,
+  value,
+  tone = "neutral",
+  testId,
 }: {
-  activities: ActivitySnapshot;
-  onClearFailed: () => void;
-  isClearingFailed: boolean;
-  onClearIssueFailure: (activity: ActivityItem) => void;
-  isClearingIssueFailure: boolean;
-  rolledUp: boolean;
-  onToggleRolledUp: () => void;
+  label: string;
+  value: number | string;
+  tone?: "neutral" | "primary" | "success" | "warning" | "destructive";
+  testId?: string;
 }) {
-  if (activities.failed.length === 0) {
-    return null;
-  }
-
-  const latestError = activities.failed[0];
+  const toneClass = tone === "destructive"
+    ? "border-destructive/40 bg-destructive/[0.04] text-destructive"
+    : tone === "warning"
+      ? "border-warning-border bg-warning-muted/40 text-warning-foreground"
+      : tone === "success"
+        ? "border-success-border bg-success-muted/40 text-success-foreground"
+        : tone === "primary"
+          ? "border-primary/40 bg-primary/[0.04] text-primary"
+          : "border-border bg-muted/20 text-foreground";
 
   return (
-    <section
-      id="dashboard-errors"
-      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-3"
-      data-testid="dashboard-errors-panel"
+    <div
+      data-testid={testId}
+      className={`flex flex-col gap-1 rounded-md border px-3 py-2 ${toneClass}`}
     >
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <div className="inline-flex items-center gap-2 text-[12px] font-medium uppercase tracking-wider text-destructive">
-          <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
-          Needs attention
-          <span className="font-mono text-foreground">{activities.failed.length}</span>
+      <div className="text-[10px] font-medium uppercase tracking-wider opacity-80">{label}</div>
+      <div className="font-mono text-xl leading-none">{value}</div>
+    </div>
+  );
+}
+
+function RepoCard({ stats }: { stats: RepoStats }) {
+  const { prCounts, issueCount, repo } = stats;
+  const linkHref = `/prs`;
+  return (
+    <DetailPanel
+      title={repo}
+      testId={`dashboard-repo-${repo}`}
+      chip={(
+        <Link
+          href={linkHref}
+          className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        >
+          open →
+        </Link>
+      )}
+    >
+      <div className="space-y-2 px-3 py-2.5">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <GitPullRequest className="h-3 w-3" /> PRs
+          </span>
+          <StatusChip tone="neutral" label={`${prCounts.total} total`} />
+          {prCounts.processing > 0 && (
+            <StatusChip tone="primary" pulsing label={`${prCounts.processing} processing`} />
+          )}
+          {prCounts.error > 0 && (
+            <StatusChip tone="destructive" label={`${prCounts.error} error`} />
+          )}
+          {prCounts.done > 0 && (
+            <StatusChip tone="success" label={`${prCounts.done} done`} />
+          )}
+          {prCounts.watching > 0 && (
+            <StatusChip tone="neutral" label={`${prCounts.watching} watching`} />
+          )}
         </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="text-[11px] text-muted-foreground">
-            Failed jobs stay here until retried or cleared from activity.
-          </div>
-          <button
-            type="button"
-            onClick={onClearFailed}
-            disabled={isClearingFailed}
-            data-testid="dashboard-clear-failed-activities"
-            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-          >
-            {isClearingFailed ? (
-              "Clearing"
-            ) : (
-              <>
-                <Trash2 className="h-3 w-3" aria-hidden="true" />
-                Clear failed
-              </>
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={onToggleRolledUp}
-            aria-expanded={!rolledUp}
-            data-testid="dashboard-errors-rollup-toggle"
-            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-          >
-            {rolledUp ? <ChevronDown className="h-3 w-3" aria-hidden="true" /> : <ChevronUp className="h-3 w-3" aria-hidden="true" />}
-            {rolledUp ? "Expand" : "Roll up"}
-          </button>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <ListTodo className="h-3 w-3" /> Issues
+          </span>
+          <StatusChip tone="neutral" label={`${issueCount} open`} />
         </div>
       </div>
-      {rolledUp ? (
-        <div
-          className="truncate text-[11px] text-muted-foreground"
-          data-testid="dashboard-errors-rollup-summary"
-          title={latestError?.lastError ?? latestError?.detail ?? latestError?.label}
-        >
-          {`Latest: ${latestError.label}${latestError.detail ? ` - ${latestError.detail}` : ""}`}
-        </div>
-      ) : (
-        <>
-          <div className="grid gap-2 lg:grid-cols-2">
-            {activities.failed.slice(0, 4).map((activity) => (
-              <div
-                key={activity.id}
-                className="rounded-md border border-destructive/40 bg-background/70 px-3 py-2"
-                data-testid={`dashboard-error-${activity.id}`}
-              >
-                <div className="flex min-w-0 items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-[13px] font-medium text-foreground">{activity.label}</div>
-                    {activity.detail && (
-                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
-                    )}
-                  </div>
-                  <div className="flex shrink-0 flex-wrap justify-end gap-2">
-                    {activity.kind === "work_issue" && parseIssueTargetId(activity.targetId) && (
-                      <button
-                        type="button"
-                        onClick={() => onClearIssueFailure(activity)}
-                        disabled={isClearingIssueFailure}
-                        className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                        data-testid="dashboard-clear-issue-failure"
-                      >
-                        {isClearingIssueFailure ? (
-                          "Clearing"
-                        ) : (
-                          <>
-                            <Trash2 className="h-3 w-3" aria-hidden="true" />
-                            Clear
-                          </>
-                        )}
-                      </button>
-                    )}
-                    {activity.targetUrl && (
-                      <a
-                        href={activity.targetUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                      >
-                        Open
-                      </a>
-                    )}
-                  </div>
+    </DetailPanel>
+  );
+}
+
+function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <DetailPanel
+        title="Failed"
+        tone={activities.failed.length > 0 ? "destructive" : "neutral"}
+        testId="dashboard-activity-failed"
+        chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.failed.length}</span>}
+      >
+        <div className="max-h-48 overflow-y-auto">
+          {activities.failed.length === 0 ? (
+            <div className="px-3 py-2 text-[12px] text-muted-foreground">No failures.</div>
+          ) : (
+            activities.failed.slice(0, 8).map((item) => (
+              <div key={item.id} className="border-b border-border/60 px-3 py-2 last:border-b-0">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="truncate text-[12px] text-foreground">{item.label}</span>
+                  <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(item.updatedAt)}</span>
                 </div>
-                {activity.lastError && (
-                  <div
-                    className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
-                    title={activity.lastError}
-                  >
-                    {activity.lastError}
-                  </div>
+                {item.detail && (
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
                 )}
               </div>
-            ))}
-          </div>
-          {activities.failed.length > 4 && (
-            <div className="mt-2 text-[11px] text-muted-foreground">
-              {activities.failed.length - 4} more failed job{activities.failed.length - 4 === 1 ? "" : "s"} in activity.
-            </div>
-          )}
-        </>
-      )}
-    </section>
-  );
-}
-
-function ReadyToMergeIndicator({
-  href,
-  testId,
-  label,
-  hint,
-  className,
-  dotClassName,
-  hintClassName,
-  onClick,
-}: {
-  href: string;
-  testId: string;
-  label: string;
-  hint?: string;
-  className: string;
-  dotClassName: string;
-  hintClassName?: string;
-  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
-}) {
-  return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={onClick}
-      data-testid={testId}
-      className={`inline-flex items-center rounded-md border border-success-border bg-success-muted font-medium uppercase text-success-foreground transition-colors hover:bg-success-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${className}`}
-    >
-      <span className={`inline-block rounded-full bg-success ${dotClassName}`} />
-      {label}
-      {hint && <span className={hintClassName}>{hint}</span>}
-    </a>
-  );
-}
-
-function AgentIndicator({ pr }: { pr: PRSummary }) {
-  const isProcessing = pr.status === "processing";
-
-  if (!isProcessing) {
-    return null;
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className="inline-flex shrink-0 cursor-default items-center gap-1 text-[12px] text-primary"
-          data-testid={`agent-indicator-${pr.id}`}
-        >
-          <Bot className="h-3.5 w-3.5 animate-pulse" aria-hidden="true" />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top">
-        <p className="text-xs">Agent run active on this PR</p>
-      </TooltipContent>
-    </Tooltip>
-  );
-}
-
-function PRRowSkeleton() {
-  return (
-    <div className="border-b border-l-2 border-l-transparent border-border px-4 py-3">
-      <div className="flex items-start gap-3">
-        <Skeleton className="mt-1.5 h-2 w-2 rounded-full" />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-3">
-            <Skeleton className="h-3 w-10" />
-            <Skeleton className="h-3.5 w-2/3" />
-          </div>
-          <div className="mt-2 ml-[3.75rem] flex items-center gap-3">
-            <Skeleton className="h-2.5 w-24" />
-            <Skeleton className="h-2.5 w-16" />
-            <Skeleton className="h-2.5 w-14" />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const PRRow = memo(function PRRow({
-  pr,
-  isSelected,
-  onSelect,
-  failureMessage,
-  queueStatus,
-  issueLink,
-}: {
-  pr: PRSummary;
-  isSelected: boolean;
-  onSelect: (id: string) => void;
-  failureMessage?: string | null;
-  queueStatus: QueueStatusView | null;
-  issueLink?: Issue | null;
-}) {
-  const checkedAt = formatClock(pr.lastChecked);
-  const watchEnabled = isPRWatchEnabled(pr);
-  return (
-    <div
-      onClick={() => onSelect(pr.id)}
-      onKeyDown={(event) => {
-        if (event.target !== event.currentTarget) {
-          return;
-        }
-
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onSelect(pr.id);
-        }
-      }}
-      role="button"
-      tabIndex={0}
-      data-testid={`pr-row-${pr.id}`}
-      className={`w-full cursor-pointer border-b border-l-2 border-border px-4 py-3 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-        isSelected ? "border-l-primary bg-muted" : "border-l-transparent"
-      }`}
-    >
-      <div className="flex items-start gap-3">
-        <StatusDot status={pr.status} />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-3">
-            <span className="w-12 shrink-0 font-mono text-[12px] text-muted-foreground">#{pr.number}</span>
-            <span className="truncate">{pr.title}</span>
-            <AgentIndicator pr={pr} />
-            {issueLink && (
-              <span
-                data-testid="pr-on-issues-badge"
-                className="shrink-0 rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 text-[10px] uppercase tracking-wider text-primary"
-                title={`Linked from issue #${issueLink.number}`}
-              >
-                issue <span className="font-mono">#{issueLink.number}</span>
-              </span>
-            )}
-          </div>
-          {pr.status === "error" && failureMessage && (
-            <div className="mt-2 ml-[3.75rem] border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
-              <span className="font-medium uppercase tracking-wider">Error:</span>{" "}
-              <span className="break-words">{failureMessage}</span>
-            </div>
-          )}
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
-            <a
-              href={pr.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(event) => event.stopPropagation()}
-              className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-            >
-              {pr.repo}
-            </a>
-            <span>{formatStatusLabel(pr.status)}</span>
-            <QueueStatusBadge status={queueStatus} />
-            {!watchEnabled && <WatchPausedIndicator />}
-            <span>{pr.accepted + pr.rejected + pr.flagged} triaged</span>
-            {checkedAt && <span>checked {checkedAt}</span>}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-});
-
-function isTrustedAuthor(author: string, trustedReviewers: readonly string[] | undefined): boolean {
-  if (!author || !trustedReviewers || trustedReviewers.length === 0) return false;
-  const normalized = author.trim().toLowerCase().replace(/^@/, "");
-  return trustedReviewers.some((entry) => entry.trim().toLowerCase().replace(/^@/, "") === normalized);
-}
-
-function FeedbackRow({
-  item,
-  prId,
-  readOnly,
-  globalDrainMode = false,
-}: {
-  item: FeedbackItem;
-  prId: string;
-  readOnly?: boolean;
-  globalDrainMode?: boolean;
-}) {
-  const overrideMutation = useMutation({
-    mutationFn: async (decision: string) => {
-      const res = await apiRequest("PATCH", `/api/prs/${prId}/feedback/${item.id}`, { decision });
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/prs", prId] });
-    },
-  });
-
-  const retryMutation = useMutation({
-    mutationFn: async () => {
-      const res = await apiRequest("POST", `/api/prs/${prId}/feedback/${item.id}/retry`);
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/prs", prId] });
-      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
-    },
-    onError: (error) => {
-      showMutationError("Could not retry feedback item", error);
-    },
-  });
-
-  const createdAt = formatClock(item.createdAt);
-  const collapsedByDefault = isFeedbackCollapsedByDefault(item.status);
-  const prominentStatusReason = (item.status === "failed" || item.status === "warning") && item.statusReason
-    ? item.statusReason
-    : null;
-  const { data: config } = useQuery<Config>({ queryKey: ["/api/config"] });
-  const trusted = isTrustedAuthor(item.author, config?.trustedReviewers);
-
-  return (
-    <Collapsible.Root defaultOpen={!collapsedByDefault} className="border-b border-border">
-      <div className="px-4 py-3">
-        {/* Header row - always visible */}
-        <div className="flex items-start gap-3">
-          <div className="shrink-0 pt-0.5">
-            <FeedbackStatusTag status={item.status} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="mb-1 flex flex-wrap items-center gap-2">
-              <span className="font-medium">{item.author}</span>
-              {trusted && (
-                <span
-                  className="rounded-md border border-success-border bg-success-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider text-success-foreground"
-                  title={`@${item.author} is in Trusted reviewers — feedback is auto-accepted, agent evaluation skipped.`}
-                  data-testid={`feedback-trusted-${item.id}`}
-                >
-                  trusted
-                </span>
-              )}
-              {item.file && (
-                <span className="font-mono text-[11px] text-muted-foreground">
-                  {item.file}{item.line ? `:${item.line}` : ""}
-                </span>
-              )}
-              <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
-              {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
-            </div>
-            {prominentStatusReason && (
-              <div className="mt-1 whitespace-pre-wrap break-words border border-destructive/30 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
-                <span className="font-medium uppercase tracking-wider">Failure reason:</span>{" "}
-                {prominentStatusReason}
-              </div>
-            )}
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {!readOnly && (item.status === "failed" || item.status === "warning") && (
-              <button
-                type="button"
-                onClick={() => retryMutation.mutate()}
-                disabled={retryMutation.isPending || globalDrainMode}
-                data-testid={`retry-${item.id}`}
-                aria-label={`Retry feedback from ${item.author}`}
-                title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Retry feedback item"}
-                className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
-              >
-                {globalDrainMode ? DRAIN_PAUSED_LABEL : "Retry"}
-              </button>
-            )}
-            <Collapsible.Trigger asChild>
-              <button
-                type="button"
-                data-testid={`toggle-${item.id}`}
-                aria-label={`${collapsedByDefault ? "Show" : "Hide"} feedback details from ${item.author}`}
-                title="Toggle feedback details"
-                className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-              >
-                Details
-              </button>
-            </Collapsible.Trigger>
-            {!readOnly && (["accept", "reject", "flag"] as const).map((decision) => {
-              const selected = item.decision === decision;
-              const selectedClass =
-                decision === "accept"
-                  ? "border-success-border bg-success-muted text-success-foreground"
-                  : decision === "reject"
-                    ? "border-destructive bg-destructive/10 text-destructive"
-                    : "border-warning-border bg-warning-muted text-warning-foreground";
-              return (
-                <button
-                  type="button"
-                  key={decision}
-                  onClick={() => overrideMutation.mutate(decision)}
-                  data-testid={`override-${decision}-${item.id}`}
-                  aria-label={`${decision} feedback from ${item.author}`}
-                  aria-pressed={selected}
-                  className={`cursor-pointer rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
-                    selected ? selectedClass : "border-border text-muted-foreground hover:bg-muted hover:text-foreground"
-                  }`}
-                >
-                  {decision}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-      <Collapsible.Content>
-        <div className="px-4 pb-3">
-          {item.bodyHtml ? (
-            <div
-              className="feedback-markdown text-[12px] leading-relaxed"
-              dangerouslySetInnerHTML={{ __html: item.bodyHtml }}
-            />
-          ) : (
-            <p className="whitespace-pre-wrap text-[12px] leading-relaxed text-foreground/80">{item.body}</p>
-          )}
-          {item.statusReason && !prominentStatusReason && (
-            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
-              <span className="font-medium uppercase tracking-wider text-foreground/70">Status reason:</span>{" "}
-              {item.statusReason}
-            </p>
-          )}
-          {item.decisionReason && (
-            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
-              <span className="font-medium uppercase tracking-wider text-foreground/70">Decision reason:</span>{" "}
-              {item.decisionReason}
-            </p>
+            ))
           )}
         </div>
-      </Collapsible.Content>
-    </Collapsible.Root>
-  );
-}
+      </DetailPanel>
 
-function LogPanel({ prId }: { prId: string | null }) {
-  const scrollerRef = useRef<HTMLDivElement>(null);
-  const { data: logs = [] } = useQuery<LogEntry[]>({
-    queryKey: ["/api/logs", prId ?? "all"],
-    queryFn: async () => {
-      const url = prId ? `/api/logs?prId=${encodeURIComponent(prId)}` : "/api/logs";
-      const res = await apiRequest("GET", url);
-      return res.json();
-    },
-    refetchInterval: 1500,
-  });
-  const visibleLogs = useMemo(
-    () => logs.length > MAX_VISIBLE_LOGS ? logs.slice(-MAX_VISIBLE_LOGS) : logs,
-    [logs],
-  );
-  const hiddenLogCount = logs.length - visibleLogs.length;
-
-  useEffect(() => {
-    const scroller = scrollerRef.current;
-    if (!scroller) {
-      return;
-    }
-
-    scroller.scrollTop = scroller.scrollHeight;
-  }, [logs.length, prId]);
-
-  return (
-    <div className="flex h-full flex-col">
-      <div ref={scrollerRef} className="flex-1 overflow-y-auto p-4 font-mono text-[11px] leading-relaxed">
-        {logs.length === 0 ? (
-          <span className="text-muted-foreground">No log entries.</span>
-        ) : (
-          <>
-            {hiddenLogCount > 0 && (
-              <div className="border-b border-border/60 pb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-                Showing latest {MAX_VISIBLE_LOGS} of {logs.length} entries.
-              </div>
-            )}
-            {visibleLogs.map((log) => {
-              const metadataText = log.metadata && Object.keys(log.metadata).length > 0
-                ? JSON.stringify(log.metadata, null, 2)
-                : null;
-
-              return (
-                <div key={log.id} className="border-b border-border/60 py-2 last:border-b-0" data-testid={`log-${log.id}`}>
-                  <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-                    <span>{formatClock(log.timestamp)}</span>
-                    <span className={
-                      log.level === "error" ? "text-destructive" :
-                      log.level === "warn" ? "text-warning-foreground" :
-                      log.level === "info" ? "text-primary" :
-                      "text-muted-foreground"
-                    }>
-                      {log.level}
-                    </span>
-                    {log.phase && <span className="border border-border px-1 py-0">{log.phase}</span>}
-                    {log.runId && <span className="normal-case text-foreground/45">run {log.runId.slice(0, 8)}</span>}
-                  </div>
-                  <div className={`mt-1 break-words ${log.level === "error" ? "text-destructive" : "text-foreground/75"}`}>
-                    {log.message}
-                  </div>
-                  {metadataText && (
-                    <pre className="mt-1 whitespace-pre-wrap break-all text-[10px] text-muted-foreground">
-                      {metadataText}
-                    </pre>
-                  )}
-                </div>
-              );
-            })}
-          </>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function HealingPanel({
-  pr,
-  config,
-  healingSessions,
-}: {
-  pr: PR;
-  config: Config | undefined;
-  healingSessions: HealingSession[];
-}) {
-  const session = selectRelevantHealingSession(healingSessions, pr.id);
-  const view = session ? getHealingSessionView(session, config) : null;
-  const toneClass = view ? HEALING_TONE_CLASSES[view.tone] : HEALING_TONE_CLASSES.neutral;
-
-  return (
-    <div
-      className="shrink-0 border-b border-border px-4 py-3"
-      data-testid="panel-ci-healing"
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">CI healing</div>
-          <div className="mt-1 flex flex-wrap items-center gap-2">
-            {view ? (
-              <>
-                <span className={`inline-flex rounded-md border px-1.5 py-0.5 text-[11px] font-medium uppercase tracking-wider ${toneClass}`}>
-                  {view.stateLabel}
-                </span>
-                <span className="text-[11px] text-muted-foreground">{view.attemptSummary}</span>
-              </>
-            ) : (
-              <span className="text-[11px] text-muted-foreground">
-                {config?.autoHealCI === false
-                  ? "Automatic CI healing is disabled in settings."
-                  : "No healing session yet for this PR."}
-              </span>
-            )}
-          </div>
-        </div>
-        {session && (
-          <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
-            head {session.currentHeadSha.slice(0, 7)}
-          </span>
-        )}
-      </div>
-
-      {view ? (
-        <>
-          <div className="mt-2 grid gap-1 text-[11px]">
-            {view.reasonSummary && (
-              <div>
-                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Reason</span>
-                <span className="ml-2 text-foreground/80">{view.reasonSummary}</span>
-              </div>
-            )}
-            <div className="text-muted-foreground">{view.statusHint}</div>
-            <div>
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Attempts</span>
-              <span className="ml-2 font-mono text-foreground/80">{view.attemptSummary}</span>
-              {session?.latestFingerprint && (
-                <>
-                  <span className="mx-1.5 text-border" aria-hidden="true">·</span>
-                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">fingerprint</span>
-                  <span className="ml-1.5 font-mono text-foreground/80">{session.latestFingerprint}</span>
-                </>
-              )}
-            </div>
-          </div>
-          {view.actions.length > 0 && (
-            <>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {view.actions.map((action) => (
-                  <button
-                    key={action.label}
-                    type="button"
-                    disabled
-                    title={action.hint}
-                    className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors ${
-                      action.available
-                        ? "border-border text-foreground/70 hover:bg-muted"
-                        : "border-border text-muted-foreground/60"
-                    } disabled:opacity-100`}
-                  >
-                    {action.label}
-                  </button>
-                ))}
-              </div>
-              <div className="mt-1 text-[10px] text-muted-foreground">
-                Operator controls are read-only until healing action endpoints are added.
-              </div>
-            </>
-          )}
-        </>
-      ) : (
-        config?.autoHealCI !== false && (
-          <div className="mt-2 text-[11px] text-muted-foreground">
-            The watcher will create a healing session when a failing check is classified as healable.
-          </div>
-        )
-      )}
-    </div>
-  );
-}
-
-function RightPanel({
-  prId,
-  prStatus,
-  globalDrainMode,
-}: {
-  prId: string | null;
-  prStatus?: PR["status"] | null;
-  globalDrainMode: boolean;
-}) {
-  const [tab, setTab] = useState<"activity" | "ask">("ask");
-
-  useEffect(() => {
-    if (prStatus === "error") {
-      setTab("activity");
-    }
-  }, [prId, prStatus]);
-
-  return (
-    <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
-      <div className="flex border-b border-border">
-        <button
-          type="button"
-          onClick={() => setTab("ask")}
-          data-testid="tab-ask"
-          className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-            tab === "ask"
-              ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          Ask Agent
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab("activity")}
-          data-testid="tab-activity"
-          className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-            tab === "activity"
-              ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          Activity
-        </button>
-      </div>
-      <div className="flex-1 overflow-hidden">
-        {tab === "activity" ? (
-          <LogPanel prId={prId} />
-        ) : prId ? (
-          <QAPanel prId={prId} globalDrainMode={globalDrainMode} />
-        ) : (
-          <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
-            Select a PR to ask questions.
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function QAPanel({ prId, globalDrainMode }: { prId: string; globalDrainMode: boolean }) {
-  const [input, setInput] = useState("");
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  const { data: questions = [] } = useQuery<PRQuestion[]>({
-    queryKey: ["/api/prs", prId, "questions"],
-    refetchInterval: 2000,
-  });
-
-  const askMutation = useMutation({
-    mutationFn: (question: string) =>
-      apiRequest("POST", `/api/prs/${prId}/questions`, { question }).then((res) => res.json()),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/prs", prId, "questions"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
-      setInput("");
-    },
-  });
-
-  useEffect(() => {
-    const scroller = scrollRef.current;
-    if (scroller) scroller.scrollTop = scroller.scrollHeight;
-  }, [questions.length, questions[questions.length - 1]?.status]);
-
-  const askDisabled = askMutation.isPending || !input.trim() || globalDrainMode;
-
-  return (
-    <div className="flex h-full flex-col">
-      <div className="border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
-        Ask Agent
-      </div>
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
-        {questions.length === 0 ? (
-          <span className="text-[12px] text-muted-foreground">
-            {globalDrainMode
-              ? ASK_DRAIN_COPY
-              : "Ask questions about this PR — the agent will read activity logs, feedback, and status to answer."}
-          </span>
-        ) : (
-          questions.map((q) => (
-            <div key={q.id} className="space-y-1.5" data-testid={`question-${q.id}`}>
-              <div className="text-[12px]">
-                <span className="font-medium text-foreground/90">Q: </span>
-                <span className="text-foreground/80">{q.question}</span>
-              </div>
-              {q.status === "pending" || q.status === "answering" ? (
-                <div className="text-[11px] text-muted-foreground animate-pulse">
-                  Agent is thinking...
-                </div>
-              ) : q.status === "error" ? (
-                <div className="text-[11px] text-destructive">
-                  Error: {q.error || "Unknown error"}
-                </div>
-              ) : (
-                <div className="text-[12px] leading-relaxed text-foreground/85 whitespace-pre-wrap border-l-2 border-primary/40 pl-3">
-                  {q.answer}
-                </div>
-              )}
-              <div className="text-[10px] text-muted-foreground">
-                {formatClock(q.createdAt)}
-                {q.answeredAt && ` — answered ${formatClock(q.answeredAt)}`}
-              </div>
-            </div>
-          ))
-        )}
-      </div>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!askDisabled) askMutation.mutate(input.trim());
-        }}
-        className="border-t border-border p-3"
+      <DetailPanel
+        title="In progress"
+        tone={activities.inProgress.length > 0 ? "warning" : "neutral"}
+        testId="dashboard-activity-in-progress"
+        chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.inProgress.length}</span>}
       >
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder={globalDrainMode ? "Drain mode is enabled." : "Was the review done? Why did this fail?"}
-            aria-label="Question for selected pull request"
-            disabled={globalDrainMode}
-            data-testid="input-question"
-            className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-          />
-          <button
-            type="submit"
-            disabled={askDisabled}
-            title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Ask agent"}
-            data-testid="button-ask"
-            className="cursor-pointer border border-primary bg-primary px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            {globalDrainMode ? DRAIN_PAUSED_LABEL : askMutation.isPending ? "..." : "Ask"}
-          </button>
+        <div className="max-h-48 overflow-y-auto">
+          {activities.inProgress.length === 0 ? (
+            <div className="px-3 py-2 text-[12px] text-muted-foreground">No active jobs.</div>
+          ) : (
+            activities.inProgress.slice(0, 8).map((item) => (
+              <div key={item.id} className="border-b border-border/60 px-3 py-2 last:border-b-0">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="inline-flex items-center gap-1 truncate text-[12px] text-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin text-primary" />
+                    {item.label}
+                  </span>
+                  <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(item.startedAt ?? item.updatedAt)}</span>
+                </div>
+                {item.detail && (
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
+                )}
+              </div>
+            ))
+          )}
         </div>
-        {askMutation.isError && (
-          <div className="mt-1 text-[11px] text-destructive">
-            {getErrorMessage(askMutation.error)}
-          </div>
-        )}
-      </form>
+      </DetailPanel>
+
+      <DetailPanel
+        title="Queued"
+        testId="dashboard-activity-queued"
+        chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.queued.length}</span>}
+      >
+        <div className="max-h-48 overflow-y-auto">
+          {activities.queued.length === 0 ? (
+            <div className="px-3 py-2 text-[12px] text-muted-foreground">Queue is empty.</div>
+          ) : (
+            activities.queued.slice(0, 8).map((item) => (
+              <div key={item.id} className="border-b border-border/60 px-3 py-2 last:border-b-0">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="truncate text-[12px] text-foreground">{item.label}</span>
+                  <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(item.queuedAt)}</span>
+                </div>
+                {item.detail && (
+                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </DetailPanel>
     </div>
   );
-}
-
-function getErrorMessage(error: unknown): string {
-  if (!(error instanceof Error)) {
-    return String(error);
-  }
-
-  const raw = error.message.replace(/^\d+:\s*/, "").trim();
-  if (!raw) {
-    return "Request failed";
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as { error?: unknown; message?: unknown };
-    if (typeof parsed.error === "string") {
-      return parsed.error;
-    }
-    if (typeof parsed.message === "string") {
-      return parsed.message;
-    }
-  } catch {
-    // Keep the original message when the server did not return JSON.
-  }
-
-  return raw;
-}
-
-function showMutationError(title: string, error: unknown) {
-  toast({
-    variant: "destructive",
-    title,
-    description: getErrorMessage(error),
-  });
 }
 
 export default function Dashboard() {
-  const [selectedPRId, setSelectedPRId] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<"active" | "issues" | "archived">("active");
-  const [prNumberSearch, setPrNumberSearch] = useState("");
-  const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
-  const handleSyncDashboard = async () => {
-    setIsRefreshing(true);
-    try {
-      await apiRequest("POST", "/api/repos/sync");
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["/api/prs"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/healing-sessions"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/runtime"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] }),
-      ]);
-    } finally {
-      setIsRefreshing(false);
-    }
-  };
-
-  const { data: prs = [], isLoading } = useQuery<PRSummary[]>({
+  const { data: config } = useQuery<Config>({ queryKey: ["/api/config"] });
+  const { data: prs = [], isLoading: prsLoading } = useQuery<PR[]>({
     queryKey: ["/api/prs"],
-    refetchInterval: 3000,
   });
-
-  const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PRSummary[]>({
-    queryKey: ["/api/prs/archived"],
-    refetchInterval: 10000,
+  const { data: issuesPage, isLoading: issuesLoading } = useQuery<IssueListPage>({
+    queryKey: ["/api/issues", 100, 0],
+    queryFn: () => fetchJson<IssueListPage>("/api/issues?limit=100&offset=0"),
   });
-
-  const { data: runtimeState } = useQuery<RuntimeState>({
-    queryKey: ["/api/runtime"],
-    refetchInterval: 3000,
-  });
-  const globalDrainMode = runtimeState?.drainMode === true;
-
-  const { data: issuesPage, isLoading: isLoadingIssues } = useQuery<IssueListPage>({
-    queryKey: ["/api/issues"],
-    enabled: runtimeState !== undefined && !globalDrainMode,
-    refetchInterval: 30000,
-  });
-  const issues = issuesPage?.items ?? [];
-
-  const { data: config } = useQuery<Config>({
-    queryKey: ["/api/config"],
-    refetchInterval: 5000,
-  });
-
-  const { data: healingSessions = [] } = useQuery<HealingSession[]>({
-    queryKey: ["/api/healing-sessions"],
-    queryFn: async () => fetchJson<HealingSession[]>("/api/healing-sessions"),
-    refetchInterval: 5000,
-  });
-
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
-    refetchInterval: 3000,
-  });
-  const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
-
-  const { data: repos = [] } = useQuery<WatchedRepo[]>({
-    queryKey: ["/api/repos/settings"],
-    refetchInterval: 5000,
   });
 
-  const issueLinkedPRByKey = useMemo(() => buildIssueLinkedPRIndex(issues), [issues]);
-  const issueLinkedPRs = useMemo(
-    () => prs.filter((pr) => issueLinkedPRByKey.has(prIssueLinkKey(pr.repo, pr.number))),
-    [prs, issueLinkedPRByKey],
-  );
-  const displayedPRs = (viewMode === "archived"
-    ? archivedPRs
-    : viewMode === "issues"
-      ? issueLinkedPRs
-      : prs
-  )
-    .filter((pr) => matchesNumberSearch(pr.number, prNumberSearch))
-    .sort((a, b) => b.number - a.number);
-  const isArchived = viewMode === "archived";
-  const normalizedPrNumberSearch = normalizeNumberSearch(prNumberSearch);
-  const isLoadingCurrentView = isArchived ? isLoadingArchived : viewMode === "issues" ? isLoading || isLoadingIssues : isLoading;
-  const selectedPRSummary = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
-  const { data: selectedPRDetail } = useQuery<PR | null>({
-    queryKey: ["/api/prs", selectedPRId],
-    enabled: selectedPRId !== null,
-    queryFn: async () => {
-      if (!selectedPRId) return null;
-      return fetchJson<PR>(`/api/prs/${selectedPRId}`);
-    },
-    refetchInterval: 3000,
-  });
+  const watchedRepos = config?.watchedRepos ?? [];
 
-  useEffect(() => {
-    if (displayedPRs.length === 0) {
-      if (selectedPRId !== null) {
-        setSelectedPRId(null);
-      }
-      return;
+  const repoStats: RepoStats[] = useMemo(() => {
+    const prsByRepo = new Map<string, PR[]>();
+    for (const pr of prs) {
+      const list = prsByRepo.get(pr.repo) ?? [];
+      list.push(pr);
+      prsByRepo.set(pr.repo, list);
     }
+    const repoTotals = issuesPage?.repoTotals ?? {};
+    return watchedRepos.map((repo) => ({
+      repo,
+      prCounts: buildPRBreakdown(prsByRepo.get(repo) ?? []),
+      issueCount: repoTotals[repo] ?? 0,
+    }));
+  }, [prs, issuesPage, watchedRepos]);
 
-    if (!selectedPRId || !displayedPRs.some((pr) => pr.id === selectedPRId)) {
-      setSelectedPRId(displayedPRs[0].id);
-    }
-  }, [displayedPRs, selectedPRId]);
+  const totalPRs = prs.length;
+  const totalIssues = issuesPage?.totalCount ?? 0;
+  const failedPRs = prs.filter((pr) => pr.status === "error").length;
+  const inProgressPRs = prs.filter((pr) => pr.status === "processing").length;
+  const activeJobs = activities.inProgress.length + activities.queued.length;
+  const failedJobs = activities.failed.length;
+  const failedTotal = failedPRs + failedJobs;
 
-  const selectedPR = selectedPRDetail ?? null;
-  const selectedPRWatchEnabled = selectedPRSummary ? isPRWatchEnabled(selectedPRSummary) : true;
-  const selectedFailedActivity = selectedPRSummary ? latestActivityForTarget(activities.failed, selectedPRSummary.id) : undefined;
-  const selectedPRQueueStatus = selectedPRSummary ? queueStatusById.get(selectedPRSummary.id) ?? null : null;
-  const selectedPRErrorMessage = selectedPRSummary?.status === "error"
-    ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
-    : null;
-  const activeErrorCount = activities.failed.length + activities.warnings.length;
-
-  const applyMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await apiRequest("POST", `/api/prs/${id}/apply`);
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
-    },
-    onError: (error) => {
-      showMutationError("Could not run babysitter", error);
-    },
-  });
-
-  const watchMutation = useMutation({
-    mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
-      const res = await apiRequest("PATCH", `/api/prs/${id}/watch`, { enabled });
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
-    },
-    onError: (error) => {
-      showMutationError("Could not update PR watch state", error);
-    },
-  });
-  const syncPrMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await apiRequest("POST", `/api/prs/${id}/fetch`);
-      return res.json() as Promise<PR>;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
-      toast({ description: "PR sync complete." });
-    },
-    onError: (error) => {
-      showMutationError("Could not sync PR", error);
-    },
-  });
-
-  const updateConfigMutation = useMutation({
-    mutationFn: async (updates: Partial<Config>) => {
-      const res = await apiRequest("PATCH", "/api/config", updates);
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/config"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
-    },
-    onError: (error) => {
-      showMutationError("Could not update settings", error);
-    },
-  });
-
-  const clearFailedActivitiesMutation = useMutation({
-    mutationFn: async () => {
-      const res = await apiRequest("DELETE", "/api/activities/failed");
-      return res.json() as Promise<{ cleared: number }>;
-    },
-    onSuccess: ({ cleared }) => {
-      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
-      toast({ description: cleared === 1 ? "Cleared 1 failed activity." : `Cleared ${cleared} failed activities.` });
-    },
-    onError: (error) => {
-      showMutationError("Could not clear failed activities", error);
-    },
-  });
-
-  const clearIssueFailureMutation = useMutation({
-    mutationFn: async (activity: ActivityItem) => {
-      const issueTarget = parseIssueTargetId(activity.targetId);
-      if (!issueTarget) {
-        throw new Error(`Could not parse issue target ${activity.targetId}`);
-      }
-
-      const res = await apiRequest("DELETE", "/api/issues/work/failures", issueTarget);
-      return res.json() as Promise<{ repo: string; number: number; id: string }>;
-    },
-    onSuccess: (issue) => {
-      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/issues"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] });
-      queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] });
-      toast({ description: `Cleared failed work attempts for #${issue.number}.` });
-    },
-    onError: (error) => {
-      showMutationError("Could not clear issue failure", error);
-    },
-  });
+  const isLoading = prsLoading || issuesLoading;
 
   return (
     <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
       <UpdateBanner />
       <AppHeader
-        active="prs"
+        active="dashboard"
         status={(
-          <span>
-            <span className="font-mono text-foreground">{prs.length}</span> PR{prs.length !== 1 ? "s" : ""} / <span className="font-mono text-foreground">{repos.length}</span> repo{repos.length !== 1 ? "s" : ""}
-          </span>
-        )}
-        actions={(
           <>
-            <label htmlFor="dashboard-coding-agent" className="text-[11px] uppercase tracking-wider text-muted-foreground">Agent</label>
-            <select
-              id="dashboard-coding-agent"
-              value={config?.codingAgent ?? "codex"}
-              onChange={(e) => {
-                const newAgent = e.target.value as Config["codingAgent"];
-                updateConfigMutation.mutate({
-                  codingAgent: newAgent,
-                });
-              }}
-              disabled={updateConfigMutation.isPending}
-              data-testid="select-coding-agent"
-              className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-1 text-[11px] transition-colors focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <option value="codex">codex</option>
-              <option value="claude">claude</option>
-            </select>
-            {activeErrorCount > 0 && (
-              <button
-                type="button"
-                onClick={() => {
-                  setAreErrorsRolledUp(false);
-                  scrollToDashboardErrors();
-                }}
-                data-testid="dashboard-error-pill"
-                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 px-2 py-0.5 text-[11px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-              >
-                <AlertTriangle className="h-3 w-3" aria-hidden="true" />
-                errors
-                <span className="font-mono">{activeErrorCount}</span>
-              </button>
+            <span><span className="font-mono text-foreground">{watchedRepos.length}</span> repos</span>
+            <span><span className="font-mono text-foreground">{totalPRs}</span> PRs</span>
+            <span><span className="font-mono text-foreground">{totalIssues}</span> issues</span>
+            {failedTotal > 0 && (
+              <span className="text-destructive"><span className="font-mono">{failedTotal}</span> failed</span>
             )}
-            <button
-              type="button"
-              onClick={() => { void handleSyncDashboard(); }}
-              disabled={isRefreshing}
-              data-testid="button-sync-dashboard"
-              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
-            >
-              {isRefreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
-              sync
-            </button>
-            <ActivityMenu
-              activities={activities}
-              onClearFailed={() => clearFailedActivitiesMutation.mutate()}
-              isClearingFailed={clearFailedActivitiesMutation.isPending}
-              globalDrainMode={globalDrainMode}
-              queueStatusById={queueStatusById}
-              pollIntervalMs={config?.pollIntervalMs}
-            />
           </>
         )}
       />
 
-      <OnboardingPanel />
-      <OperatorWarningsBanner warnings={activities.warnings} />
-      <DashboardErrorsPanel
-        activities={activities}
-        onClearFailed={() => clearFailedActivitiesMutation.mutate()}
-        isClearingFailed={clearFailedActivitiesMutation.isPending}
-        onClearIssueFailure={(activity) => clearIssueFailureMutation.mutate(activity)}
-        isClearingIssueFailure={clearIssueFailureMutation.isPending}
-        rolledUp={areErrorsRolledUp}
-        onToggleRolledUp={() => setAreErrorsRolledUp((current) => !current)}
-      />
-      <DashboardDrainBanner runtimeState={runtimeState} />
-
-      <div className="flex flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
-        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-y-auto border-b border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-b-0 lg:border-r">
-          <div className="sticky top-0 z-10 flex shrink-0 border-b border-border bg-background">
-            <button
-              type="button"
-              onClick={() => setViewMode("active")}
-              data-testid="tab-active"
-              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-                viewMode === "active"
-                  ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              Active ({prs.length})
-            </button>
-            <button
-              type="button"
-              onClick={() => setViewMode("issues")}
-              data-testid="tab-on-issues"
-              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-                viewMode === "issues"
-                  ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              Issues ({issueLinkedPRs.length})
-            </button>
-            <button
-              type="button"
-              onClick={() => setViewMode("archived")}
-              data-testid="tab-archived"
-              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-                viewMode === "archived"
-                  ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              Archived ({archivedPRs.length})
-            </button>
-          </div>
-          <div className="border-b border-border px-3 py-2">
-            <label htmlFor="pr-number-search" className="sr-only">Search PR number</label>
-            <input
-              id="pr-number-search"
-              value={prNumberSearch}
-              onChange={(event) => setPrNumberSearch(event.target.value)}
-              placeholder="Search #"
-              data-testid="pr-number-search"
-              className="h-7 w-full rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      <main className="flex-1 overflow-y-auto p-4 lg:p-6">
+        <div className="space-y-4">
+          <section data-testid="dashboard-kpi-strip" className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            <KpiCell label="Watched repos" value={watchedRepos.length} testId="kpi-repos" />
+            <KpiCell label="Open PRs" value={totalPRs} testId="kpi-prs" />
+            <KpiCell label="Open issues" value={totalIssues} testId="kpi-issues" />
+            <KpiCell
+              label="Processing"
+              value={inProgressPRs}
+              tone={inProgressPRs > 0 ? "primary" : "neutral"}
+              testId="kpi-processing"
             />
-          </div>
-          <div className="flex-1">
-            {isLoadingCurrentView ? (
-              <div data-testid="pr-list-loading" aria-label="Loading pull requests">
-                {Array.from({ length: 6 }).map((_, idx) => (
-                  <PRRowSkeleton key={idx} />
-                ))}
-              </div>
-            ) : displayedPRs.length === 0 ? (
-              <div className="p-4 text-[12px] text-muted-foreground">
-                {normalizedPrNumberSearch
-                  ? `No PRs match #${normalizedPrNumberSearch}.`
-                  : isArchived
-                    ? "No archived PRs. Closed PRs are archived automatically."
-                    : viewMode === "issues"
-                      ? "No active PRs are linked from Issues yet."
-                  : "No PRs tracked yet. Add a repository or PR from Settings."}
-              </div>
-            ) : (
-              displayedPRs.map((pr) => (
-                <PRRow
-                  key={pr.id}
-                  pr={pr}
-                  isSelected={pr.id === selectedPRId}
-                  onSelect={setSelectedPRId}
-                  queueStatus={queueStatusById.get(pr.id) ?? null}
-                  issueLink={issueLinkedPRByKey.get(prIssueLinkKey(pr.repo, pr.number)) ?? null}
-                  failureMessage={
-                    pr.status === "error"
-                      ? latestActivityForTarget(activities.failed, pr.id)?.lastError ?? getPRFeedbackFailureReason(pr)
-                      : null
-                  }
-                />
-              ))
-            )}
-          </div>
-        </div>
+            <KpiCell
+              label="Active jobs"
+              value={activeJobs}
+              tone={activeJobs > 0 ? "warning" : "neutral"}
+              testId="kpi-active-jobs"
+            />
+            <KpiCell
+              label="Failed"
+              value={failedTotal}
+              tone={failedTotal > 0 ? "destructive" : "neutral"}
+              testId="kpi-failed"
+            />
+          </section>
 
-        <div className="flex min-h-[32rem] flex-1 flex-col overflow-hidden lg:min-h-0">
-          {selectedPR ? (
-            <>
-              <div className="shrink-0 border-b border-border px-4 py-3">
-                <div className="mb-1 flex items-start justify-between gap-4">
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <StatusDot status={selectedPR.status} />
-                      <span className="truncate text-[15px] font-semibold tracking-tight">{selectedPR.title}</span>
-                      <AgentIndicator pr={selectedPR} />
-                      {!selectedPRWatchEnabled && <WatchPausedIndicator />}
-                      <a
-                        href={selectedPR.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="shrink-0 font-mono text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                      >
-                        {selectedPR.repo}#{selectedPR.number}
-                      </a>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-                      <span>status: <span className="text-foreground">{formatStatusLabel(selectedPR.status)}</span></span>
-                      {!selectedPRWatchEnabled && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <WatchPausedIndicator />
-                        </>
-                      )}
-                      <span className="text-border" aria-hidden="true">·</span>
-                      <span><span className="font-mono text-foreground">{selectedPR.feedbackItems.length}</span> items</span>
-                      {selectedPRQueueStatus && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <QueueStatusBadge status={selectedPRQueueStatus} />
-                        </>
-                      )}
-                      {selectedPR.feedbackItems.length > 0 && (() => {
-                        const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);
-                        return (
-                          <>
-                            {counts.queued > 0 && (
-                              <>
-                                <span className="text-border" aria-hidden="true">·</span>
-                                <span className="text-primary"><span className="font-mono">{counts.queued}</span> queued</span>
-                              </>
-                            )}
-                            {counts.inProgress > 0 && (
-                              <>
-                                <span className="text-border" aria-hidden="true">·</span>
-                                <span className="text-primary"><span className="font-mono">{counts.inProgress}</span> in progress</span>
-                              </>
-                            )}
-                            {counts.failed > 0 && (
-                              <>
-                                <span className="text-border" aria-hidden="true">·</span>
-                                <span className="text-destructive"><span className="font-mono">{counts.failed}</span> failed</span>
-                              </>
-                            )}
-                            {counts.warning > 0 && (
-                              <>
-                                <span className="text-border" aria-hidden="true">·</span>
-                                <span className="text-warning-foreground"><span className="font-mono">{counts.warning}</span> warnings</span>
-                              </>
-                            )}
-                          </>
-                        );
-                      })()}
-                      {selectedPR.testsPassed !== null && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span>tests: <span className={selectedPR.testsPassed ? "text-success" : "text-destructive"}>{selectedPR.testsPassed ? "pass" : "fail"}</span></span>
-                        </>
-                      )}
-                      {selectedPR.lintPassed !== null && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span>lint: <span className={selectedPR.lintPassed ? "text-success" : "text-destructive"}>{selectedPR.lintPassed ? "pass" : "fail"}</span></span>
-                        </>
-                      )}
-                      {selectedPR.lastChecked && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span>checked <span className="font-mono">{formatClock(selectedPR.lastChecked)}</span></span>
-                        </>
-                      )}
-                      {selectedPR.lastSyncSucceededAt && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span>synced <span className="font-mono">{formatClock(selectedPR.lastSyncSucceededAt)}</span></span>
-                        </>
-                      )}
-                      {selectedPR.lastSyncError && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span className="text-destructive">sync error</span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                  {!isArchived && (
-                    <div className="flex flex-wrap items-center justify-end gap-2">
-                      <button
-                        type="button"
-                        onClick={() => syncPrMutation.mutate(selectedPR.id)}
-                        disabled={syncPrMutation.isPending || globalDrainMode}
-                        title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Sync GitHub feedback now"}
-                        data-testid="button-sync-pr"
-                        className="cursor-pointer border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        {syncPrMutation.isPending ? "Syncing" : "Sync"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => applyMutation.mutate(selectedPR.id)}
-                        disabled={applyMutation.isPending || selectedPR.status === "processing" || globalDrainMode}
-                        title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Run babysitter now"}
-                        data-testid="button-apply"
-                        className="cursor-pointer border border-primary bg-primary px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        {globalDrainMode ? DRAIN_PAUSED_LABEL : selectedPR.status === "processing" ? "Running" : "Run now"}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => watchMutation.mutate({ id: selectedPR.id, enabled: !selectedPRWatchEnabled })}
-                        disabled={watchMutation.isPending}
-                        data-testid="button-toggle-watch"
-                        className="cursor-pointer border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
-                      >
-                        {selectedPRWatchEnabled ? "Pause watch" : "Resume watch"}
-                      </button>
-                    </div>
-                  )}
-                </div>
-                {isPRReadyToMerge(selectedPR.feedbackItems) && selectedPR.status !== "processing" && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
-                  <ReadyToMergeIndicator
-                    href={selectedPR.url}
-                    testId="detail-ready-to-merge"
-                    label="All comments resolved — ready to merge"
-                    hint="Open PR on GitHub →"
-                    className="mt-2 gap-2 px-3 py-1.5 text-[12px] tracking-wider"
-                    dotClassName="h-2 w-2"
-                    hintClassName="text-[11px] normal-case tracking-normal text-success-foreground/75"
-                  />
+          <div className="grid gap-4 lg:grid-cols-[1fr_24rem]">
+            <section aria-label="Repository overview">
+              <div className="border-b border-border pb-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+                Repositories
+                {watchedRepos.length > 0 && (
+                  <span className="ml-2 font-mono text-foreground/80">({watchedRepos.length})</span>
                 )}
-                {selectedPRErrorMessage && (
-                  <div
-                    className="mt-2 border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] leading-5 text-destructive"
-                    data-testid="selected-pr-error"
+              </div>
+              {isLoading ? (
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  {Array.from({ length: 4 }).map((_, idx) => (
+                    <Skeleton key={idx} className="h-28 w-full" />
+                  ))}
+                </div>
+              ) : watchedRepos.length === 0 ? (
+                <div
+                  data-testid="dashboard-empty-repos"
+                  className="mt-3 flex flex-col items-start gap-2 rounded-md border border-dashed border-border bg-muted/10 px-4 py-6 text-[12px] text-muted-foreground"
+                >
+                  <AlertTriangle className="h-4 w-4 text-warning-foreground" />
+                  <div>No repositories are being watched yet.</div>
+                  <Link
+                    href="/settings"
+                    className="text-[11px] uppercase tracking-wider text-primary underline decoration-border underline-offset-2 hover:text-primary/90"
                   >
-                    <div className="text-[10px] font-medium uppercase tracking-wider">Automation error</div>
-                    <div className="mt-1 whitespace-pre-wrap break-words">{selectedPRErrorMessage}</div>
-                  </div>
-                )}
-                <div className="mt-2 text-[11px] text-muted-foreground">
-                  {globalDrainMode
-                    ? GLOBAL_DRAIN_PR_COPY
-                    : selectedPRWatchEnabled
-                      ? "Background watcher syncs GitHub feedback and pushes approved fixes automatically."
-                      : "Background watch is paused for this PR; manual runs still work."}
+                    Add a repo in settings →
+                  </Link>
                 </div>
-              </div>
+              ) : (
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  {repoStats.map((stats) => (
+                    <RepoCard key={stats.repo} stats={stats} />
+                  ))}
+                </div>
+              )}
+            </section>
 
-              <HealingPanel pr={selectedPR} config={config} healingSessions={healingSessions} />
-
-              <div className="flex-1 overflow-y-auto">
-                {selectedPR.feedbackItems.length === 0 ? (
-                  <div className="p-4 text-[12px] text-muted-foreground">
-                    {selectedPRWatchEnabled
-                      ? "No feedback yet. The watcher will sync GitHub comments automatically."
-                      : "No feedback yet. Background watch is paused for this PR."}
-                  </div>
-                ) : (
-                  selectedPR.feedbackItems.map((item) => (
-                    <FeedbackRow
-                      key={item.id}
-                      item={item}
-                      prId={selectedPR.id}
-                      readOnly={isArchived}
-                      globalDrainMode={globalDrainMode}
-                    />
-                  ))
-                )}
+            <aside aria-label="Activity">
+              <div className="border-b border-border pb-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+                Activity
               </div>
-            </>
-          ) : (
-            <div className="flex flex-1 items-center justify-center text-[12px] text-muted-foreground">
-              Select a PR from the left panel.
-            </div>
-          )}
+              <div className="mt-3">
+                <DashboardActivityPanel activities={activities} />
+              </div>
+            </aside>
+          </div>
         </div>
-
-        <RightPanel
-          prId={selectedPRId}
-          prStatus={selectedPR?.status ?? null}
-          globalDrainMode={globalDrainMode}
-        />
-      </div>
+      </main>
     </div>
   );
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
-import { AlertTriangle, GitPullRequest, ListTodo, Loader2 } from "lucide-react";
-import type { ActivitySnapshot, Config, IssueListPage, PR } from "@shared/schema";
+import { AlertTriangle, ExternalLink, GitPullRequest, ListTodo, Loader2 } from "lucide-react";
+import type { ActivityItem, ActivitySnapshot, BackgroundJobKind, Config, IssueListPage, PR } from "@shared/schema";
 import { fetchJson } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -41,6 +41,106 @@ function buildPRBreakdown(prs: PR[]): PRBreakdown {
   return result;
 }
 
+function activityTargetRoute(kind: BackgroundJobKind): string | null {
+  switch (kind) {
+    case "babysit_pr":
+    case "answer_pr_question":
+      return "/prs";
+    case "evaluate_issue":
+    case "verify_issue":
+    case "work_issue":
+      return "/issues";
+    case "process_release_run":
+      return "/releases";
+    case "sync_watched_repos":
+    case "heal_deployment":
+    case "generate_social_changelog":
+    default:
+      return null;
+  }
+}
+
+function ActivityRow({ item, accent, leadingIcon, timeRef }: {
+  item: ActivityItem;
+  accent?: "destructive" | "warning" | "neutral";
+  leadingIcon?: React.ReactNode;
+  timeRef?: "queuedAt" | "startedAt" | "updatedAt";
+}) {
+  const route = activityTargetRoute(item.kind);
+  const timestamp = timeRef === "queuedAt"
+    ? item.queuedAt
+    : timeRef === "startedAt"
+      ? (item.startedAt ?? item.updatedAt)
+      : item.updatedAt;
+  const errorMessage = accent === "destructive" ? item.lastError : null;
+
+  const labelClass = accent === "destructive"
+    ? "inline-flex items-center gap-1 truncate text-[12px] font-medium text-destructive"
+    : "inline-flex items-center gap-1 truncate text-[12px] text-foreground";
+
+  const content = (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className={labelClass}>
+          {leadingIcon}
+          {item.label}
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(timestamp)}</span>
+      </div>
+      {item.detail && (
+        <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
+      )}
+      {errorMessage && (
+        <div
+          title={errorMessage}
+          className="mt-1 line-clamp-2 break-words text-[11px] leading-snug text-destructive/85"
+        >
+          {errorMessage}
+        </div>
+      )}
+      {(route || item.targetUrl) && (
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+          {route && (
+            <span className="inline-flex items-center gap-1 text-primary">
+              open {route === "/prs" ? "PR" : route === "/issues" ? "issue" : "page"} →
+            </span>
+          )}
+          {item.targetUrl && (
+            <a
+              href={item.targetUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              onClick={(event) => event.stopPropagation()}
+              className="inline-flex items-center gap-1 underline decoration-border underline-offset-2 hover:text-foreground"
+            >
+              <ExternalLink className="h-3 w-3" />
+              GitHub
+            </a>
+          )}
+        </div>
+      )}
+    </>
+  );
+
+  if (route) {
+    return (
+      <Link
+        href={route}
+        data-testid={`activity-row-${item.id}`}
+        className="block cursor-pointer border-b border-border/60 px-3 py-2 transition-colors last:border-b-0 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div data-testid={`activity-row-${item.id}`} className="border-b border-border/60 px-3 py-2 last:border-b-0">
+      {content}
+    </div>
+  );
+}
+
 function formatRelative(value: string | null | undefined): string {
   if (!value) return "never";
   const parsed = Date.parse(value);
@@ -52,16 +152,24 @@ function formatRelative(value: string | null | undefined): string {
   return `${Math.round(diffMs / 86_400_000)}d ago`;
 }
 
+function scrollToId(id: string): void {
+  if (typeof document === "undefined") return;
+  const target = document.getElementById(id);
+  if (target) target.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
 function KpiCell({
   label,
   value,
   tone = "neutral",
   testId,
+  scrollTo,
 }: {
   label: string;
   value: number | string;
   tone?: "neutral" | "primary" | "success" | "warning" | "destructive";
   testId?: string;
+  scrollTo?: string;
 }) {
   const toneClass = tone === "destructive"
     ? "border-destructive/40 bg-destructive/[0.04] text-destructive"
@@ -73,11 +181,24 @@ function KpiCell({
           ? "border-primary/40 bg-primary/[0.04] text-primary"
           : "border-border bg-muted/20 text-foreground";
 
+  const baseClass = `flex flex-col gap-1 rounded-md border px-3 py-2 ${toneClass}`;
+
+  if (scrollTo) {
+    return (
+      <button
+        type="button"
+        data-testid={testId}
+        onClick={() => scrollToId(scrollTo)}
+        className={`${baseClass} text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring`}
+      >
+        <div className="text-[10px] font-medium uppercase tracking-wider opacity-80">{label}</div>
+        <div className="font-mono text-xl leading-none">{value}</div>
+      </button>
+    );
+  }
+
   return (
-    <div
-      data-testid={testId}
-      className={`flex flex-col gap-1 rounded-md border px-3 py-2 ${toneClass}`}
-    >
+    <div data-testid={testId} className={baseClass}>
       <div className="text-[10px] font-medium uppercase tracking-wider opacity-80">{label}</div>
       <div className="font-mono text-xl leading-none">{value}</div>
     </div>
@@ -133,30 +254,29 @@ function RepoCard({ stats }: { stats: RepoStats }) {
 function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }) {
   return (
     <div className="flex flex-col gap-3">
-      <DetailPanel
-        title="Failed"
-        tone={activities.failed.length > 0 ? "destructive" : "neutral"}
-        testId="dashboard-activity-failed"
-        chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.failed.length}</span>}
-      >
-        <div className="max-h-48 overflow-y-auto">
-          {activities.failed.length === 0 ? (
-            <div className="px-3 py-2 text-[12px] text-muted-foreground">No failures.</div>
-          ) : (
-            activities.failed.slice(0, 8).map((item) => (
-              <div key={item.id} className="border-b border-border/60 px-3 py-2 last:border-b-0">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="truncate text-[12px] text-foreground">{item.label}</span>
-                  <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(item.updatedAt)}</span>
-                </div>
-                {item.detail && (
-                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
-                )}
-              </div>
-            ))
-          )}
-        </div>
-      </DetailPanel>
+      <div id="failed-activity" className="scroll-mt-4">
+        <DetailPanel
+          title="Failed"
+          tone={activities.failed.length > 0 ? "destructive" : "neutral"}
+          testId="dashboard-activity-failed"
+          chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.failed.length}</span>}
+        >
+          <div className="max-h-72 overflow-y-auto">
+            {activities.failed.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-muted-foreground">No failures.</div>
+            ) : (
+              activities.failed.slice(0, 12).map((item) => (
+                <ActivityRow
+                  key={item.id}
+                  item={item}
+                  accent="destructive"
+                  leadingIcon={<AlertTriangle className="h-3 w-3 text-destructive" />}
+                />
+              ))
+            )}
+          </div>
+        </DetailPanel>
+      </div>
 
       <DetailPanel
         title="In progress"
@@ -169,18 +289,12 @@ function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }
             <div className="px-3 py-2 text-[12px] text-muted-foreground">No active jobs.</div>
           ) : (
             activities.inProgress.slice(0, 8).map((item) => (
-              <div key={item.id} className="border-b border-border/60 px-3 py-2 last:border-b-0">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="inline-flex items-center gap-1 truncate text-[12px] text-foreground">
-                    <Loader2 className="h-3 w-3 animate-spin text-primary" />
-                    {item.label}
-                  </span>
-                  <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(item.startedAt ?? item.updatedAt)}</span>
-                </div>
-                {item.detail && (
-                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
-                )}
-              </div>
+              <ActivityRow
+                key={item.id}
+                item={item}
+                leadingIcon={<Loader2 className="h-3 w-3 animate-spin text-primary" />}
+                timeRef="startedAt"
+              />
             ))
           )}
         </div>
@@ -196,15 +310,7 @@ function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }
             <div className="px-3 py-2 text-[12px] text-muted-foreground">Queue is empty.</div>
           ) : (
             activities.queued.slice(0, 8).map((item) => (
-              <div key={item.id} className="border-b border-border/60 px-3 py-2 last:border-b-0">
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="truncate text-[12px] text-foreground">{item.label}</span>
-                  <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(item.queuedAt)}</span>
-                </div>
-                {item.detail && (
-                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
-                )}
-              </div>
+              <ActivityRow key={item.id} item={item} timeRef="queuedAt" />
             ))
           )}
         </div>
@@ -264,7 +370,14 @@ export default function Dashboard() {
             <span><span className="font-mono text-foreground">{totalPRs}</span> PRs</span>
             <span><span className="font-mono text-foreground">{totalIssues}</span> issues</span>
             {failedTotal > 0 && (
-              <span className="text-destructive"><span className="font-mono">{failedTotal}</span> failed</span>
+              <button
+                type="button"
+                onClick={() => scrollToId("failed-activity")}
+                data-testid="header-failed-link"
+                className="cursor-pointer rounded-md border border-destructive/40 bg-destructive/[0.06] px-1.5 py-0 text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <span className="font-mono">{failedTotal}</span> failed →
+              </button>
             )}
           </>
         )}
@@ -293,6 +406,7 @@ export default function Dashboard() {
               value={failedTotal}
               tone={failedTotal > 0 ? "destructive" : "neutral"}
               testId="kpi-failed"
+              scrollTo={failedTotal > 0 ? "failed-activity" : undefined}
             />
           </section>
 

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { Link } from "wouter";
+import { useMemo, type KeyboardEvent } from "react";
+import { Link, useLocation } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, ExternalLink, GitPullRequest, ListTodo, Loader2 } from "lucide-react";
 import type { ActivityItem, ActivitySnapshot, BackgroundJobKind, Config, IssueListPage, PR } from "@shared/schema";
@@ -66,6 +66,7 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
   leadingIcon?: React.ReactNode;
   timeRef?: "queuedAt" | "startedAt" | "updatedAt";
 }) {
+  const [, setLocation] = useLocation();
   const route = activityTargetRoute(item.kind);
   const timestamp = timeRef === "queuedAt"
     ? item.queuedAt
@@ -78,8 +79,38 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
     ? "inline-flex items-center gap-1 truncate text-[12px] font-medium text-destructive"
     : "inline-flex items-center gap-1 truncate text-[12px] text-foreground";
 
-  const content = (
-    <>
+  const handleNavigate = () => {
+    if (!route) return;
+    setLocation(route);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!route) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setLocation(route);
+    }
+  };
+
+  const interactiveProps = route
+    ? {
+        role: "link" as const,
+        tabIndex: 0,
+        onClick: handleNavigate,
+        onKeyDown: handleKeyDown,
+      }
+    : {};
+
+  return (
+    <div
+      data-testid={`activity-row-${item.id}`}
+      {...interactiveProps}
+      className={`border-b border-border/60 px-3 py-2 last:border-b-0 ${
+        route
+          ? "cursor-pointer transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          : ""
+      }`}
+    >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className={labelClass}>
           {leadingIcon}
@@ -119,24 +150,6 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
           )}
         </div>
       )}
-    </>
-  );
-
-  if (route) {
-    return (
-      <Link
-        href={route}
-        data-testid={`activity-row-${item.id}`}
-        className="block cursor-pointer border-b border-border/60 px-3 py-2 transition-colors last:border-b-0 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-      >
-        {content}
-      </Link>
-    );
-  }
-
-  return (
-    <div data-testid={`activity-row-${item.id}`} className="border-b border-border/60 px-3 py-2 last:border-b-0">
-      {content}
     </div>
   );
 }

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -6,11 +6,17 @@ import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
 import { issueListPageSchema, issueSchema, type ActivitySnapshot, type Config, type Issue, type IssueListPage, type IssueSubtask, type LogEntry, type RuntimeState } from "@shared/schema";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
+import { DetailHeader } from "@/components/detail/DetailHeader";
+import { DetailPanel } from "@/components/detail/DetailPanel";
+import { MetaBreadcrumb, type MetaItem } from "@/components/detail/MetaBreadcrumb";
+import { StageProgressBar } from "@/components/detail/StageProgressBar";
+import { StatusChip } from "@/components/detail/StatusChip";
+import { buildIssueStages } from "@/lib/stages";
+import { autoWorkTone, issueEvaluationTone, issueRowTone, issueWorkStatusTone, toneRailClass } from "@/lib/statusTones";
 
 const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v2";
 const ISSUES_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
@@ -187,19 +193,6 @@ function formatEvaluationConfidence(confidence: number): string {
   return `${grade} (${Math.round(confidence * 100)}%)`;
 }
 
-function getEvaluationBadgeClass(issue: Issue): string {
-  if (issue.evaluationStatus === "approved") {
-    return "border-success-border bg-success-muted text-success-foreground";
-  }
-  if (issue.evaluationStatus === "blocked") {
-    return "border-destructive bg-destructive/10 text-destructive";
-  }
-  if (issue.evaluationStatus === "needs_review") {
-    return "border-warning-border bg-warning-muted text-warning-foreground";
-  }
-  return "border-border text-muted-foreground";
-}
-
 type IssueWorkFilter = "all" | "ready" | "auto" | "needs_eval" | "review" | "failed" | "stale";
 
 function isStaleIssue(issue: Issue): boolean {
@@ -273,19 +266,12 @@ function getLogMetadataEntries(metadata: LogEntry["metadata"]): Array<{ key: str
 }
 
 function IssueStatusBadge({ issue }: { issue: Issue }) {
-  const cls =
-    issue.workStatus === "failed"
-      ? "border-destructive bg-destructive/10 text-destructive"
-      : issue.workStatus === "in_progress"
-        ? "border-primary bg-primary/10 text-primary animate-pulse"
-        : issue.workStatus === "queued"
-          ? "border-primary/50 text-primary"
-          : "border-border text-muted-foreground";
-
   return (
-    <span className={`rounded-md border px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider ${cls}`}>
-      {issue.workStatus.replace("_", " ")}
-    </span>
+    <StatusChip
+      tone={issueWorkStatusTone(issue.workStatus)}
+      pulsing={issue.workStatus === "in_progress"}
+      label={issue.workStatus.replace("_", " ")}
+    />
   );
 }
 
@@ -348,7 +334,11 @@ function IssueRow({
         : null;
 
   return (
-    <div className={`cursor-pointer border-b border-l-2 border-border px-4 py-3 transition-colors ${selected ? "border-l-primary bg-muted" : "border-l-transparent hover:bg-muted/30"}`}>
+    <div className={`cursor-pointer border-b border-border px-4 py-3 transition-colors ${
+      selected
+        ? "border-l-[3px] border-l-primary bg-muted"
+        : `border-l-2 ${toneRailClass(issueRowTone(issue))} hover:bg-muted/30`
+    }`}>
       <button
         type="button"
         onClick={() => onSelect(issue.id)}
@@ -369,23 +359,24 @@ function IssueRow({
             {formatBodyPreview(issue.body)}
           </div>
           <div className="mt-2 flex flex-wrap gap-1">
-            <span
-              data-testid="issue-evaluation-state-list"
+            <StatusChip
+              tone={issueEvaluationTone(issue.evaluationStatus)}
+              label={formatEvaluationState(issue)}
               title={issue.evaluationSummary ?? undefined}
-              className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${getEvaluationBadgeClass(issue)}`}
-            >
-              {formatEvaluationState(issue)}
-            </span>
+              testId="issue-evaluation-state-list"
+            />
             <QueueStatusBadge status={queueStatus} />
             {verifyState && <VerifyStateBadge state={verifyState} />}
+            {issue.isWorked && (
+              <StatusChip tone="success" label="worked" testId="issue-worked-badge" />
+            )}
             {issue.subtasks && issue.subtasks.length >= 2 && (
-              <span
-                data-testid="issue-multi-bug-badge"
+              <StatusChip
+                tone="primary"
+                label={`${issue.subtasks.length} bugs`}
                 title={issue.subtasks.map((task) => `• ${task.title}`).join("\n")}
-                className="border border-primary/60 bg-primary/10 px-1.5 py-0 text-[10px] uppercase tracking-wider text-primary"
-              >
-                {issue.subtasks.length} bugs
-              </span>
+                testId="issue-multi-bug-badge"
+              />
             )}
             {issue.labels.slice(0, 3).map((label) => (
               <span key={label} className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
@@ -464,18 +455,15 @@ function SubtaskListPanel({ subtasks }: { subtasks: IssueSubtask[] }) {
   const doneCount = subtasks.reduce((sum, task) => sum + (task.status === "done" ? 1 : 0), 0);
 
   return (
-    <div
-      data-testid="issue-subtasks"
-      className="mt-3 border border-border/60 bg-muted/10"
-    >
-      <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
-          Subtasks
-        </div>
+    <DetailPanel
+      title="Subtasks"
+      testId="issue-subtasks"
+      chip={(
         <span className="font-mono text-[10px] text-muted-foreground">
           {doneCount} / {subtasks.length} done
         </span>
-      </div>
+      )}
+    >
       <ul className="divide-y divide-border/60">
         {subtasks.map((task) => (
           <li
@@ -508,7 +496,7 @@ function SubtaskListPanel({ subtasks }: { subtasks: IssueSubtask[] }) {
           </li>
         ))}
       </ul>
-    </div>
+    </DetailPanel>
   );
 }
 
@@ -553,6 +541,34 @@ function IssueLogRow({ entry }: { entry: LogEntry }) {
           })}
         </div>
       )}
+    </div>
+  );
+}
+
+function IssueLogPanel({ logs, selected }: { logs: LogEntry[]; selected: boolean }) {
+  return (
+    <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
+      <div className="flex shrink-0 border-b border-border">
+        <div
+          className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+          data-testid="tab-issue-activity"
+        >
+          Activity
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto" data-testid="issue-detail-logs">
+        {!selected ? (
+          <div className="p-4 text-[12px] text-muted-foreground">
+            Select an issue to see logs.
+          </div>
+        ) : logs.length === 0 ? (
+          <div className="p-4 text-[12px] text-muted-foreground">
+            No workflow logs yet.
+          </div>
+        ) : (
+          logs.map((entry) => <IssueLogRow key={entry.id} entry={entry} />)
+        )}
+      </div>
     </div>
   );
 }
@@ -1240,82 +1256,62 @@ function IssuesPage() {
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {selectedIssue ? (
-            <ScrollArea className="min-h-0 flex-1" data-testid="issue-detail-logs">
-              <div className="border-b border-border px-4 py-3">
-                <div className="mb-2 grid grid-cols-[minmax(0,1fr)_auto] items-start gap-3">
-                  <div className="min-w-0">
-                    <h1 className="line-clamp-2 break-words text-[15px] font-semibold leading-snug tracking-tight">
-                      {selectedIssue.title}
-                    </h1>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
-                      <span>{selectedIssue.repo} <span className="font-mono text-foreground/80">#{selectedIssue.number}</span></span>
-                      <span className="text-border" aria-hidden="true">·</span>
-                      <span>author: <span className="text-foreground/80">{selectedIssue.author || "unknown"}</span></span>
-                      <span className="text-border" aria-hidden="true">·</span>
-                      <span>comments: <span className="font-mono text-foreground/80">{selectedIssue.comments}</span></span>
-                      <span className="text-border" aria-hidden="true">·</span>
-                      <span>updated <span className="font-mono">{formatDateTime(selectedIssue.updatedAt)}</span></span>
-                      {selectedIssue.lastSyncSucceededAt && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span>synced <span className="font-mono">{formatDateTime(selectedIssue.lastSyncSucceededAt)}</span></span>
-                        </>
-                      )}
-                      {selectedIssue.lastSyncError && (
-                        <>
-                          <span className="text-border" aria-hidden="true">·</span>
-                          <span className="text-destructive">sync error</span>
-                        </>
-                      )}
-                    </div>
-                    <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <IssueStatusBadge issue={selectedIssue} />
-                      <QueueStatusBadge status={selectedIssueQueueStatus} />
-                      {selectedIssue.workStage && selectedIssue.workStage !== selectedIssue.workStatus && (
-                        <span
-                          data-testid="issue-work-stage"
-                          className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground"
-                        >
-                          {formatIssueWorkStage(selectedIssue)}
-                        </span>
-                      )}
-                      {formatIssueWorkAttempt(selectedIssue) && (
-                        <span
-                          data-testid="issue-work-attempt"
-                          className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground"
-                        >
-                          {formatIssueWorkAttempt(selectedIssue)}
-                        </span>
-                      )}
-                      <span
-                        data-testid="issue-auto-work-state"
-                        className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${
-                          selectedIssue.autoWorkEligible
-                            ? "border-success-border text-success-foreground"
-                            : "border-border text-muted-foreground"
-                        }`}
-                      >
-                        {formatAutoWorkState(selectedIssue)}
-                      </span>
-                      <span
-                        data-testid="issue-evaluation-state"
-                        title={selectedIssue.evaluationSummary ?? undefined}
-                        className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${getEvaluationBadgeClass(selectedIssue)}`}
-                      >
-                        {formatEvaluationState(selectedIssue)}
-                      </span>
-                      <a
-                        href={selectedIssue.url}
-                        target="_blank"
-                        rel="noreferrer noopener"
-                        className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-                      >
-                        <ExternalLink className="h-3.5 w-3.5" />
-                        open issue
-                      </a>
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 justify-end gap-2">
+            <>
+              {(() => {
+                const metaItems: MetaItem[] = [
+                  { key: "repo", content: <span>{selectedIssue.repo} <span className="font-mono text-foreground/80">#{selectedIssue.number}</span></span> },
+                  { key: "author", content: <span>author: <span className="text-foreground/80">{selectedIssue.author || "unknown"}</span></span> },
+                  { key: "comments", content: <span>comments: <span className="font-mono text-foreground/80">{selectedIssue.comments}</span></span> },
+                  { key: "updated", content: <span>updated <span className="font-mono">{formatDateTime(selectedIssue.updatedAt)}</span></span> },
+                ];
+                if (selectedIssue.lastSyncSucceededAt) {
+                  metaItems.push({ key: "synced", content: <span>synced <span className="font-mono">{formatDateTime(selectedIssue.lastSyncSucceededAt)}</span></span> });
+                }
+                if (selectedIssue.lastSyncError) {
+                  metaItems.push({ key: "sync-error", content: <span className="text-destructive">sync error</span> });
+                }
+                return (
+              <DetailHeader
+                title={selectedIssue.title}
+                titleMultiline
+                accentTone="warning"
+                failed={selectedIssue.workStatus === "failed"}
+                stageBar={<StageProgressBar stages={buildIssueStages(selectedIssue)} testId="issue-stage-progress" />}
+                externalLink={{ href: selectedIssue.url, label: `${selectedIssue.repo}#${selectedIssue.number}` }}
+                meta={<MetaBreadcrumb items={metaItems} />}
+                chips={(
+                  <>
+                    <IssueStatusBadge issue={selectedIssue} />
+                    <QueueStatusBadge status={selectedIssueQueueStatus} />
+                    {selectedIssue.workStage && selectedIssue.workStage !== selectedIssue.workStatus && (
+                      <StatusChip
+                        tone="neutral"
+                        label={formatIssueWorkStage(selectedIssue)}
+                        testId="issue-work-stage"
+                      />
+                    )}
+                    {formatIssueWorkAttempt(selectedIssue) && (
+                      <StatusChip
+                        tone="neutral"
+                        label={formatIssueWorkAttempt(selectedIssue) ?? ""}
+                        testId="issue-work-attempt"
+                      />
+                    )}
+                    <StatusChip
+                      tone={autoWorkTone(selectedIssue.autoWorkEligible)}
+                      label={formatAutoWorkState(selectedIssue)}
+                      testId="issue-auto-work-state"
+                    />
+                    <StatusChip
+                      tone={issueEvaluationTone(selectedIssue.evaluationStatus)}
+                      label={formatEvaluationState(selectedIssue)}
+                      title={selectedIssue.evaluationSummary ?? undefined}
+                      testId="issue-evaluation-state"
+                    />
+                  </>
+                )}
+                actions={(
+                  <>
                     <button
                       type="button"
                       onClick={() => syncIssueMutation.mutate(selectedIssue)}
@@ -1417,8 +1413,13 @@ function IssuesPage() {
                         </>
                       )}
                     </button>
-                  </div>
-                </div>
+                  </>
+                )}
+              />
+                );
+              })()}
+              <div className="flex-1 overflow-y-auto" data-testid="issue-detail-body">
+              <div className="px-4 py-3">
                 <div data-testid="issue-label-editor" className="flex flex-wrap items-center gap-1">
                   {selectedIssue.labels.length > 0 ? selectedIssue.labels.map((label) => (
                     <span key={label} className="inline-flex max-w-full items-center gap-1 border border-border pl-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
@@ -1514,14 +1515,11 @@ function IssuesPage() {
                   </a>
                 )}
                 {selectedIssue.workStatus === "failed" && selectedIssue.lastError && (
-                  <div
-                    data-testid="issue-work-failed"
-                    className="mt-3 border border-destructive/40 bg-destructive/10 text-[11px] text-destructive"
-                  >
-                    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-destructive/20 px-3 py-2">
-                      <div className="text-[10px] uppercase tracking-wider text-destructive/70">
-                        Issue work failed
-                      </div>
+                  <DetailPanel
+                    title="Issue work failed"
+                    tone="destructive"
+                    testId="issue-work-failed"
+                    action={(
                       <button
                         type="button"
                         onClick={() => clearFailuresMutation.mutate(selectedIssue)}
@@ -1542,55 +1540,56 @@ function IssuesPage() {
                           </>
                         )}
                       </button>
-                    </div>
-                    <div className="max-h-80 overflow-auto whitespace-pre-wrap px-3 py-2 leading-5">
+                    )}
+                  >
+                    <div className="max-h-80 overflow-auto whitespace-pre-wrap px-3 py-2 text-[11px] leading-5 text-destructive">
                       {selectedIssue.lastError}
                     </div>
-                  </div>
+                  </DetailPanel>
                 )}
                 {selectedIssue.subtasks && selectedIssue.subtasks.length > 0 && (
                   <SubtaskListPanel subtasks={selectedIssue.subtasks} />
                 )}
-                <div
-                  data-testid="issue-evaluation-detail"
-                  className="mt-3 border border-border/60 bg-muted/10 px-3 py-2"
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                      Automation gate
-                    </div>
-                    <span className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${getEvaluationBadgeClass(selectedIssue)}`}>
-                      {formatEvaluationState(selectedIssue)}
-                    </span>
-                  </div>
-                  <div className="mt-2 text-[12px] leading-5 text-foreground/85">
-                    {selectedIssue.evaluationSummary ?? selectedIssue.autoWorkBlockedReason ?? "Evaluate this issue before auto-mode can work it."}
-                  </div>
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                      auto: {selectedIssue.autoWorkEligible ? "enabled" : "blocked"}
-                    </span>
-                    {typeof selectedIssue.evaluationConfidence === "number" && (
-                      <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                        confidence: {formatEvaluationConfidence(selectedIssue.evaluationConfidence)}
-                      </span>
-                    )}
-                    {selectedIssue.evaluationUpdatedAt && (
-                      <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                        evaluated: {formatDateTime(selectedIssue.evaluationUpdatedAt)}
-                      </span>
-                    )}
-                  </div>
-                  {selectedIssue.evaluationSafetyFlags && selectedIssue.evaluationSafetyFlags.length > 0 && (
-                    <div className="mt-2 flex flex-wrap gap-1.5">
-                      {selectedIssue.evaluationSafetyFlags.map((flag) => (
-                        <span key={flag} className="border border-destructive/40 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive">
-                          {flag}
-                        </span>
-                      ))}
-                    </div>
+                <DetailPanel
+                  title="Automation gate"
+                  testId="issue-evaluation-detail"
+                  chip={(
+                    <StatusChip
+                      tone={issueEvaluationTone(selectedIssue.evaluationStatus)}
+                      label={formatEvaluationState(selectedIssue)}
+                    />
                   )}
-                </div>
+                >
+                  <div className="px-3 py-2">
+                    <div className="text-[12px] leading-5 text-foreground/85">
+                      {selectedIssue.evaluationSummary ?? selectedIssue.autoWorkBlockedReason ?? "Evaluate this issue before auto-mode can work it."}
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                        auto: {selectedIssue.autoWorkEligible ? "enabled" : "blocked"}
+                      </span>
+                      {typeof selectedIssue.evaluationConfidence === "number" && (
+                        <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          confidence: {formatEvaluationConfidence(selectedIssue.evaluationConfidence)}
+                        </span>
+                      )}
+                      {selectedIssue.evaluationUpdatedAt && (
+                        <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          evaluated: {formatDateTime(selectedIssue.evaluationUpdatedAt)}
+                        </span>
+                      )}
+                    </div>
+                    {selectedIssue.evaluationSafetyFlags && selectedIssue.evaluationSafetyFlags.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {selectedIssue.evaluationSafetyFlags.map((flag) => (
+                          <span key={flag} className="border border-destructive/40 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive">
+                            {flag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </DetailPanel>
                 <div className="mt-3 text-[11px] uppercase tracking-wider text-muted-foreground">
                   Issue body
                 </div>
@@ -1606,32 +1605,16 @@ function IssuesPage() {
                   </pre>
                 )}
               </div>
-
-              <div className="grid min-h-0 grid-rows-[auto,1fr]">
-                <div className="border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
-                  Recent issue work logs
-                </div>
-                <div>
-                  {issueLogs.length === 0 ? (
-                    <div className="p-4 text-[12px] text-muted-foreground">
-                      No workflow logs yet.
-                    </div>
-                  ) : (
-                    <div>
-                      {issueLogs.map((entry) => (
-                        <IssueLogRow key={entry.id} entry={entry} />
-                      ))}
-                    </div>
-                  )}
-                </div>
               </div>
-            </ScrollArea>
+            </>
           ) : (
             <div className="flex flex-1 items-center justify-center text-[12px] text-muted-foreground">
               Select an issue from the left panel.
             </div>
           )}
         </div>
+
+        <IssueLogPanel logs={issueLogs} selected={Boolean(selectedIssue)} />
       </div>
     </div>
   );

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -1,0 +1,1680 @@
+import { memo, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import { Link } from "wouter";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, Pause, Play, PlayCircle, RefreshCw, Trash2 } from "lucide-react";
+import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
+import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, RuntimeState, WatchedRepo } from "@shared/schema";
+import { AppHeader } from "@/components/AppHeader";
+import { OnboardingPanel } from "@/components/OnboardingPanel";
+import { UpdateBanner } from "@/components/UpdateBanner";
+import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { toast } from "@/hooks/use-toast";
+import {
+  formatFeedbackStatusLabel,
+  getFeedbackStatusBadgeClass,
+  isFeedbackCollapsedByDefault,
+  countActiveFeedbackStatuses,
+  isPRReadyToMerge,
+} from "@/lib/feedbackStatus";
+import {
+  getHealingSessionView,
+  selectRelevantHealingSession,
+} from "@/lib/ciHealing";
+import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
+import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DetailHeader } from "@/components/detail/DetailHeader";
+import { MetaBreadcrumb, type MetaItem } from "@/components/detail/MetaBreadcrumb";
+import { StageProgressBar } from "@/components/detail/StageProgressBar";
+import { StatusChip } from "@/components/detail/StatusChip";
+import { buildPRStages } from "@/lib/stages";
+import { prStatusTone, toneRailClass } from "@/lib/statusTones";
+
+function formatClock(timestamp: string | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
+}
+
+function isPRWatchEnabled(pr: Pick<PRSummary, "watchEnabled">): boolean {
+  return pr.watchEnabled;
+}
+
+function normalizeNumberSearch(value: string): string {
+  return value.trim().replace(/^#/, "").trim();
+}
+
+function matchesNumberSearch(number: number, search: string): boolean {
+  const normalized = normalizeNumberSearch(search);
+  return normalized === "" || String(number).includes(normalized);
+}
+
+function prIssueLinkKey(repo: string, number: number): string {
+  return `${repo}#${number}`;
+}
+
+function buildIssueLinkedPRIndex(issues: Issue[]): Map<string, Issue> {
+  const index = new Map<string, Issue>();
+  for (const issue of issues) {
+    if (issue.workPrNumber === null || issue.workPrNumber === undefined) {
+      continue;
+    }
+
+    index.set(prIssueLinkKey(issue.repo, issue.workPrNumber), issue);
+  }
+  return index;
+}
+
+function formatStatusLabel(status: PR["status"], prStage?: PR["prStage"]): string {
+  if (status === "processing") {
+    if (prStage === "feedback_synced") return "feedback synced";
+    if (prStage === "triaged") return "triaged";
+    if (prStage === "applying") return "applying fixes";
+    if (prStage === "tests") return "running tests";
+    if (prStage === "done") return "completed";
+    return "autonomous run active";
+  }
+
+  if (status === "done") {
+    return "completed";
+  }
+
+  if (status === "error") {
+    return "attention needed";
+  }
+
+  if (status === "archived") {
+    return "archived";
+  }
+
+  return "watching";
+}
+
+function latestActivityForTarget(activities: ActivityItem[], targetId: string): ActivityItem | undefined {
+  return activities.reduce((latest, activity) => {
+    if (activity.targetId !== targetId) {
+      return latest;
+    }
+    if (!latest || Date.parse(activity.updatedAt) > Date.parse(latest.updatedAt)) {
+      return activity;
+    }
+    return latest;
+  }, undefined as ActivityItem | undefined);
+}
+
+function parseIssueTargetId(targetId: string): { repo: string; number: number } | null {
+  const separator = targetId.lastIndexOf("#");
+  if (separator === -1) {
+    return null;
+  }
+
+  const repo = targetId.slice(0, separator);
+  const number = Number(targetId.slice(separator + 1));
+  if (!repo || !Number.isInteger(number) || number <= 0) {
+    return null;
+  }
+
+  return { repo, number };
+}
+
+function scrollToDashboardErrors() {
+  document.getElementById("dashboard-errors")?.scrollIntoView({ block: "start" });
+}
+
+function getPRFeedbackFailureReason(pr: PR | PRSummary | null): string | null {
+  if (!pr || !("feedbackItems" in pr)) {
+    return null;
+  }
+
+  const failedItem = pr.feedbackItems.find((item) =>
+    (item.status === "failed" || item.status === "warning") && Boolean(item.statusReason),
+  );
+
+  return failedItem?.statusReason ?? null;
+}
+
+const MAX_VISIBLE_LOGS = 200;
+const DRAIN_PAUSED_LABEL = "Paused";
+const DRAIN_PAUSED_TITLE = "Paused by drain mode";
+const MANUAL_RUNS_BLOCKED_COPY = "Manual runs are blocked while global automation is paused.";
+const GLOBAL_DRAIN_PR_COPY = "Background and manual runs are paused by drain mode.";
+const ASK_DRAIN_COPY = "Ask Agent is paused by drain mode.";
+
+const HEALING_TONE_CLASSES: Record<"neutral" | "info" | "warning" | "success" | "danger", string> = {
+  neutral: "border-border text-muted-foreground",
+  info: "border-primary bg-primary/10 text-primary",
+  warning: "border-warning-border bg-warning-muted text-warning-foreground",
+  success: "border-success-border bg-success-muted text-success-foreground",
+  danger: "border-destructive bg-destructive/10 text-destructive",
+};
+
+function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
+  const cls = getFeedbackStatusBadgeClass(status);
+  return (
+    <span className={`inline-block border px-1.5 py-0 text-[11px] uppercase tracking-wide ${cls}`}>
+      {formatFeedbackStatusLabel(status)}
+    </span>
+  );
+}
+
+function WatchPausedIndicator() {
+  return (
+    <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+      watch paused
+    </span>
+  );
+}
+
+function DashboardDrainBanner({ runtimeState }: { runtimeState: RuntimeState | undefined }) {
+  if (!runtimeState?.drainMode) {
+    return null;
+  }
+
+  return (
+    <div
+      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-[12px]"
+      data-testid="dashboard-drain-banner"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-destructive">
+            {DRAIN_PAUSED_TITLE}
+          </div>
+          {runtimeState.drainReason ? (
+            <div
+              className="mt-1 break-words text-foreground/80"
+              data-testid="dashboard-drain-reason"
+            >
+              {runtimeState.drainReason}
+            </div>
+          ) : null}
+          <div className="mt-1 text-[11px] text-muted-foreground">
+            {MANUAL_RUNS_BLOCKED_COPY}
+          </div>
+        </div>
+        <Link
+          href="/settings"
+          className="shrink-0 border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        >
+          Settings
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
+  if (warnings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="shrink-0 border-b border-yellow-600/50 bg-yellow-500/10 px-4 py-3"
+      data-testid="operator-warnings-banner"
+    >
+      <div className="space-y-3">
+        {warnings.map((warning) => (
+          <div key={warning.id} data-testid={`operator-warning-${warning.id}`}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="text-[12px] font-medium uppercase tracking-wider text-yellow-600">
+                {warning.title}
+              </div>
+              {warning.targetUrl && (
+                <a
+                  href={warning.targetUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="border border-yellow-600/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-yellow-600 transition-colors hover:bg-yellow-600 hover:text-background"
+                >
+                  Open PR
+                </a>
+              )}
+            </div>
+            <div className="mt-1 text-[12px] text-foreground/80">{warning.message}</div>
+            <ol className="mt-2 list-decimal space-y-1 pl-4 text-[11px] text-muted-foreground">
+              {warning.fixSteps.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ol>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DashboardErrorsPanel({
+  activities,
+  onClearFailed,
+  isClearingFailed,
+  onClearIssueFailure,
+  isClearingIssueFailure,
+  rolledUp,
+  onToggleRolledUp,
+}: {
+  activities: ActivitySnapshot;
+  onClearFailed: () => void;
+  isClearingFailed: boolean;
+  onClearIssueFailure: (activity: ActivityItem) => void;
+  isClearingIssueFailure: boolean;
+  rolledUp: boolean;
+  onToggleRolledUp: () => void;
+}) {
+  if (activities.failed.length === 0) {
+    return null;
+  }
+
+  const latestError = activities.failed[0];
+
+  return (
+    <section
+      id="dashboard-errors"
+      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-3"
+      data-testid="dashboard-errors-panel"
+    >
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="inline-flex items-center gap-2 text-[12px] font-medium uppercase tracking-wider text-destructive">
+          <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+          Needs attention
+          <span className="font-mono text-foreground">{activities.failed.length}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="text-[11px] text-muted-foreground">
+            Failed jobs stay here until retried or cleared from activity.
+          </div>
+          <button
+            type="button"
+            onClick={onClearFailed}
+            disabled={isClearingFailed}
+            data-testid="dashboard-clear-failed-activities"
+            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            {isClearingFailed ? (
+              "Clearing"
+            ) : (
+              <>
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+                Clear failed
+              </>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={onToggleRolledUp}
+            aria-expanded={!rolledUp}
+            data-testid="dashboard-errors-rollup-toggle"
+            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            {rolledUp ? <ChevronDown className="h-3 w-3" aria-hidden="true" /> : <ChevronUp className="h-3 w-3" aria-hidden="true" />}
+            {rolledUp ? "Expand" : "Roll up"}
+          </button>
+        </div>
+      </div>
+      {rolledUp ? (
+        <div
+          className="truncate text-[11px] text-muted-foreground"
+          data-testid="dashboard-errors-rollup-summary"
+          title={latestError?.lastError ?? latestError?.detail ?? latestError?.label}
+        >
+          {`Latest: ${latestError.label}${latestError.detail ? ` - ${latestError.detail}` : ""}`}
+        </div>
+      ) : (
+        <>
+          <div className="grid gap-2 lg:grid-cols-2">
+            {activities.failed.slice(0, 4).map((activity) => (
+              <div
+                key={activity.id}
+                className="rounded-md border border-destructive/40 bg-background/70 px-3 py-2"
+                data-testid={`dashboard-error-${activity.id}`}
+              >
+                <div className="flex min-w-0 items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-[13px] font-medium text-foreground">{activity.label}</div>
+                    {activity.detail && (
+                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 flex-wrap justify-end gap-2">
+                    {activity.kind === "work_issue" && parseIssueTargetId(activity.targetId) && (
+                      <button
+                        type="button"
+                        onClick={() => onClearIssueFailure(activity)}
+                        disabled={isClearingIssueFailure}
+                        className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                        data-testid="dashboard-clear-issue-failure"
+                      >
+                        {isClearingIssueFailure ? (
+                          "Clearing"
+                        ) : (
+                          <>
+                            <Trash2 className="h-3 w-3" aria-hidden="true" />
+                            Clear
+                          </>
+                        )}
+                      </button>
+                    )}
+                    {activity.targetUrl && (
+                      <a
+                        href={activity.targetUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                      >
+                        Open
+                      </a>
+                    )}
+                  </div>
+                </div>
+                {activity.lastError && (
+                  <div
+                    className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
+                    title={activity.lastError}
+                  >
+                    {activity.lastError}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+          {activities.failed.length > 4 && (
+            <div className="mt-2 text-[11px] text-muted-foreground">
+              {activities.failed.length - 4} more failed job{activities.failed.length - 4 === 1 ? "" : "s"} in activity.
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function ReadyToMergeIndicator({
+  href,
+  testId,
+  label,
+  hint,
+  className,
+  dotClassName,
+  hintClassName,
+  onClick,
+}: {
+  href: string;
+  testId: string;
+  label: string;
+  hint?: string;
+  className: string;
+  dotClassName: string;
+  hintClassName?: string;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={onClick}
+      data-testid={testId}
+      className={`inline-flex items-center rounded-md border border-success-border bg-success-muted font-medium uppercase text-success-foreground transition-colors hover:bg-success-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${className}`}
+    >
+      <span className={`inline-block rounded-full bg-success ${dotClassName}`} />
+      {label}
+      {hint && <span className={hintClassName}>{hint}</span>}
+    </a>
+  );
+}
+
+function AgentIndicator({ pr }: { pr: PRSummary }) {
+  const isProcessing = pr.status === "processing";
+
+  if (!isProcessing) {
+    return null;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex shrink-0 cursor-default items-center gap-1 text-[12px] text-primary"
+          data-testid={`agent-indicator-${pr.id}`}
+        >
+          <Bot className="h-3.5 w-3.5 animate-pulse" aria-hidden="true" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <p className="text-xs">Agent run active on this PR</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function PRRowSkeleton() {
+  return (
+    <div className="border-b border-l-2 border-l-transparent border-border px-4 py-3">
+      <div className="flex items-start gap-3">
+        <Skeleton className="mt-1.5 h-2 w-2 rounded-full" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-3 w-10" />
+            <Skeleton className="h-3.5 w-2/3" />
+          </div>
+          <div className="mt-2 ml-[3.75rem] flex items-center gap-3">
+            <Skeleton className="h-2.5 w-24" />
+            <Skeleton className="h-2.5 w-16" />
+            <Skeleton className="h-2.5 w-14" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const PRRow = memo(function PRRow({
+  pr,
+  isSelected,
+  onSelect,
+  failureMessage,
+  queueStatus,
+  issueLink,
+}: {
+  pr: PRSummary;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  failureMessage?: string | null;
+  queueStatus: QueueStatusView | null;
+  issueLink?: Issue | null;
+}) {
+  const checkedAt = formatClock(pr.lastChecked);
+  const watchEnabled = isPRWatchEnabled(pr);
+  return (
+    <div
+      onClick={() => onSelect(pr.id)}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect(pr.id);
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      data-testid={`pr-row-${pr.id}`}
+      className={`w-full cursor-pointer border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+        isSelected
+          ? "border-l-[3px] border-l-primary bg-muted"
+          : `border-l-2 ${toneRailClass(prStatusTone(pr))}`
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3">
+            <span className="w-12 shrink-0 font-mono text-[12px] text-muted-foreground">#{pr.number}</span>
+            <span className="truncate">{pr.title}</span>
+            <AgentIndicator pr={pr} />
+            {issueLink && (
+              <span
+                data-testid="pr-on-issues-badge"
+                className="shrink-0 rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 text-[10px] uppercase tracking-wider text-primary"
+                title={`Linked from issue #${issueLink.number}`}
+              >
+                issue <span className="font-mono">#{issueLink.number}</span>
+              </span>
+            )}
+          </div>
+          {pr.status === "error" && failureMessage && (
+            <div className="mt-2 ml-[3.75rem] border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
+              <span className="font-medium uppercase tracking-wider">Error:</span>{" "}
+              <span className="break-words">{failureMessage}</span>
+            </div>
+          )}
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
+            <a
+              href={pr.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(event) => event.stopPropagation()}
+              className="underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            >
+              {pr.repo}
+            </a>
+            <span>{formatStatusLabel(pr.status, pr.prStage)}</span>
+            <QueueStatusBadge status={queueStatus} />
+            {!watchEnabled && <WatchPausedIndicator />}
+            <span>{pr.accepted + pr.rejected + pr.flagged} triaged</span>
+            {checkedAt && <span>checked {checkedAt}</span>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+function isTrustedAuthor(author: string, trustedReviewers: readonly string[] | undefined): boolean {
+  if (!author || !trustedReviewers || trustedReviewers.length === 0) return false;
+  const normalized = author.trim().toLowerCase().replace(/^@/, "");
+  return trustedReviewers.some((entry) => entry.trim().toLowerCase().replace(/^@/, "") === normalized);
+}
+
+function FeedbackRow({
+  item,
+  prId,
+  readOnly,
+  globalDrainMode = false,
+}: {
+  item: FeedbackItem;
+  prId: string;
+  readOnly?: boolean;
+  globalDrainMode?: boolean;
+}) {
+  const overrideMutation = useMutation({
+    mutationFn: async (decision: string) => {
+      const res = await apiRequest("PATCH", `/api/prs/${prId}/feedback/${item.id}`, { decision });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs", prId] });
+    },
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("POST", `/api/prs/${prId}/feedback/${item.id}/retry`);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs", prId] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
+    },
+    onError: (error) => {
+      showMutationError("Could not retry feedback item", error);
+    },
+  });
+
+  const createdAt = formatClock(item.createdAt);
+  const collapsedByDefault = isFeedbackCollapsedByDefault(item.status);
+  const prominentStatusReason = (item.status === "failed" || item.status === "warning") && item.statusReason
+    ? item.statusReason
+    : null;
+  const { data: config } = useQuery<Config>({ queryKey: ["/api/config"] });
+  const trusted = isTrustedAuthor(item.author, config?.trustedReviewers);
+
+  return (
+    <Collapsible.Root defaultOpen={!collapsedByDefault} className="border-b border-border">
+      <div className="px-4 py-3">
+        {/* Header row - always visible */}
+        <div className="flex items-start gap-3">
+          <div className="shrink-0 pt-0.5">
+            <FeedbackStatusTag status={item.status} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 flex flex-wrap items-center gap-2">
+              <span className="font-medium">{item.author}</span>
+              {trusted && (
+                <span
+                  className="rounded-md border border-success-border bg-success-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider text-success-foreground"
+                  title={`@${item.author} is in Trusted reviewers — feedback is auto-accepted, agent evaluation skipped.`}
+                  data-testid={`feedback-trusted-${item.id}`}
+                >
+                  trusted
+                </span>
+              )}
+              {item.file && (
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {item.file}{item.line ? `:${item.line}` : ""}
+                </span>
+              )}
+              <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
+              {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
+            </div>
+            {prominentStatusReason && (
+              <div className="mt-1 whitespace-pre-wrap break-words border border-destructive/30 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
+                <span className="font-medium uppercase tracking-wider">Failure reason:</span>{" "}
+                {prominentStatusReason}
+              </div>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {!readOnly && (item.status === "failed" || item.status === "warning") && (
+              <button
+                type="button"
+                onClick={() => retryMutation.mutate()}
+                disabled={retryMutation.isPending || globalDrainMode}
+                data-testid={`retry-${item.id}`}
+                aria-label={`Retry feedback from ${item.author}`}
+                title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Retry feedback item"}
+                className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
+              >
+                {globalDrainMode ? DRAIN_PAUSED_LABEL : "Retry"}
+              </button>
+            )}
+            <Collapsible.Trigger asChild>
+              <button
+                type="button"
+                data-testid={`toggle-${item.id}`}
+                aria-label={`${collapsedByDefault ? "Show" : "Hide"} feedback details from ${item.author}`}
+                title="Toggle feedback details"
+                className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+              >
+                Details
+              </button>
+            </Collapsible.Trigger>
+            {!readOnly && (["accept", "reject", "flag"] as const).map((decision) => {
+              const selected = item.decision === decision;
+              const selectedClass =
+                decision === "accept"
+                  ? "border-success-border bg-success-muted text-success-foreground"
+                  : decision === "reject"
+                    ? "border-destructive bg-destructive/10 text-destructive"
+                    : "border-warning-border bg-warning-muted text-warning-foreground";
+              return (
+                <button
+                  type="button"
+                  key={decision}
+                  onClick={() => overrideMutation.mutate(decision)}
+                  data-testid={`override-${decision}-${item.id}`}
+                  aria-label={`${decision} feedback from ${item.author}`}
+                  aria-pressed={selected}
+                  className={`cursor-pointer rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+                    selected ? selectedClass : "border-border text-muted-foreground hover:bg-muted hover:text-foreground"
+                  }`}
+                >
+                  {decision}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      <Collapsible.Content>
+        <div className="px-4 pb-3">
+          {item.bodyHtml ? (
+            <div
+              className="feedback-markdown text-[12px] leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: item.bodyHtml }}
+            />
+          ) : (
+            <p className="whitespace-pre-wrap text-[12px] leading-relaxed text-foreground/80">{item.body}</p>
+          )}
+          {item.statusReason && !prominentStatusReason && (
+            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+              <span className="font-medium uppercase tracking-wider text-foreground/70">Status reason:</span>{" "}
+              {item.statusReason}
+            </p>
+          )}
+          {item.decisionReason && (
+            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+              <span className="font-medium uppercase tracking-wider text-foreground/70">Decision reason:</span>{" "}
+              {item.decisionReason}
+            </p>
+          )}
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
+
+function LogPanel({ prId }: { prId: string | null }) {
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const { data: logs = [] } = useQuery<LogEntry[]>({
+    queryKey: ["/api/logs", prId ?? "all"],
+    queryFn: async () => {
+      const url = prId ? `/api/logs?prId=${encodeURIComponent(prId)}` : "/api/logs";
+      const res = await apiRequest("GET", url);
+      return res.json();
+    },
+    refetchInterval: 1500,
+  });
+  const visibleLogs = useMemo(
+    () => logs.length > MAX_VISIBLE_LOGS ? logs.slice(-MAX_VISIBLE_LOGS) : logs,
+    [logs],
+  );
+  const hiddenLogCount = logs.length - visibleLogs.length;
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) {
+      return;
+    }
+
+    scroller.scrollTop = scroller.scrollHeight;
+  }, [logs.length, prId]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div ref={scrollerRef} className="flex-1 overflow-y-auto p-4 font-mono text-[11px] leading-relaxed">
+        {logs.length === 0 ? (
+          <span className="text-muted-foreground">No log entries.</span>
+        ) : (
+          <>
+            {hiddenLogCount > 0 && (
+              <div className="border-b border-border/60 pb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                Showing latest {MAX_VISIBLE_LOGS} of {logs.length} entries.
+              </div>
+            )}
+            {visibleLogs.map((log) => {
+              const metadataText = log.metadata && Object.keys(log.metadata).length > 0
+                ? JSON.stringify(log.metadata, null, 2)
+                : null;
+
+              return (
+                <div key={log.id} className="border-b border-border/60 py-2 last:border-b-0" data-testid={`log-${log.id}`}>
+                  <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                    <span>{formatClock(log.timestamp)}</span>
+                    <span className={
+                      log.level === "error" ? "text-destructive" :
+                      log.level === "warn" ? "text-warning-foreground" :
+                      log.level === "info" ? "text-primary" :
+                      "text-muted-foreground"
+                    }>
+                      {log.level}
+                    </span>
+                    {log.phase && <span className="border border-border px-1 py-0">{log.phase}</span>}
+                    {log.runId && <span className="normal-case text-foreground/45">run {log.runId.slice(0, 8)}</span>}
+                  </div>
+                  <div className={`mt-1 break-words ${log.level === "error" ? "text-destructive" : "text-foreground/75"}`}>
+                    {log.message}
+                  </div>
+                  {metadataText && (
+                    <pre className="mt-1 whitespace-pre-wrap break-all text-[10px] text-muted-foreground">
+                      {metadataText}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HealingPanel({
+  pr,
+  config,
+  healingSessions,
+}: {
+  pr: PR;
+  config: Config | undefined;
+  healingSessions: HealingSession[];
+}) {
+  const session = selectRelevantHealingSession(healingSessions, pr.id);
+  const view = session ? getHealingSessionView(session, config) : null;
+  const toneClass = view ? HEALING_TONE_CLASSES[view.tone] : HEALING_TONE_CLASSES.neutral;
+
+  return (
+    <div
+      className="shrink-0 border-b border-border px-4 py-3"
+      data-testid="panel-ci-healing"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">CI healing</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            {view ? (
+              <>
+                <span className={`inline-flex rounded-md border px-1.5 py-0.5 text-[11px] font-medium uppercase tracking-wider ${toneClass}`}>
+                  {view.stateLabel}
+                </span>
+                <span className="text-[11px] text-muted-foreground">{view.attemptSummary}</span>
+              </>
+            ) : (
+              <span className="text-[11px] text-muted-foreground">
+                {config?.autoHealCI === false
+                  ? "Automatic CI healing is disabled in settings."
+                  : "No healing session yet for this PR."}
+              </span>
+            )}
+          </div>
+        </div>
+        {session && (
+          <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+            head {session.currentHeadSha.slice(0, 7)}
+          </span>
+        )}
+      </div>
+
+      {view ? (
+        <>
+          <div className="mt-2 grid gap-1 text-[11px]">
+            {view.reasonSummary && (
+              <div>
+                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Reason</span>
+                <span className="ml-2 text-foreground/80">{view.reasonSummary}</span>
+              </div>
+            )}
+            <div className="text-muted-foreground">{view.statusHint}</div>
+            <div>
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Attempts</span>
+              <span className="ml-2 font-mono text-foreground/80">{view.attemptSummary}</span>
+              {session?.latestFingerprint && (
+                <>
+                  <span className="mx-1.5 text-border" aria-hidden="true">·</span>
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">fingerprint</span>
+                  <span className="ml-1.5 font-mono text-foreground/80">{session.latestFingerprint}</span>
+                </>
+              )}
+            </div>
+          </div>
+          {view.actions.length > 0 && (
+            <>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {view.actions.map((action) => (
+                  <button
+                    key={action.label}
+                    type="button"
+                    disabled
+                    title={action.hint}
+                    className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors ${
+                      action.available
+                        ? "border-border text-foreground/70 hover:bg-muted"
+                        : "border-border text-muted-foreground/60"
+                    } disabled:opacity-100`}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                Operator controls are read-only until healing action endpoints are added.
+              </div>
+            </>
+          )}
+        </>
+      ) : (
+        config?.autoHealCI !== false && (
+          <div className="mt-2 text-[11px] text-muted-foreground">
+            The watcher will create a healing session when a failing check is classified as healable.
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+function PRDescriptionPanel({ pr }: { pr: PR }) {
+  const [isOpen, setIsOpen] = useState(false);
+  if (!pr.body && !pr.bodyHtml) return null;
+  return (
+    <div className="shrink-0 border-b border-border px-4 py-3" data-testid="panel-pr-description">
+      <button
+        type="button"
+        onClick={() => setIsOpen((o) => !o)}
+        aria-expanded={isOpen}
+        className="flex w-full items-center justify-between gap-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Description</div>
+        {isOpen ? <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />}
+      </button>
+      {isOpen && (
+        pr.bodyHtml ? (
+          <article
+            data-testid="pr-body-markdown"
+            className="issue-markdown mt-2 border border-border/60 bg-background p-4"
+            dangerouslySetInnerHTML={{ __html: pr.bodyHtml }}
+          />
+        ) : (
+          <pre className="mt-2 whitespace-pre-wrap break-words border border-border/60 bg-background p-4 text-[12px] leading-6 text-muted-foreground">
+            {pr.body?.trim() || "No description provided."}
+          </pre>
+        )
+      )}
+    </div>
+  );
+}
+
+function RightPanel({
+  prId,
+  prStatus,
+  globalDrainMode,
+}: {
+  prId: string | null;
+  prStatus?: PR["status"] | null;
+  globalDrainMode: boolean;
+}) {
+  const [tab, setTab] = useState<"activity" | "ask">("ask");
+
+  useEffect(() => {
+    if (prStatus === "error") {
+      setTab("activity");
+    }
+  }, [prId, prStatus]);
+
+  return (
+    <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
+      <div className="flex border-b border-border">
+        <button
+          type="button"
+          onClick={() => setTab("ask")}
+          data-testid="tab-ask"
+          className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+            tab === "ask"
+              ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Ask Agent
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("activity")}
+          data-testid="tab-activity"
+          className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+            tab === "activity"
+              ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Activity
+        </button>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {tab === "activity" ? (
+          <LogPanel prId={prId} />
+        ) : prId ? (
+          <QAPanel prId={prId} globalDrainMode={globalDrainMode} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+            Select a PR to ask questions.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function QAPanel({ prId, globalDrainMode }: { prId: string; globalDrainMode: boolean }) {
+  const [input, setInput] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const { data: questions = [] } = useQuery<PRQuestion[]>({
+    queryKey: ["/api/prs", prId, "questions"],
+    refetchInterval: 2000,
+  });
+
+  const askMutation = useMutation({
+    mutationFn: (question: string) =>
+      apiRequest("POST", `/api/prs/${prId}/questions`, { question }).then((res) => res.json()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs", prId, "questions"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      setInput("");
+    },
+  });
+
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (scroller) scroller.scrollTop = scroller.scrollHeight;
+  }, [questions.length, questions[questions.length - 1]?.status]);
+
+  const askDisabled = askMutation.isPending || !input.trim() || globalDrainMode;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+        Ask Agent
+      </div>
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+        {questions.length === 0 ? (
+          <span className="text-[12px] text-muted-foreground">
+            {globalDrainMode
+              ? ASK_DRAIN_COPY
+              : "Ask questions about this PR — the agent will read activity logs, feedback, and status to answer."}
+          </span>
+        ) : (
+          questions.map((q) => (
+            <div key={q.id} className="space-y-1.5" data-testid={`question-${q.id}`}>
+              <div className="text-[12px]">
+                <span className="font-medium text-foreground/90">Q: </span>
+                <span className="text-foreground/80">{q.question}</span>
+              </div>
+              {q.status === "pending" || q.status === "answering" ? (
+                <div className="text-[11px] text-muted-foreground animate-pulse">
+                  Agent is thinking...
+                </div>
+              ) : q.status === "error" ? (
+                <div className="text-[11px] text-destructive">
+                  Error: {q.error || "Unknown error"}
+                </div>
+              ) : (
+                <div className="text-[12px] leading-relaxed text-foreground/85 whitespace-pre-wrap border-l-2 border-primary/40 pl-3">
+                  {q.answer}
+                </div>
+              )}
+              <div className="text-[10px] text-muted-foreground">
+                {formatClock(q.createdAt)}
+                {q.answeredAt && ` — answered ${formatClock(q.answeredAt)}`}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!askDisabled) askMutation.mutate(input.trim());
+        }}
+        className="border-t border-border p-3"
+      >
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={globalDrainMode ? "Drain mode is enabled." : "Was the review done? Why did this fail?"}
+            aria-label="Question for selected pull request"
+            disabled={globalDrainMode}
+            data-testid="input-question"
+            className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          />
+          <button
+            type="submit"
+            disabled={askDisabled}
+            title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Ask agent"}
+            data-testid="button-ask"
+            className="cursor-pointer border border-primary bg-primary px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {globalDrainMode ? DRAIN_PAUSED_LABEL : askMutation.isPending ? "..." : "Ask"}
+          </button>
+        </div>
+        {askMutation.isError && (
+          <div className="mt-1 text-[11px] text-destructive">
+            {getErrorMessage(askMutation.error)}
+          </div>
+        )}
+      </form>
+    </div>
+  );
+}
+
+function getErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  const raw = error.message.replace(/^\d+:\s*/, "").trim();
+  if (!raw) {
+    return "Request failed";
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { error?: unknown; message?: unknown };
+    if (typeof parsed.error === "string") {
+      return parsed.error;
+    }
+    if (typeof parsed.message === "string") {
+      return parsed.message;
+    }
+  } catch {
+    // Keep the original message when the server did not return JSON.
+  }
+
+  return raw;
+}
+
+function showMutationError(title: string, error: unknown) {
+  toast({
+    variant: "destructive",
+    title,
+    description: getErrorMessage(error),
+  });
+}
+
+export default function Dashboard() {
+  const [selectedPRId, setSelectedPRId] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<"active" | "issues" | "archived">("active");
+  const [prNumberSearch, setPrNumberSearch] = useState("");
+  const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleSyncDashboard = async () => {
+    setIsRefreshing(true);
+    try {
+      await apiRequest("POST", "/api/repos/sync");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/prs"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/healing-sessions"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/runtime"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/repos/settings"] }),
+      ]);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const { data: prs = [], isLoading } = useQuery<PRSummary[]>({
+    queryKey: ["/api/prs"],
+    refetchInterval: 3000,
+  });
+
+  const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PRSummary[]>({
+    queryKey: ["/api/prs/archived"],
+    refetchInterval: 10000,
+  });
+
+  const { data: runtimeState } = useQuery<RuntimeState>({
+    queryKey: ["/api/runtime"],
+    refetchInterval: 3000,
+  });
+  const globalDrainMode = runtimeState?.drainMode === true;
+
+  const { data: issuesPage, isLoading: isLoadingIssues } = useQuery<IssueListPage>({
+    queryKey: ["/api/issues"],
+    enabled: runtimeState !== undefined && !globalDrainMode,
+    refetchInterval: 30000,
+  });
+  const issues = issuesPage?.items ?? [];
+
+  const { data: config } = useQuery<Config>({
+    queryKey: ["/api/config"],
+    refetchInterval: 5000,
+  });
+
+  const { data: healingSessions = [] } = useQuery<HealingSession[]>({
+    queryKey: ["/api/healing-sessions"],
+    queryFn: async () => fetchJson<HealingSession[]>("/api/healing-sessions"),
+    refetchInterval: 5000,
+  });
+
+  const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
+    queryKey: ["/api/activities"],
+    refetchInterval: 3000,
+  });
+  const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
+
+  const { data: repos = [] } = useQuery<WatchedRepo[]>({
+    queryKey: ["/api/repos/settings"],
+    refetchInterval: 5000,
+  });
+
+  const issueLinkedPRByKey = useMemo(() => buildIssueLinkedPRIndex(issues), [issues]);
+  const issueLinkedPRs = useMemo(
+    () => prs.filter((pr) => issueLinkedPRByKey.has(prIssueLinkKey(pr.repo, pr.number))),
+    [prs, issueLinkedPRByKey],
+  );
+  const displayedPRs = (viewMode === "archived"
+    ? archivedPRs
+    : viewMode === "issues"
+      ? issueLinkedPRs
+      : prs
+  )
+    .filter((pr) => matchesNumberSearch(pr.number, prNumberSearch))
+    .sort((a, b) => b.number - a.number);
+  const isArchived = viewMode === "archived";
+  const normalizedPrNumberSearch = normalizeNumberSearch(prNumberSearch);
+  const isLoadingCurrentView = isArchived ? isLoadingArchived : viewMode === "issues" ? isLoading || isLoadingIssues : isLoading;
+  const selectedPRSummary = displayedPRs.find((pr) => pr.id === selectedPRId) ?? null;
+  const { data: selectedPRDetail } = useQuery<PR | null>({
+    queryKey: ["/api/prs", selectedPRId],
+    enabled: selectedPRId !== null,
+    queryFn: async () => {
+      if (!selectedPRId) return null;
+      return fetchJson<PR>(`/api/prs/${selectedPRId}`);
+    },
+    refetchInterval: 3000,
+  });
+
+  useEffect(() => {
+    if (displayedPRs.length === 0) {
+      if (selectedPRId !== null) {
+        setSelectedPRId(null);
+      }
+      return;
+    }
+
+    if (!selectedPRId || !displayedPRs.some((pr) => pr.id === selectedPRId)) {
+      setSelectedPRId(displayedPRs[0].id);
+    }
+  }, [displayedPRs, selectedPRId]);
+
+  const selectedPR = selectedPRDetail ?? null;
+  const selectedPRWatchEnabled = selectedPRSummary ? isPRWatchEnabled(selectedPRSummary) : true;
+  const selectedFailedActivity = selectedPRSummary ? latestActivityForTarget(activities.failed, selectedPRSummary.id) : undefined;
+  const selectedPRQueueStatus = selectedPRSummary ? queueStatusById.get(selectedPRSummary.id) ?? null : null;
+  const selectedPRErrorMessage = selectedPRSummary?.status === "error"
+    ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
+    : null;
+  const activeErrorCount = activities.failed.length + activities.warnings.length;
+
+  const applyMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await apiRequest("POST", `/api/prs/${id}/apply`);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
+    },
+    onError: (error) => {
+      showMutationError("Could not run babysitter", error);
+    },
+  });
+
+  const watchMutation = useMutation({
+    mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
+      const res = await apiRequest("PATCH", `/api/prs/${id}/watch`, { enabled });
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
+    },
+    onError: (error) => {
+      showMutationError("Could not update PR watch state", error);
+    },
+  });
+  const syncPrMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await apiRequest("POST", `/api/prs/${id}/fetch`);
+      return res.json() as Promise<PR>;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
+      toast({ description: "PR sync complete." });
+    },
+    onError: (error) => {
+      showMutationError("Could not sync PR", error);
+    },
+  });
+
+  const updateConfigMutation = useMutation({
+    mutationFn: async (updates: Partial<Config>) => {
+      const res = await apiRequest("PATCH", "/api/config", updates);
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/config"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
+    },
+    onError: (error) => {
+      showMutationError("Could not update settings", error);
+    },
+  });
+
+  const clearFailedActivitiesMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("DELETE", "/api/activities/failed");
+      return res.json() as Promise<{ cleared: number }>;
+    },
+    onSuccess: ({ cleared }) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      toast({ description: cleared === 1 ? "Cleared 1 failed activity." : `Cleared ${cleared} failed activities.` });
+    },
+    onError: (error) => {
+      showMutationError("Could not clear failed activities", error);
+    },
+  });
+
+  const clearIssueFailureMutation = useMutation({
+    mutationFn: async (activity: ActivityItem) => {
+      const issueTarget = parseIssueTargetId(activity.targetId);
+      if (!issueTarget) {
+        throw new Error(`Could not parse issue target ${activity.targetId}`);
+      }
+
+      const res = await apiRequest("DELETE", "/api/issues/work/failures", issueTarget);
+      return res.json() as Promise<{ repo: string; number: number; id: string }>;
+    },
+    onSuccess: (issue) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/issues"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] });
+      queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] });
+      toast({ description: `Cleared failed work attempts for #${issue.number}.` });
+    },
+    onError: (error) => {
+      showMutationError("Could not clear issue failure", error);
+    },
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
+      <UpdateBanner />
+      <AppHeader
+        active="prs"
+        status={(
+          <span>
+            <span className="font-mono text-foreground">{prs.length}</span> PR{prs.length !== 1 ? "s" : ""} / <span className="font-mono text-foreground">{repos.length}</span> repo{repos.length !== 1 ? "s" : ""}
+          </span>
+        )}
+        actions={(
+          <>
+            <label htmlFor="dashboard-coding-agent" className="text-[11px] uppercase tracking-wider text-muted-foreground">Agent</label>
+            <select
+              id="dashboard-coding-agent"
+              value={config?.codingAgent ?? "codex"}
+              onChange={(e) => {
+                const newAgent = e.target.value as Config["codingAgent"];
+                updateConfigMutation.mutate({
+                  codingAgent: newAgent,
+                });
+              }}
+              disabled={updateConfigMutation.isPending}
+              data-testid="select-coding-agent"
+              className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-1 text-[11px] transition-colors focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="codex">codex</option>
+              <option value="claude">claude</option>
+            </select>
+            {activeErrorCount > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  setAreErrorsRolledUp(false);
+                  scrollToDashboardErrors();
+                }}
+                data-testid="dashboard-error-pill"
+                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 px-2 py-0.5 text-[11px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+              >
+                <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                errors
+                <span className="font-mono">{activeErrorCount}</span>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => { void handleSyncDashboard(); }}
+              disabled={isRefreshing}
+              data-testid="button-sync-dashboard"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+            >
+              {isRefreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              sync
+            </button>
+            <ActivityMenu
+              activities={activities}
+              onClearFailed={() => clearFailedActivitiesMutation.mutate()}
+              isClearingFailed={clearFailedActivitiesMutation.isPending}
+              globalDrainMode={globalDrainMode}
+              queueStatusById={queueStatusById}
+              pollIntervalMs={config?.pollIntervalMs}
+            />
+          </>
+        )}
+      />
+
+      <OnboardingPanel />
+      <OperatorWarningsBanner warnings={activities.warnings} />
+      <DashboardErrorsPanel
+        activities={activities}
+        onClearFailed={() => clearFailedActivitiesMutation.mutate()}
+        isClearingFailed={clearFailedActivitiesMutation.isPending}
+        onClearIssueFailure={(activity) => clearIssueFailureMutation.mutate(activity)}
+        isClearingIssueFailure={clearIssueFailureMutation.isPending}
+        rolledUp={areErrorsRolledUp}
+        onToggleRolledUp={() => setAreErrorsRolledUp((current) => !current)}
+      />
+      <DashboardDrainBanner runtimeState={runtimeState} />
+
+      <div className="flex flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
+        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-y-auto border-b border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-b-0 lg:border-r">
+          <div className="sticky top-0 z-10 flex shrink-0 border-b border-border bg-background">
+            <button
+              type="button"
+              onClick={() => setViewMode("active")}
+              data-testid="tab-active"
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+                viewMode === "active"
+                  ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Active ({prs.length})
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode("issues")}
+              data-testid="tab-on-issues"
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+                viewMode === "issues"
+                  ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Issues ({issueLinkedPRs.length})
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode("archived")}
+              data-testid="tab-archived"
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+                viewMode === "archived"
+                  ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              Archived ({archivedPRs.length})
+            </button>
+          </div>
+          <div className="border-b border-border px-3 py-2">
+            <label htmlFor="pr-number-search" className="sr-only">Search PR number</label>
+            <input
+              id="pr-number-search"
+              value={prNumberSearch}
+              onChange={(event) => setPrNumberSearch(event.target.value)}
+              placeholder="Search #"
+              data-testid="pr-number-search"
+              className="h-7 w-full rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
+          <div className="flex-1">
+            {isLoadingCurrentView ? (
+              <div data-testid="pr-list-loading" aria-label="Loading pull requests">
+                {Array.from({ length: 6 }).map((_, idx) => (
+                  <PRRowSkeleton key={idx} />
+                ))}
+              </div>
+            ) : displayedPRs.length === 0 ? (
+              <div className="p-4 text-[12px] text-muted-foreground">
+                {normalizedPrNumberSearch
+                  ? `No PRs match #${normalizedPrNumberSearch}.`
+                  : isArchived
+                    ? "No archived PRs. Closed PRs are archived automatically."
+                    : viewMode === "issues"
+                      ? "No active PRs are linked from Issues yet."
+                  : "No PRs tracked yet. Add a repository or PR from Settings."}
+              </div>
+            ) : (
+              displayedPRs.map((pr) => (
+                <PRRow
+                  key={pr.id}
+                  pr={pr}
+                  isSelected={pr.id === selectedPRId}
+                  onSelect={setSelectedPRId}
+                  queueStatus={queueStatusById.get(pr.id) ?? null}
+                  issueLink={issueLinkedPRByKey.get(prIssueLinkKey(pr.repo, pr.number)) ?? null}
+                  failureMessage={
+                    pr.status === "error"
+                      ? latestActivityForTarget(activities.failed, pr.id)?.lastError ?? getPRFeedbackFailureReason(pr)
+                      : null
+                  }
+                />
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="flex min-h-[32rem] flex-1 flex-col overflow-hidden lg:min-h-0">
+          {selectedPR ? (
+            <>
+              {(() => {
+                const metaItems: MetaItem[] = [
+                  { key: "status", content: <span>status: <span className="text-foreground">{formatStatusLabel(selectedPR.status, selectedPR.prStage)}</span></span> },
+                  { key: "items", content: <span><span className="font-mono text-foreground">{selectedPR.feedbackItems.length}</span> items</span> },
+                ];
+                if (selectedPRQueueStatus) {
+                  metaItems.push({ key: "queue", content: <QueueStatusBadge status={selectedPRQueueStatus} /> });
+                }
+                if (selectedPR.feedbackItems.length > 0) {
+                  const counts = countActiveFeedbackStatuses(selectedPR.feedbackItems);
+                  if (counts.queued > 0) metaItems.push({ key: "fb-queued", content: <span className="text-primary"><span className="font-mono">{counts.queued}</span> queued</span> });
+                  if (counts.inProgress > 0) metaItems.push({ key: "fb-inprogress", content: <span className="text-primary"><span className="font-mono">{counts.inProgress}</span> in progress</span> });
+                  if (counts.failed > 0) metaItems.push({ key: "fb-failed", content: <span className="text-destructive"><span className="font-mono">{counts.failed}</span> failed</span> });
+                  if (counts.warning > 0) metaItems.push({ key: "fb-warning", content: <span className="text-warning-foreground"><span className="font-mono">{counts.warning}</span> warnings</span> });
+                }
+                if (selectedPR.testsPassed !== null) {
+                  metaItems.push({ key: "tests", content: <span>tests: <span className={selectedPR.testsPassed ? "text-success" : "text-destructive"}>{selectedPR.testsPassed ? "pass" : "fail"}</span></span> });
+                }
+                if (selectedPR.lintPassed !== null) {
+                  metaItems.push({ key: "lint", content: <span>lint: <span className={selectedPR.lintPassed ? "text-success" : "text-destructive"}>{selectedPR.lintPassed ? "pass" : "fail"}</span></span> });
+                }
+                if (selectedPR.lastChecked) {
+                  metaItems.push({ key: "checked", content: <span>checked <span className="font-mono">{formatClock(selectedPR.lastChecked)}</span></span> });
+                }
+                if (selectedPR.lastSyncSucceededAt) {
+                  metaItems.push({ key: "synced", content: <span>synced <span className="font-mono">{formatClock(selectedPR.lastSyncSucceededAt)}</span></span> });
+                }
+                if (selectedPR.lastSyncError) {
+                  metaItems.push({ key: "sync-error", content: <span className="text-destructive">sync error</span> });
+                }
+                return (
+              <DetailHeader
+                title={selectedPR.title}
+                accentTone="primary"
+                failed={selectedPR.status === "error"}
+                stageBar={<StageProgressBar stages={buildPRStages(selectedPR)} testId="pr-stage-progress" />}
+                titleSuffix={(
+                  <>
+                    <AgentIndicator pr={selectedPR} />
+                    {!selectedPRWatchEnabled && <WatchPausedIndicator />}
+                    <StatusChip tone={prStatusTone(selectedPR)} pulsing={selectedPR.status === "processing"} label={formatStatusLabel(selectedPR.status, selectedPR.prStage)} />
+                  </>
+                )}
+                externalLink={{ href: selectedPR.url, label: `${selectedPR.repo}#${selectedPR.number}` }}
+                meta={<MetaBreadcrumb items={metaItems} />}
+                actions={!isArchived ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => syncPrMutation.mutate(selectedPR.id)}
+                      disabled={syncPrMutation.isPending || globalDrainMode}
+                      title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Sync GitHub feedback now"}
+                      data-testid="button-sync-pr"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {syncPrMutation.isPending ? (
+                        <><Loader2 className="h-3.5 w-3.5 animate-spin" />Syncing</>
+                      ) : (
+                        <><RefreshCw className="h-3.5 w-3.5" />Sync</>
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => watchMutation.mutate({ id: selectedPR.id, enabled: !selectedPRWatchEnabled })}
+                      disabled={watchMutation.isPending}
+                      data-testid="button-toggle-watch"
+                      title={selectedPRWatchEnabled ? "Pause background watch for this PR" : "Resume background watch for this PR"}
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {selectedPRWatchEnabled ? (
+                        <><Pause className="h-3.5 w-3.5" />Pause watch</>
+                      ) : (
+                        <><Play className="h-3.5 w-3.5" />Resume watch</>
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => applyMutation.mutate(selectedPR.id)}
+                      disabled={applyMutation.isPending || selectedPR.status === "processing" || globalDrainMode}
+                      title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Run babysitter now"}
+                      data-testid="button-apply"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {applyMutation.isPending || selectedPR.status === "processing" ? (
+                        <><Loader2 className="h-3.5 w-3.5 animate-spin" />{selectedPR.status === "processing" ? "Running" : "Queuing"}</>
+                      ) : (
+                        <><PlayCircle className="h-3.5 w-3.5" />{globalDrainMode ? DRAIN_PAUSED_LABEL : "Run now"}</>
+                      )}
+                    </button>
+                  </>
+                ) : undefined}
+                banner={(
+                  <>
+                    {isPRReadyToMerge(selectedPR.feedbackItems) && selectedPR.status !== "processing" && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
+                      <ReadyToMergeIndicator
+                        href={selectedPR.url}
+                        testId="detail-ready-to-merge"
+                        label="All comments resolved — ready to merge"
+                        hint="Open PR on GitHub →"
+                        className="mt-2 gap-2 px-3 py-1.5 text-[12px] tracking-wider"
+                        dotClassName="h-2 w-2"
+                        hintClassName="text-[11px] normal-case tracking-normal text-success-foreground/75"
+                      />
+                    )}
+                    {selectedPRErrorMessage && (
+                      <div
+                        className="mt-2 border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] leading-5 text-destructive"
+                        data-testid="selected-pr-error"
+                      >
+                        <div className="text-[10px] font-medium uppercase tracking-wider">Automation error</div>
+                        <div className="mt-1 whitespace-pre-wrap break-words">{selectedPRErrorMessage}</div>
+                      </div>
+                    )}
+                    <div className="mt-2 text-[11px] text-muted-foreground">
+                      {globalDrainMode
+                        ? GLOBAL_DRAIN_PR_COPY
+                        : selectedPRWatchEnabled
+                          ? "Background watcher syncs GitHub feedback and pushes approved fixes automatically."
+                          : "Background watch is paused for this PR; manual runs still work."}
+                    </div>
+                  </>
+                )}
+              />
+                );
+              })()}
+
+              <HealingPanel pr={selectedPR} config={config} healingSessions={healingSessions} />
+              <PRDescriptionPanel pr={selectedPR} />
+
+              <div className="flex-1 overflow-y-auto">
+                {selectedPR.feedbackItems.length === 0 ? (
+                  <div className="p-4 text-[12px] text-muted-foreground">
+                    {selectedPRWatchEnabled
+                      ? "No feedback yet. The watcher will sync GitHub comments automatically."
+                      : "No feedback yet. Background watch is paused for this PR."}
+                  </div>
+                ) : (
+                  selectedPR.feedbackItems.map((item) => (
+                    <FeedbackRow
+                      key={item.id}
+                      item={item}
+                      prId={selectedPR.id}
+                      readOnly={isArchived}
+                      globalDrainMode={globalDrainMode}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-[12px] text-muted-foreground">
+              Select a PR from the left panel.
+            </div>
+          )}
+        </div>
+
+        <RightPanel
+          prId={selectedPRId}
+          prStatus={selectedPR?.status ?? null}
+          globalDrainMode={globalDrainMode}
+        />
+      </div>
+    </div>
+  );
+}

--- a/design-system/patchdeck/MASTER.md
+++ b/design-system/patchdeck/MASTER.md
@@ -1,0 +1,203 @@
+# Design System Master File
+
+> **LOGIC:** When building a specific page, first check `design-system/pages/[page-name].md`.
+> If that file exists, its rules **override** this Master file.
+> If not, strictly follow the rules below.
+
+---
+
+**Project:** Patchdeck
+**Generated:** 2026-05-15 10:07:42
+**Category:** Analytics Dashboard
+
+---
+
+## Global Rules
+
+### Color Palette
+
+| Role | Hex | CSS Variable |
+|------|-----|--------------|
+| Primary | `#1E293B` | `--color-primary` |
+| Secondary | `#334155` | `--color-secondary` |
+| CTA/Accent | `#22C55E` | `--color-cta` |
+| Background | `#0F172A` | `--color-background` |
+| Text | `#F8FAFC` | `--color-text` |
+
+**Color Notes:** Code dark + run green
+
+### Typography
+
+- **Heading Font:** Fira Code
+- **Body Font:** Fira Sans
+- **Mood:** dashboard, data, analytics, code, technical, precise
+- **Google Fonts:** [Fira Code + Fira Sans](https://fonts.google.com/share?selection.family=Fira+Code:wght@400;500;600;700|Fira+Sans:wght@300;400;500;600;700)
+
+**CSS Import:**
+```css
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Fira+Sans:wght@300;400;500;600;700&display=swap');
+```
+
+### Spacing Variables
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--space-xs` | `4px` / `0.25rem` | Tight gaps |
+| `--space-sm` | `8px` / `0.5rem` | Icon gaps, inline spacing |
+| `--space-md` | `16px` / `1rem` | Standard padding |
+| `--space-lg` | `24px` / `1.5rem` | Section padding |
+| `--space-xl` | `32px` / `2rem` | Large gaps |
+| `--space-2xl` | `48px` / `3rem` | Section margins |
+| `--space-3xl` | `64px` / `4rem` | Hero padding |
+
+### Shadow Depths
+
+| Level | Value | Usage |
+|-------|-------|-------|
+| `--shadow-sm` | `0 1px 2px rgba(0,0,0,0.05)` | Subtle lift |
+| `--shadow-md` | `0 4px 6px rgba(0,0,0,0.1)` | Cards, buttons |
+| `--shadow-lg` | `0 10px 15px rgba(0,0,0,0.1)` | Modals, dropdowns |
+| `--shadow-xl` | `0 20px 25px rgba(0,0,0,0.15)` | Hero images, featured cards |
+
+---
+
+## Component Specs
+
+### Buttons
+
+```css
+/* Primary Button */
+.btn-primary {
+  background: #22C55E;
+  color: white;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+/* Secondary Button */
+.btn-secondary {
+  background: transparent;
+  color: #1E293B;
+  border: 2px solid #1E293B;
+  padding: 12px 24px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+```
+
+### Cards
+
+```css
+.card {
+  background: #0F172A;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: var(--shadow-md);
+  transition: all 200ms ease;
+  cursor: pointer;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
+}
+```
+
+### Inputs
+
+```css
+.input {
+  padding: 12px 16px;
+  border: 1px solid #E2E8F0;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 200ms ease;
+}
+
+.input:focus {
+  border-color: #1E293B;
+  outline: none;
+  box-shadow: 0 0 0 3px #1E293B20;
+}
+```
+
+### Modals
+
+```css
+.modal-overlay {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  background: white;
+  border-radius: 16px;
+  padding: 32px;
+  box-shadow: var(--shadow-xl);
+  max-width: 500px;
+  width: 90%;
+}
+```
+
+---
+
+## Style Guidelines
+
+**Style:** Data-Dense Dashboard
+
+**Keywords:** Multiple charts/widgets, data tables, KPI cards, minimal padding, grid layout, space-efficient, maximum data visibility
+
+**Best For:** Business intelligence dashboards, financial analytics, enterprise reporting, operational dashboards, data warehousing
+
+**Key Effects:** Hover tooltips, chart zoom on click, row highlighting on hover, smooth filter animations, data loading spinners
+
+### Page Pattern
+
+**Pattern Name:** Product Review/Ratings Focused
+
+- **Conversion Strategy:** User-generated content builds trust. Show verified purchases. Filter by rating. Respond to negative reviews.
+- **CTA Placement:** After reviews summary + Buy button alongside reviews
+- **Section Order:** 1. Hero (product + aggregate rating), 2. Rating breakdown, 3. Individual reviews, 4. Buy/CTA
+
+---
+
+## Anti-Patterns (Do NOT Use)
+
+- ❌ Ornate design
+- ❌ No filtering
+
+### Additional Forbidden Patterns
+
+- ❌ **Emojis as icons** — Use SVG icons (Heroicons, Lucide, Simple Icons)
+- ❌ **Missing cursor:pointer** — All clickable elements must have cursor:pointer
+- ❌ **Layout-shifting hovers** — Avoid scale transforms that shift layout
+- ❌ **Low contrast text** — Maintain 4.5:1 minimum contrast ratio
+- ❌ **Instant state changes** — Always use transitions (150-300ms)
+- ❌ **Invisible focus states** — Focus states must be visible for a11y
+
+---
+
+## Pre-Delivery Checklist
+
+Before delivering any UI code, verify:
+
+- [ ] No emojis used as icons (use SVG instead)
+- [ ] All icons from consistent icon set (Heroicons/Lucide)
+- [ ] `cursor-pointer` on all clickable elements
+- [ ] Hover states with smooth transitions (150-300ms)
+- [ ] Light mode: text contrast 4.5:1 minimum
+- [ ] Focus states visible for keyboard navigation
+- [ ] `prefers-reduced-motion` respected
+- [ ] Responsive: 375px, 768px, 1024px, 1440px
+- [ ] No content hidden behind fixed navbars
+- [ ] No horizontal scroll on mobile

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -12,6 +12,7 @@ import type {
   LogEntry,
   OperatorWarning,
   PR,
+  PRStage,
   PRSummary,
   PRQuestion,
   ReleaseRun,
@@ -461,6 +462,45 @@ function issueWorkStatusFromJobs(jobs: BackgroundJob[]): { workStatus: Issue["wo
 
 export function issueWorkAttemptCountFromJobs(jobs: Array<Pick<BackgroundJob, "attemptCount">>): number {
   return jobs.reduce((total, job) => total + job.attemptCount + 1, 0);
+}
+
+function derivePrStageFromLogs(logs: LogEntry[]): PRStage {
+  let stage: PRStage = "feedback_synced";
+  for (const log of logs) {
+    const phase = log.phase?.toLowerCase() ?? "";
+    const message = log.message.toLowerCase();
+    if (phase.includes("run.sync") || message.includes("syncing github comments/reviews")) {
+      stage = "feedback_synced";
+      continue;
+    }
+    if (phase.includes("evaluate.comments")) {
+      stage = "triaged";
+      continue;
+    }
+    if (phase.includes("run.agent-running") || phase.includes("run.replay") || phase.includes("run.started")) {
+      stage = "applying";
+      continue;
+    }
+    if (phase.includes("verify.ci") || message.includes("waiting for checks") || message.includes("ci")) {
+      stage = "tests";
+      continue;
+    }
+    if (phase.includes("run.done") || message.includes("resolved")) {
+      stage = "done";
+    }
+  }
+  return stage;
+}
+
+async function attachDerivedPrStage<T extends PR | PRSummary>(pr: T, storage: IStorage): Promise<T> {
+  if (pr.status === "watching") {
+    return { ...pr, prStage: "feedback_synced" };
+  }
+  if (pr.status === "done" || pr.status === "archived") {
+    return { ...pr, prStage: "done" };
+  }
+  const logs = await storage.getLogs(pr.id);
+  return { ...pr, prStage: derivePrStageFromLogs(logs) };
 }
 
 function issueWorkStageFromLogs(
@@ -1081,6 +1121,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       includePrMergeability?: boolean;
       issueJobs?: BackgroundJob[];
       octokit?: Awaited<ReturnType<typeof buildOctokit>>;
+      isWorked?: boolean;
     } = {},
   ): Promise<Issue> {
     const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
@@ -1129,6 +1170,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       ...issue,
       id: targetId,
       repo: issue.repoFullName,
+      isWorked: options.isWorked ?? false,
       lastSyncAttemptedAt: issueSyncState.get(targetId)?.lastSyncAttemptedAt ?? null,
       lastSyncSucceededAt: issueSyncState.get(targetId)?.lastSyncSucceededAt ?? null,
       lastSyncError: issueSyncState.get(targetId)?.lastSyncError ?? null,
@@ -1224,8 +1266,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       };
     }
 
-    const synced = await storage.listSyncedIssues({ repos: config.watchedRepos, limit, offset });
-    const counts = await storage.listSyncedIssueCounts({ repos: config.watchedRepos });
+    const synced = await storage.listSyncedIssues({ repos: config.watchedRepos, limit, offset, includeWorked: true });
+    const counts = await storage.listSyncedIssueCounts({ repos: config.watchedRepos, includeWorked: true });
     const octokit = await buildOctokit(config);
     const workJobs = await storage.listBackgroundJobs({ kind: "work_issue" });
     const workJobsByTarget = new Map<string, BackgroundJob[]>();
@@ -1241,7 +1283,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
       const attemptedAt = markIssueSyncAttempt(targetId);
       markIssueSyncSuccess(targetId, attemptedAt);
-      return applyIssueWorkState(issue, { issueJobs: workJobsByTarget.get(targetId) ?? [], octokit });
+      return applyIssueWorkState(issue, { issueJobs: workJobsByTarget.get(targetId) ?? [], octokit, isWorked: record.isWorked });
     }));
 
     const sortedItems = issuesWithWorkLinks
@@ -1304,7 +1346,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     const attemptedAt = markIssueSyncAttempt(targetId);
     if (existing?.isWorked) {
       markIssueSyncSuccess(targetId, attemptedAt);
-      return applyIssueWorkState(existing.payload, { includePrMergeability: true });
+      return applyIssueWorkState(existing.payload, { includePrMergeability: true, isWorked: true });
     }
 
     const octokit = await buildOctokit(config);
@@ -2021,15 +2063,18 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     async listPRs(view = "active") {
-      if (view === "archived") {
-        return storage.getArchivedPRSummaries();
-      }
-
-      return storage.getPRSummaries();
+      const prs = view === "archived"
+        ? await storage.getArchivedPRSummaries()
+        : await storage.getPRSummaries();
+      return Promise.all(prs.map((pr) => attachDerivedPrStage(pr, storage)));
     },
 
     async getPR(id) {
-      return (await storage.getPR(id)) ?? null;
+      const pr = await storage.getPR(id);
+      if (!pr) {
+        return null;
+      }
+      return attachDerivedPrStage(pr, storage);
     },
 
     async addPR(url) {
@@ -2061,6 +2106,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const pr = await storage.addPR({
         number: parsed.number,
         title: summary.title,
+        body: summary.body,
+        bodyHtml: summary.bodyHtml,
         repo: repoSlug,
         branch: summary.branch,
         author: summary.author,

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import { access } from "fs/promises";
 import path from "path";
-import type { AgentRun, CheckSnapshot, FeedbackItem, HealingSession, PR } from "@shared/schema";
+import type { AgentRun, CheckSnapshot, FeedbackItem, HealingSession, PR, PRStage } from "@shared/schema";
 import type { IStorage } from "./storage";
 import {
   applyFixesWithAgent,
@@ -226,6 +226,15 @@ export function isTrustedReviewer(author: string, trustedReviewers: readonly str
     }
   }
   return false;
+}
+
+const PR_STAGE_ORDER: PRStage[] = ["feedback_synced", "triaged", "applying", "tests", "done"];
+
+function maxPrStage(current: PRStage | undefined, candidate: PRStage): PRStage {
+  if (!current) return candidate;
+  const currentIdx = PR_STAGE_ORDER.indexOf(current);
+  const candidateIdx = PR_STAGE_ORDER.indexOf(candidate);
+  return currentIdx >= candidateIdx ? current : candidate;
 }
 
 function countDecisions(items: FeedbackItem[]): {
@@ -1778,8 +1787,28 @@ export class PRBabysitter {
     const { merged, newCount } = mergeFeedbackItems(pr.feedbackItems, incomingFeedback);
     const counters = countDecisions(merged);
 
+    let refreshedTitle = pr.title;
+    let refreshedBody: string | null = pr.body;
+    let refreshedBodyHtml: string | null = pr.bodyHtml;
+    try {
+      const pullSummary = await this.github.fetchPullSummary(octokit, parsed);
+      refreshedTitle = pullSummary.title;
+      refreshedBody = pullSummary.body;
+      refreshedBodyHtml = pullSummary.bodyHtml;
+    } catch {
+      // Non-fatal: keep existing PR metadata if the summary fetch fails.
+    }
+
+    const candidateStage: PRStage = counters.accepted + counters.rejected + counters.flagged > 0
+      ? "triaged"
+      : "feedback_synced";
+    const nextPrStage = maxPrStage(pr.prStage, candidateStage);
+
     const updated = await this.storage.updatePR(pr.id, {
-      title: pr.title,
+      title: refreshedTitle,
+      body: refreshedBody,
+      bodyHtml: refreshedBodyHtml,
+      prStage: nextPrStage,
       status: pr.status,
       lastChecked: new Date().toISOString(),
       lastSyncAttemptedAt: new Date().toISOString(),
@@ -1959,7 +1988,7 @@ export class PRBabysitter {
             }
           }
 
-          await this.storage.updatePR(pr.id, { status: "archived" });
+          await this.storage.updatePR(pr.id, { status: "archived", prStage: "done" });
           await this.supersedeActiveHealingSessionsForArchivedPr(pr.id);
           await this.storage.addLog(pr.id, "info", `PR #${pr.number} is no longer open on GitHub — archived`, {
             phase: "watcher",
@@ -2784,6 +2813,7 @@ export class PRBabysitter {
 
       await this.storage.updatePR(prId, {
         status: "processing",
+        prStage: "applying",
         lastChecked: new Date().toISOString(),
       });
       await queueLog(prId, "info", `Babysitter run started using preferred agent ${preferredAgent}${recoveryMode ? " (recovery)" : ""}`, {
@@ -4487,6 +4517,7 @@ export class PRBabysitter {
 
           await this.storage.updatePR(pr.id, {
             testsPassed: false,
+            prStage: "tests",
             lastChecked: new Date().toISOString(),
           });
 
@@ -4560,6 +4591,7 @@ export class PRBabysitter {
           });
           await this.storage.updatePR(pr.id, {
             testsPassed: true,
+            prStage: "tests",
             lastChecked: new Date().toISOString(),
           });
 

--- a/server/github.ts
+++ b/server/github.ts
@@ -33,6 +33,8 @@ export type ParsedRepoSlug = {
 export type GitHubPullSummary = {
   number: number;
   title: string;
+  body: string | null;
+  bodyHtml: string | null;
   branch: string;
   author: string;
   url: string;
@@ -1267,9 +1269,12 @@ export async function fetchPullSummary(
   const pull = response.data;
   const baseRef = pull.base?.ref || pull.base?.repo?.default_branch || "";
 
+  const body = typeof pull.body === "string" ? pull.body : null;
   return {
     number: pull.number,
     title: pull.title || `PR #${pull.number}`,
+    body,
+    bodyHtml: body ? renderGitHubMarkdown(body) : null,
     branch: pull.head?.ref || "unknown",
     author: pull.user?.login || "",
     url: pull.html_url || `https://github.com/${parsed.owner}/${parsed.repo}/pull/${pull.number}`,
@@ -2008,9 +2013,13 @@ export async function listOpenPullsForRepo(
     per_page: 100,
   }));
 
-  return pulls.map((pull) => ({
+  return pulls.map((pull) => {
+    const body = typeof pull.body === "string" ? pull.body : null;
+    return {
     number: pull.number,
     title: pull.title || `PR #${pull.number}`,
+    body,
+    bodyHtml: body ? renderGitHubMarkdown(body) : null,
     branch: pull.head?.ref || "unknown",
     author: pull.user?.login || "",
     url: pull.html_url || `https://github.com/${repo.owner}/${repo.repo}/pull/${pull.number}`,
@@ -2023,7 +2032,8 @@ export async function listOpenPullsForRepo(
     baseRef: pull.base?.ref || pull.base?.repo?.default_branch || "",
     baseSha: pull.base?.sha || "",
     mergeable: null,
-  }));
+    };
+  });
 }
 
 export async function listOpenIssuesForRepo(

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -367,7 +367,7 @@ export class MemStorage implements IStorage {
     const repos = new Set(input.repos.map((repo) => repo.toLowerCase()));
     const includeWorked = input.includeWorked ?? false;
     const all = Array.from(this.syncedIssues.values())
-      .filter((record) => record.isOpen && repos.has(record.repo.toLowerCase()) && (includeWorked || !record.isWorked))
+      .filter((record) => (record.isOpen || (includeWorked && record.isWorked)) && repos.has(record.repo.toLowerCase()) && (includeWorked || !record.isWorked))
       .sort((a, b) => b.number - a.number);
     const items = all.slice(input.offset, input.offset + input.limit).map((record) => structuredClone(record));
     return { items, hasMore: input.offset + items.length < all.length };
@@ -379,7 +379,7 @@ export class MemStorage implements IStorage {
     const repoTotals: Record<string, number> = {};
     let totalCount = 0;
     for (const record of Array.from(this.syncedIssues.values())) {
-      if (!record.isOpen) continue;
+      if (!record.isOpen && !(includeWorked && record.isWorked)) continue;
       if (!repos.has(record.repo.toLowerCase())) continue;
       if (!includeWorked && record.isWorked) continue;
       repoTotals[record.repo] = (repoTotals[record.repo] ?? 0) + 1;

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
 import type { SQLInputValue } from "node:sqlite";
-import { backgroundJobStatusEnum, docsAssessmentSchema, feedbackStatusEnum } from "@shared/schema";
+import { backgroundJobStatusEnum, docsAssessmentSchema, feedbackStatusEnum, prStageEnum } from "@shared/schema";
 import type {
   AgentRun,
   AgentRunStatus,
@@ -146,6 +146,9 @@ type PRRow = {
   id: string;
   number: number;
   title: string;
+  body: string | null;
+  body_html: string | null;
+  pr_stage: string | null;
   repo: string;
   branch: string;
   author: string;
@@ -958,6 +961,9 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("prs", "last_sync_attempted_at", "TEXT");
     this.ensureColumn("prs", "last_sync_succeeded_at", "TEXT");
     this.ensureColumn("prs", "last_sync_error", "TEXT");
+    this.ensureColumn("prs", "body", "TEXT");
+    this.ensureColumn("prs", "body_html", "TEXT");
+    this.ensureColumn("prs", "pr_stage", "TEXT");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
     if (!configExists) {
@@ -1255,6 +1261,9 @@ export class SqliteStorage implements IStorage {
       id: row.id,
       number: row.number,
       title: row.title,
+      body: row.body ?? null,
+      bodyHtml: row.body_html ?? null,
+      prStage: this.parsePRStage(row.pr_stage),
       repo: row.repo,
       branch: row.branch,
       author: row.author,
@@ -1281,6 +1290,9 @@ export class SqliteStorage implements IStorage {
       id: row.id,
       number: row.number,
       title: row.title,
+      body: row.body ?? null,
+      bodyHtml: row.body_html ?? null,
+      prStage: this.parsePRStage(row.pr_stage),
       repo: row.repo,
       branch: row.branch,
       author: row.author,
@@ -1299,6 +1311,12 @@ export class SqliteStorage implements IStorage {
       docsAssessment: this.parseDocsAssessment(row.docs_assessment_json),
       addedAt: row.added_at,
     };
+  }
+
+  private parsePRStage(raw: string | null): PR["prStage"] {
+    if (!raw) return undefined;
+    const parsed = prStageEnum.safeParse(raw);
+    return parsed.success ? parsed.data : undefined;
   }
 
   private parseDocsAssessment(raw: string | null): PR["docsAssessment"] {
@@ -1617,7 +1635,7 @@ export class SqliteStorage implements IStorage {
 
   async getPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
-      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+      SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
@@ -1631,7 +1649,7 @@ export class SqliteStorage implements IStorage {
 
   async getArchivedPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
-      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+      SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
@@ -1645,7 +1663,7 @@ export class SqliteStorage implements IStorage {
 
   async getPRSummaries(): Promise<PRSummary[]> {
     const rows = this.all<PRRow>(`
-      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+      SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
@@ -1657,7 +1675,7 @@ export class SqliteStorage implements IStorage {
 
   async getArchivedPRSummaries(): Promise<PRSummary[]> {
     const rows = this.all<PRRow>(`
-      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+      SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
@@ -1669,7 +1687,7 @@ export class SqliteStorage implements IStorage {
 
   async getPR(id: string): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
-      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+      SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE id = ?
@@ -1685,7 +1703,7 @@ export class SqliteStorage implements IStorage {
 
   async getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
-      SELECT id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+      SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
              tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE repo = ? AND number = ?
@@ -1705,13 +1723,16 @@ export class SqliteStorage implements IStorage {
     this.withWriteTransaction(() => {
       this.run(`
         INSERT INTO prs (
-          id, number, title, repo, branch, author, url, status, accepted, rejected, flagged,
+          id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
           tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         full.id,
         full.number,
         full.title,
+        full.body ?? null,
+        full.bodyHtml ?? null,
+        full.prStage ?? null,
         full.repo,
         full.branch,
         full.author,
@@ -1747,13 +1768,16 @@ export class SqliteStorage implements IStorage {
     this.withWriteTransaction(() => {
       this.run(`
         UPDATE prs
-        SET number = ?, title = ?, repo = ?, branch = ?, author = ?, url = ?, status = ?,
+        SET number = ?, title = ?, body = ?, body_html = ?, pr_stage = ?, repo = ?, branch = ?, author = ?, url = ?, status = ?,
             accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, last_checked = ?,
             last_sync_attempted_at = ?, last_sync_succeeded_at = ?, last_sync_error = ?, watch_enabled = ?, docs_assessment_json = ?
         WHERE id = ?
       `,
         updated.number,
         updated.title,
+        updated.body ?? null,
+        updated.bodyHtml ?? null,
+        updated.prStage ?? null,
         updated.repo,
         updated.branch,
         updated.author,
@@ -2189,10 +2213,11 @@ export class SqliteStorage implements IStorage {
       `
         SELECT repo, issue_number, payload_json, is_open, is_worked, first_seen_at, last_seen_at
         FROM synced_issues
-        WHERE is_open = 1 AND repo IN (${placeholders}) AND (? = 1 OR is_worked = 0)
+        WHERE (is_open = 1 OR (? = 1 AND is_worked = 1)) AND repo IN (${placeholders}) AND (? = 1 OR is_worked = 0)
         ORDER BY issue_number DESC
         LIMIT ? OFFSET ?
       `,
+      includeWorked ? 1 : 0,
       ...input.repos,
       includeWorked ? 1 : 0,
       input.limit + 1,
@@ -2213,9 +2238,10 @@ export class SqliteStorage implements IStorage {
       `
         SELECT repo, COUNT(*) as count
         FROM synced_issues
-        WHERE is_open = 1 AND repo IN (${placeholders}) AND (? = 1 OR is_worked = 0)
+        WHERE (is_open = 1 OR (? = 1 AND is_worked = 1)) AND repo IN (${placeholders}) AND (? = 1 OR is_worked = 0)
         GROUP BY repo
       `,
+      includeWorked ? 1 : 0,
       ...input.repos,
       includeWorked ? 1 : 0,
     );

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 export const prStatusEnum = z.enum(["watching", "processing", "done", "error", "archived"]);
 export type PRStatus = z.infer<typeof prStatusEnum>;
+export const prStageEnum = z.enum(["feedback_synced", "triaged", "applying", "tests", "done"]);
+export type PRStage = z.infer<typeof prStageEnum>;
 
 export const triageDecision = z.enum(["accept", "reject", "flag"]);
 export type TriageDecision = z.infer<typeof triageDecision>;
@@ -59,11 +61,14 @@ export const prSchema = z.object({
   id: z.string(),
   number: z.number(),
   title: z.string(),
+  body: z.string().nullable().default(null),
+  bodyHtml: z.string().nullable().default(null),
   repo: z.string(), // "owner/repo"
   branch: z.string(),
   author: z.string(),
   url: z.string(),
   status: prStatusEnum,
+  prStage: prStageEnum.optional(),
   feedbackItems: z.array(feedbackItemSchema),
   accepted: z.number(),
   rejected: z.number(),
@@ -232,6 +237,7 @@ export const issueSchema = z.object({
   number: z.number(),
   title: z.string(),
   repo: z.string(),
+  isWorked: z.boolean().optional(),
   author: z.string(),
   url: z.string(),
   body: z.string().nullable(),


### PR DESCRIPTION
## Summary

- New **Dashboard overview** at `/` (KPI strip, per-repo cards, Activity panel). Existing PR list moves to `/prs`. Nav order is now **Dashboard · Issues · PRs · Releases**.
- **Unified detail layout** for PRs and Issues via shared primitives (`DetailHeader`, `MetaBreadcrumb`, `DetailPanel`, `StatusChip`, `StageProgressBar`). Status-colored left rails on list rows, entity-accent stripes (blue for PRs, amber for Issues), failed-state background wash, right-side log panel on Issues.
- **Verify Work**: `POST /api/issues/verify` queues a `verify_issue` background job that re-decomposes the issue body, fetches the work PR diff, grades each subtask, persists verdicts, and posts a verification checklist comment to the PR. New Subtasks panel + `re-verifying`/`re-verified` badges driven by `/api/activities`.
- **PR pipeline stages**: `feedback_synced → triaged → applying → tests → done` driven by babysitter transitions. New `prStage` enum + column with monotonic promotion in `syncFeedbackForPR`.
- **PR markdown body**: `body` + `bodyHtml` added to PR schema; collapsible Description panel in PR detail view (default collapsed).

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run test:all` — 629/629 passing
- [ ] Manual: `/` renders Dashboard overview with KPI strip + repo cards + activity panel
- [ ] Manual: `/prs` renders existing PR list, nav highlight on "PRs"
- [ ] Manual: nav order reads Dashboard · Issues · PRs · Releases
- [ ] Manual: open a PR — confirm Description panel collapsed by default + chevron toggle; confirm StageProgressBar reflects current `prStage`
- [ ] Manual: open an Issue, click **Verify work** — confirm:
  - Toast shows "Queued verification…"
  - `verify_issue` activity appears, row shows pulsing `re-verifying` badge
  - On completion, Subtasks panel shows verdicts with reasons, badge flips to `re-verified` for ~8s, PR receives a verification checklist comment
- [ ] Manual: babysit a PR and confirm pipeline bar advances `feedback_synced → triaged → applying → tests`
- [ ] Manual: failed PR / failed Issue gets the destructive accent (left rail + header wash)