### PR TITLE
feat: improve PR activity stream and repo auto-mode visibility

### DIFF
--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -193,7 +193,7 @@ function formatEvaluationConfidence(confidence: number): string {
   return `${grade} (${Math.round(confidence * 100)}%)`;
 }
 
-type IssueWorkFilter = "all" | "ready" | "auto" | "needs_eval" | "review" | "failed" | "stale";
+type IssueWorkFilter = "all" | "ready" | "worked" | "auto" | "needs_eval" | "review" | "failed" | "stale";
 
 function isStaleIssue(issue: Issue): boolean {
   const updatedAt = Date.parse(issue.updatedAt);
@@ -205,13 +205,30 @@ function isStaleIssue(issue: Issue): boolean {
 }
 
 function matchesIssueWorkFilter(issue: Issue, filter: IssueWorkFilter): boolean {
-  if (filter === "ready") return Boolean(issue.workPrUrl);
+  if (filter === "ready") return issue.workPrMergeable === true;
+  if (filter === "worked") return Boolean(issue.isWorked);
   if (filter === "auto") return Boolean(issue.autoWorkEligible);
   if (filter === "needs_eval") return !issue.evaluationStatus;
   if (filter === "review") return issue.evaluationStatus === "blocked" || issue.evaluationStatus === "needs_review";
   if (filter === "failed") return issue.workStatus === "failed";
   if (filter === "stale") return isStaleIssue(issue);
   return true;
+}
+
+function issueLifecycleLabel(issue: Issue): string | null {
+  if (!issue.isWorked) {
+    return null;
+  }
+
+  if (issue.workPrUrl && issue.workPrMergeable === false) {
+    return "re-opened after divergence";
+  }
+
+  if (issue.workPrUrl) {
+    return "worked, awaiting merge";
+  }
+
+  return "worked";
 }
 
 const LOG_METADATA_ORDER = ["repo", "issueNumber", "prNumber", "prUrl", "jobId", "stage", "status", "safetyFlags"] as const;
@@ -289,20 +306,33 @@ function IssueRow({
   verifyState: VerifyState | null;
 }) {
   const showInlineStatusBadge = issue.workStatus !== "queued" && issue.workStatus !== "in_progress";
+  const lifecycle = issueLifecycleLabel(issue);
   const rowAction =
     issue.workPrUrl && issue.workPrNumber !== undefined && issue.workPrNumber !== null
       ? (
+        (() => {
+          const readiness = getWorkPrReadiness(issue);
+          const toneClass = readiness.tone === "success"
+            ? "border-success-border text-success-foreground"
+            : readiness.tone === "warning"
+              ? "border-warning-border text-warning-foreground"
+              : "border-border text-muted-foreground";
+          return (
         <a
           href={issue.workPrUrl}
           target="_blank"
           rel="noreferrer noopener"
           data-testid="issue-ready-to-merge-list"
-          className="mt-2 inline-flex items-center gap-1 rounded-md border border-success-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-success-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          className={`mt-2 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${toneClass}`}
         >
           <ExternalLink className="h-3 w-3" />
           PR <span className="font-mono">#{issue.workPrNumber}</span>
-          <span className="text-success-foreground/70">ready to merge</span>
+          <span className={readiness.tone === "success" ? "text-success-foreground/70" : readiness.tone === "warning" ? "text-warning-foreground/70" : "text-muted-foreground/70"}>
+            {readiness.label.toLowerCase()}
+          </span>
         </a>
+          );
+        })()
       )
       : hasExternalIssuePr(issue)
         ? (
@@ -367,6 +397,13 @@ function IssueRow({
             />
             <QueueStatusBadge status={queueStatus} />
             {verifyState && <VerifyStateBadge state={verifyState} />}
+            {lifecycle && (
+              <StatusChip
+                tone={lifecycle === "re-opened after divergence" ? "warning" : "success"}
+                label={lifecycle}
+                testId="issue-lifecycle-badge"
+              />
+            )}
             {issue.isWorked && (
               <StatusChip tone="success" label="worked" testId="issue-worked-badge" />
             )}
@@ -1007,7 +1044,10 @@ function IssuesPage() {
   const activeIssueCount = issues.filter((issue) => isActiveWorkStatus(issue.workStatus)).length;
   const visibleIssues = filteredIssues;
   const readyIssueCount = issues.filter((issue) =>
-    (selectedRepo === "all" || issue.repo === selectedRepo) && Boolean(issue.workPrUrl)
+    (selectedRepo === "all" || issue.repo === selectedRepo) && issue.workPrMergeable === true
+  ).length;
+  const workedIssueCount = issues.filter((issue) =>
+    (selectedRepo === "all" || issue.repo === selectedRepo) && Boolean(issue.isWorked)
   ).length;
   const autoEligibleIssueCount = issues.filter((issue) =>
     (selectedRepo === "all" || issue.repo === selectedRepo) && Boolean(issue.autoWorkEligible)
@@ -1123,9 +1163,9 @@ function IssuesPage() {
                 Status
               </span>
               <div className="flex min-w-0 flex-1 flex-wrap gap-1">
-                <button
-                  type="button"
-                  onClick={() => setSelectedWorkFilter("ready")}
+            <button
+              type="button"
+              onClick={() => setSelectedWorkFilter("ready")}
               className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "ready"
                   ? "border-primary bg-primary/10 text-primary"
@@ -1133,6 +1173,18 @@ function IssuesPage() {
               }`}
             >
               ready to merge ({readyIssueCount})
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedWorkFilter("worked")}
+              data-testid="issue-worked-filter"
+              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+                selectedWorkFilter === "worked"
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
+              }`}
+            >
+              worked ({workedIssueCount})
             </button>
             <button
               type="button"

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearch } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 import { fetchJson } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
+import type { ActivitySnapshot } from "@shared/schema";
+import { EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 
 const LEVELS = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
 type Level = (typeof LEVELS)[number];
@@ -108,6 +111,10 @@ export default function Logs() {
   const [records, setRecords] = useState<LogRecord[]>([]);
   const [sources, setSources] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
+    queryKey: ["/api/activities"],
+    refetchInterval: 3000,
+  });
 
   const recordsRef = useRef<LogRecord[]>([]);
   recordsRef.current = records;
@@ -195,6 +202,13 @@ export default function Logs() {
     }
     return out;
   }, [records, level, source, searchTerm]);
+
+  const activityItems = useMemo(
+    () => [...activities.failed, ...activities.inProgress, ...activities.queued]
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .slice(0, 100),
+    [activities.failed, activities.inProgress, activities.queued],
+  );
 
   const onCopy = async () => {
     try {
@@ -291,6 +305,27 @@ export default function Logs() {
       )}
 
       <div ref={containerRef} className="flex-1 overflow-y-auto p-3 font-mono text-[11px] leading-relaxed">
+        <div className="mb-3 border border-border/60">
+          <div className="border-b border-border/60 px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+            Activity
+          </div>
+          <div className="max-h-56 overflow-y-auto">
+            {activityItems.length === 0 ? (
+              <div className="px-2 py-2 text-[10px] text-muted-foreground">No active activity.</div>
+            ) : (
+              activityItems.map((item) => (
+                <div key={item.id} className="border-b border-border/40 px-2 py-1.5 last:border-b-0">
+                  <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                    <span>{item.kind.replace("_", " ")}</span>
+                    <span>{item.status.replace("_", " ")}</span>
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-foreground/85">{item.label}</div>
+                  {item.detail && <div className="text-[10px] text-muted-foreground">{item.detail}</div>}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
         {filteredRecords.length === 0 ? (
           <div className="text-center text-muted-foreground">No log records match the current filter.</div>
         ) : (

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -727,10 +727,14 @@ function LogPanel({ prId }: { prId: string | null }) {
   const { data: logs = [] } = useQuery<LogEntry[]>({
     queryKey: ["/api/logs", prId ?? "all"],
     queryFn: async () => {
-      const url = prId ? `/api/logs?prId=${encodeURIComponent(prId)}` : "/api/logs";
+      if (!prId) {
+        return [];
+      }
+      const url = `/api/logs?prId=${encodeURIComponent(prId)}`;
       const res = await apiRequest("GET", url);
       return res.json();
     },
+    enabled: Boolean(prId),
     refetchInterval: 1500,
   });
   const visibleLogs = useMemo(
@@ -738,7 +742,6 @@ function LogPanel({ prId }: { prId: string | null }) {
     [logs],
   );
   const hiddenLogCount = logs.length - visibleLogs.length;
-
   useEffect(() => {
     const scroller = scrollerRef.current;
     if (!scroller) {
@@ -751,7 +754,9 @@ function LogPanel({ prId }: { prId: string | null }) {
   return (
     <div className="flex h-full flex-col">
       <div ref={scrollerRef} className="flex-1 overflow-y-auto p-4 font-mono text-[11px] leading-relaxed">
-        {logs.length === 0 ? (
+        {!prId ? (
+          <span className="text-muted-foreground">Select a PR to view activity.</span>
+        ) : logs.length === 0 ? (
           <span className="text-muted-foreground">No log entries.</span>
         ) : (
           <>
@@ -932,61 +937,14 @@ function PRDescriptionPanel({ pr }: { pr: PR }) {
   );
 }
 
-function RightPanel({
-  prId,
-  prStatus,
-  globalDrainMode,
-}: {
-  prId: string | null;
-  prStatus?: PR["status"] | null;
-  globalDrainMode: boolean;
-}) {
-  const [tab, setTab] = useState<"activity" | "ask">("ask");
-
-  useEffect(() => {
-    if (prStatus === "error") {
-      setTab("activity");
-    }
-  }, [prId, prStatus]);
-
+function RightPanel({ prId }: { prId: string | null }) {
   return (
     <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
-      <div className="flex border-b border-border">
-        <button
-          type="button"
-          onClick={() => setTab("ask")}
-          data-testid="tab-ask"
-          className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-            tab === "ask"
-              ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          Ask Agent
-        </button>
-        <button
-          type="button"
-          onClick={() => setTab("activity")}
-          data-testid="tab-activity"
-          className={`flex-1 px-3 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
-            tab === "activity"
-              ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          Activity
-        </button>
+      <div className="border-b border-border px-3 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+        <span data-testid="tab-activity">Activity</span>
       </div>
       <div className="flex-1 overflow-hidden">
-        {tab === "activity" ? (
-          <LogPanel prId={prId} />
-        ) : prId ? (
-          <QAPanel prId={prId} globalDrainMode={globalDrainMode} />
-        ) : (
-          <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
-            Select a PR to ask questions.
-          </div>
-        )}
+        <LogPanel prId={prId} />
       </div>
     </div>
   );
@@ -1135,6 +1093,7 @@ export default function Dashboard() {
   const [prNumberSearch, setPrNumberSearch] = useState("");
   const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isAskOpen, setIsAskOpen] = useState(false);
 
   const handleSyncDashboard = async () => {
     setIsRefreshing(true);
@@ -1671,9 +1630,30 @@ export default function Dashboard() {
 
         <RightPanel
           prId={selectedPRId}
-          prStatus={selectedPR?.status ?? null}
-          globalDrainMode={globalDrainMode}
         />
+      </div>
+      <div className="fixed bottom-4 right-4 z-50">
+        {isAskOpen && (
+          <div className="mb-2 h-[32rem] w-[22rem] max-w-[calc(100vw-2rem)] overflow-hidden rounded-md border border-border bg-background shadow-2xl">
+            {selectedPRId ? (
+              <QAPanel prId={selectedPRId} globalDrainMode={globalDrainMode} />
+            ) : (
+              <div className="flex h-full items-center justify-center p-4 text-[12px] text-muted-foreground">
+                Select a PR to ask questions.
+              </div>
+            )}
+          </div>
+        )}
+        <span data-testid="tab-ask" className="sr-only">Ask Agent</span>
+        <button
+          type="button"
+          onClick={() => setIsAskOpen((current) => !current)}
+          data-testid="button-ask-agent-fab"
+          title={isAskOpen ? "Close Ask Agent" : "Open Ask Agent"}
+          className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-primary bg-primary text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        >
+          <Bot className="h-5 w-5" />
+        </button>
       </div>
     </div>
   );

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -147,6 +147,14 @@ function repoTestId(repo: string): string {
   return repo.replace("/", "-");
 }
 
+function isRepoFullyAuto(repo: WatchedRepo): boolean {
+  return repo.prAutoMonitor !== false && repo.issueAutoEvaluate && repo.issueAutoWork;
+}
+
+function isRepoPartiallyAuto(repo: WatchedRepo): boolean {
+  return repo.prAutoMonitor !== false || repo.issueAutoEvaluate || repo.issueAutoWork;
+}
+
 function SegmentControl<T extends string>({
   options,
   value,
@@ -716,6 +724,11 @@ export default function Settings() {
                   const id = repoTestId(repo.repo);
                   const manualReleasePending = manualReleaseMutation.isPending
                     && manualReleaseMutation.variables === repo.repo;
+                  const repoFullyAuto = isRepoFullyAuto(repo);
+                  const repoPartiallyAuto = isRepoPartiallyAuto(repo);
+                  const shouldShowRepoAutoAlert = config?.autoPrs !== false
+                    && config?.autoIssues !== false
+                    && !repoFullyAuto;
 
                   return (
                     <div
@@ -735,6 +748,35 @@ export default function Settings() {
                           </a>
                           <div className="mt-1 text-[11px] text-muted-foreground">
                             {repo.ownPrsOnly === false ? "Tracking team PRs" : "Tracking your PRs"} · PR monitoring {repo.prAutoMonitor === false ? "manual" : "auto"} · issue evaluate {repo.issueAutoEvaluate ? "auto" : "manual"} · issue work {repo.issueAutoWork ? "auto" : "manual"}
+                          </div>
+                          <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider">
+                            <span
+                              className={`inline-flex items-center border px-2 py-0.5 ${
+                                repoFullyAuto
+                                  ? "border-success-border bg-success-muted text-success-foreground"
+                                  : repoPartiallyAuto
+                                    ? "border-warning-border bg-warning-muted text-warning-foreground"
+                                    : "border-border bg-muted text-muted-foreground"
+                              }`}
+                              data-testid={`tracked-repo-automation-mode-${repo.repo.replace("/", "-")}`}
+                            >
+                              {repoFullyAuto ? "Auto mode" : repoPartiallyAuto ? "Mixed mode" : "Manual mode"}
+                            </span>
+                            {repo.prAutoMonitor === false && (
+                              <span className="inline-flex items-center border border-border px-2 py-0.5 text-muted-foreground">
+                                PR: manual
+                              </span>
+                            )}
+                            {!repo.issueAutoEvaluate && (
+                              <span className="inline-flex items-center border border-border px-2 py-0.5 text-muted-foreground">
+                                Issue evaluate: manual
+                              </span>
+                            )}
+                            {!repo.issueAutoWork && (
+                              <span className="inline-flex items-center border border-border px-2 py-0.5 text-muted-foreground">
+                                Issue work: manual
+                              </span>
+                            )}
                           </div>
                         </div>
                         <button
@@ -776,6 +818,32 @@ export default function Settings() {
                           Remove data
                         </button>
                       </div>
+                      {shouldShowRepoAutoAlert && (
+                        <div
+                          data-testid={`tracked-repo-auto-alert-${repo.repo.replace("/", "-")}`}
+                          className="mt-3 flex flex-wrap items-center justify-between gap-2 border border-warning-border bg-warning-muted px-3 py-2 text-[11px] text-warning-foreground"
+                        >
+                          <span>
+                            Global auto is on, but this repo is not fully automated yet.
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              updateRepoSettingsMutation.mutate({
+                                repo: repo.repo,
+                                prAutoMonitor: true,
+                                issueAutoEvaluate: true,
+                                issueAutoWork: true,
+                              })
+                            }
+                            disabled={updateRepoSettingsMutation.isPending}
+                            data-testid={`tracked-repo-enable-auto-${repo.repo.replace("/", "-")}`}
+                            className="shrink-0 border border-warning-border bg-background px-2 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:bg-warning-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-40"
+                          >
+                            Enable auto for repo
+                          </button>
+                        </div>
+                      )}
                       {config?.autoIssues === false && (
                         <div
                           data-testid={`tracked-repo-global-issues-off-${repo.repo.replace("/", "-")}`}


### PR DESCRIPTION
## Summary
- make PR Activity sidebar show the selected PR's workflow/log activity (single stream, no duplicate nested Activity header)
- keep PR Activity empty state scoped to selection (no global log bleed when no PR selected)
- add repo automation mode badge in Settings (Auto / Mixed / Manual)
- add per-repo warning when global auto is on but repo-level automation is not fully enabled
- add one-click "Enable auto for repo" action in Settings
- keep prior issue lifecycle/status UI updates in this branch

## Verification
- npm run check
- npm run test -- client/src/lib/fullAppQaSurface.test.ts