### PR TITLE
fix: gate GitHub rate-limit per resource (core/graphql/search)

### DIFF
--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -817,14 +817,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         return;
       }
 
-      const rateLimit = getRateLimitState();
+      const rateLimit = getRateLimitState("core");
       if (rateLimit.limited && rateLimit.resetAt) {
         log.info(
           {
             resetAt: rateLimit.resetAt.toISOString(),
             secondsUntilReset: Math.ceil((rateLimit.resetAt.getTime() - Date.now()) / 1000),
           },
-          "Skipping watcher tick: GitHub rate limit gate active",
+          "Skipping watcher tick: GitHub core rate limit gate active",
         );
         return;
       }

--- a/server/github.ts
+++ b/server/github.ts
@@ -5,7 +5,13 @@ import { runCommand } from "./agentRunner";
 import { normalizeCheckSnapshotsFromRef } from "./ciCheckIngestor";
 import { childLogger } from "./logger";
 import { renderGitHubMarkdown } from "./markdown";
-import { clearRateLimited, getRateLimitState, markRateLimited } from "./rateLimitState";
+import {
+  clearRateLimited,
+  deriveRateLimitResource,
+  getRateLimitState,
+  markRateLimited,
+  type RateLimitResource,
+} from "./rateLimitState";
 
 const octokitLog = childLogger("octokit");
 
@@ -757,13 +763,16 @@ async function withGitHubErrorHandling<T>(
 class RateLimitGateError extends Error {
   readonly status = 403;
   readonly response: { headers: Record<string, string> };
-  constructor(resetAt: Date) {
-    super(`GitHub rate limit gate active until ${resetAt.toISOString()}`);
+  readonly resource: RateLimitResource;
+  constructor(resetAt: Date, resource: RateLimitResource) {
+    super(`GitHub rate limit gate active for ${resource} until ${resetAt.toISOString()}`);
     this.name = "RateLimitGateError";
+    this.resource = resource;
     this.response = {
       headers: {
         "x-ratelimit-remaining": "0",
         "x-ratelimit-reset": String(Math.ceil(resetAt.getTime() / 1000)),
+        "x-ratelimit-resource": resource,
       },
     };
   }
@@ -927,17 +936,24 @@ function attachRateLimitHook(
   resolveRateLimitResetAt?: (resourceHint: string | null) => Promise<Date | null>,
 ): void {
   client.hook.wrap("request", async (request, options) => {
-    const state = getRateLimitState();
-    if (state.limited && state.resetAt) {
-      throw new RateLimitGateError(state.resetAt);
+    const requestResource = deriveRateLimitResource(options.url);
+    const resourceState = getRateLimitState(requestResource);
+    if (resourceState.limited && resourceState.resetAt) {
+      throw new RateLimitGateError(resourceState.resetAt, requestResource);
     }
 
     const dispatch = async (): Promise<ReturnType<typeof request>> => {
       const response = await request(options);
+      const headerResourceRaw = typeof response.headers?.["x-ratelimit-resource"] === "string"
+        ? response.headers["x-ratelimit-resource"]
+        : null;
+      const responseResource = headerResourceRaw
+        ? deriveRateLimitResource(headerResourceRaw)
+        : requestResource;
       const remainingRaw = response.headers?.["x-ratelimit-remaining"];
       const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
       if (Number.isFinite(remaining) && remaining > 0) {
-        clearRateLimited();
+        clearRateLimited(responseResource);
       }
       return response;
     };
@@ -955,8 +971,9 @@ function attachRateLimitHook(
           throw error;
         }
 
+        const limitedResource = deriveRateLimitResource(resource ?? options.url);
         const exactResetAt = resolveRateLimitResetAt ? await resolveRateLimitResetAt(resource) : null;
-        const gateAt = markRateLimited(exactResetAt ?? gateUntil ?? undefined);
+        const gateAt = markRateLimited(exactResetAt ?? gateUntil ?? undefined, limitedResource);
         const waitMs = gateAt.getTime() - Date.now();
         if (attempt === 0 && waitMs > 0 && waitMs <= RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS) {
           attempt += 1;

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -227,6 +227,53 @@ test("octokit hook does not auto-retry when the Retry-After wait exceeds the thr
   assert.ok(state.resetAt!.getTime() - Date.now() > 60_000);
 });
 
+test("octokit hook gates only the resource that 403d, leaving others free", async () => {
+  const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
+  let graphqlCalls = 0;
+  let restCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async (input) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/graphql")) {
+          graphqlCalls += 1;
+          return new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+            status: 403,
+            headers: {
+              "content-type": "application/json",
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": String(resetUnixSeconds),
+              "x-ratelimit-resource": "graphql",
+            },
+          });
+        }
+        restCalls += 1;
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+            "x-ratelimit-resource": "core",
+          },
+        });
+      },
+    },
+  );
+
+  await assert.rejects(() => octokit.graphql("query { viewer { login } }"));
+  assert.ok(graphqlCalls >= 1);
+
+  // graphql is gated...
+  assert.equal(getRateLimitState("graphql").limited, true);
+  // ...but core is not, so a REST call still reaches the fake fetch.
+  const ok = await octokit.request("GET /user");
+  assert.equal(ok.data.login, "octo");
+  assert.ok(restCalls >= 1);
+  assert.equal(getRateLimitState("core").limited, false);
+});
+
 test("octokit hook clears the gate on a successful response with remaining > 0", async () => {
   let callIndex = 0;
   const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { clearRateLimitStateForTests, clearRateLimited, getRateLimitState, markRateLimited } from "./rateLimitState";
+import {
+  clearRateLimitStateForTests,
+  clearRateLimited,
+  deriveRateLimitResource,
+  getRateLimitState,
+  markRateLimited,
+} from "./rateLimitState";
 
 test.beforeEach(() => clearRateLimitStateForTests());
 
@@ -53,4 +59,55 @@ test("clearRateLimited resets the gate", () => {
   clearRateLimited();
   assert.equal(getRateLimitState().limited, false);
   assert.equal(getRateLimitState().recentlyLimited, true);
+});
+
+test("deriveRateLimitResource routes URLs and headers to the right bucket", () => {
+  assert.equal(deriveRateLimitResource("POST /graphql"), "graphql");
+  assert.equal(deriveRateLimitResource("/graphql"), "graphql");
+  assert.equal(deriveRateLimitResource("graphql"), "graphql");
+  assert.equal(deriveRateLimitResource("GET /search/issues"), "search");
+  assert.equal(deriveRateLimitResource("/search/code"), "search");
+  assert.equal(deriveRateLimitResource("search"), "search");
+  assert.equal(deriveRateLimitResource("GET /repos/foo/bar/pulls"), "core");
+  assert.equal(deriveRateLimitResource(undefined), "core");
+  assert.equal(deriveRateLimitResource(""), "core");
+});
+
+test("limiting graphql does not gate core, and vice versa", () => {
+  const reset = Math.floor(Date.now() / 1000) + 600;
+  markRateLimited(reset, "graphql");
+
+  const coreState = getRateLimitState("core");
+  assert.equal(coreState.limited, false, "core should still be open");
+
+  const graphqlState = getRateLimitState("graphql");
+  assert.equal(graphqlState.limited, true);
+  assert.equal(graphqlState.resetAt!.getTime(), reset * 1000);
+
+  const aggregate = getRateLimitState();
+  assert.equal(aggregate.limited, true, "aggregate is limited if any resource is");
+  assert.equal(aggregate.resources.core.limited, false);
+  assert.equal(aggregate.resources.graphql.limited, true);
+  assert.equal(aggregate.resources.search.limited, false);
+});
+
+test("clearing one resource does not clear the others", () => {
+  const reset = Math.floor(Date.now() / 1000) + 600;
+  markRateLimited(reset, "core");
+  markRateLimited(reset, "search");
+
+  clearRateLimited("core");
+
+  assert.equal(getRateLimitState("core").limited, false);
+  assert.equal(getRateLimitState("search").limited, true);
+});
+
+test("aggregate resetAt is the latest among limited resources", () => {
+  const soon = Math.floor(Date.now() / 1000) + 300;
+  const later = Math.floor(Date.now() / 1000) + 900;
+  markRateLimited(soon, "core");
+  markRateLimited(later, "graphql");
+
+  const aggregate = getRateLimitState();
+  assert.equal(aggregate.resetAt!.getTime(), later * 1000);
 });

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -2,66 +2,136 @@ import { childLogger } from "./logger";
 
 const log = childLogger("rateLimit");
 
-export type RateLimitSnapshot = {
+export type RateLimitResource = "core" | "graphql" | "search";
+
+const RESOURCES: RateLimitResource[] = ["core", "graphql", "search"];
+
+export type ResourceSnapshot = {
   limited: boolean;
   resetAt: Date | null;
   recentlyLimited: boolean;
   lastLimitedAt: Date | null;
 };
 
-let resetAt: Date | null = null;
-let lastLimitedAt: Date | null = null;
+export type RateLimitSnapshot = ResourceSnapshot & {
+  resources: Record<RateLimitResource, ResourceSnapshot>;
+};
+
+type ResourceState = { resetAt: Date | null; lastLimitedAt: Date | null };
+
 const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
-export function markRateLimited(reset: Date | number | undefined): Date {
-  let parsed: Date | null = null;
-  if (reset instanceof Date) {
-    parsed = reset;
-  } else if (typeof reset === "number" && Number.isFinite(reset) && reset > 0) {
+const state: Record<RateLimitResource, ResourceState> = {
+  core: { resetAt: null, lastLimitedAt: null },
+  graphql: { resetAt: null, lastLimitedAt: null },
+  search: { resetAt: null, lastLimitedAt: null },
+};
+
+export function deriveRateLimitResource(
+  urlOrHeader: string | null | undefined,
+): RateLimitResource {
+  if (!urlOrHeader) return "core";
+  const trimmed = urlOrHeader.trim().toLowerCase();
+  if (!trimmed) return "core";
+  if (trimmed === "graphql" || trimmed.startsWith("graphql ") || trimmed.includes("/graphql")) {
+    return "graphql";
+  }
+  if (trimmed === "search" || trimmed.startsWith("search ") || trimmed.includes("/search/")) {
+    return "search";
+  }
+  return "core";
+}
+
+function parseReset(reset: Date | number | undefined): Date | null {
+  if (reset instanceof Date) return reset;
+  if (typeof reset === "number" && Number.isFinite(reset) && reset > 0) {
     // Accept both unix seconds (GitHub's `x-ratelimit-reset`) and millis.
     const ms = reset < 1e12 ? reset * 1000 : reset;
-    parsed = new Date(ms);
+    return new Date(ms);
   }
+  return null;
+}
 
+export function markRateLimited(
+  reset: Date | number | undefined,
+  resource: RateLimitResource = "core",
+): Date {
+  const parsed = parseReset(reset);
   // Without a header we still want to gate further calls for a short window —
   // most rate-limit windows reset within an hour, so a 60s safety floor avoids
   // hammering immediately on the next tick.
   const fallback = new Date(Date.now() + 60_000);
   const next = parsed && parsed.getTime() > Date.now() ? parsed : fallback;
 
-  if (!resetAt || next.getTime() > resetAt.getTime()) {
-    resetAt = next;
+  const entry = state[resource];
+  if (!entry.resetAt || next.getTime() > entry.resetAt.getTime()) {
+    entry.resetAt = next;
     log.warn(
-      { resetAt: resetAt.toISOString(), secondsUntilReset: Math.ceil((resetAt.getTime() - Date.now()) / 1000) },
+      {
+        resource,
+        resetAt: entry.resetAt.toISOString(),
+        secondsUntilReset: Math.ceil((entry.resetAt.getTime() - Date.now()) / 1000),
+      },
       "GitHub rate limit reached; gating further requests until reset",
     );
   }
-  lastLimitedAt = new Date();
+  entry.lastLimitedAt = new Date();
 
-  return resetAt;
+  return entry.resetAt;
 }
 
-export function getRateLimitState(): RateLimitSnapshot {
+function snapshotResource(resource: RateLimitResource, now: number): ResourceSnapshot {
+  const entry = state[resource];
+  const recentlyLimited = entry.lastLimitedAt !== null
+    && (now - entry.lastLimitedAt.getTime()) <= RECENT_RATE_LIMIT_WINDOW_MS;
+  if (entry.resetAt && entry.resetAt.getTime() <= now) {
+    entry.resetAt = null;
+  }
+  if (!entry.resetAt) {
+    return { limited: false, resetAt: null, recentlyLimited, lastLimitedAt: entry.lastLimitedAt };
+  }
+  return { limited: true, resetAt: entry.resetAt, recentlyLimited, lastLimitedAt: entry.lastLimitedAt };
+}
+
+export function getRateLimitState(resource?: RateLimitResource): RateLimitSnapshot {
   const now = Date.now();
-  const recentlyLimited = lastLimitedAt !== null && (now - lastLimitedAt.getTime()) <= RECENT_RATE_LIMIT_WINDOW_MS;
-  if (!resetAt) {
-    return { limited: false, resetAt: null, recentlyLimited, lastLimitedAt };
+  const resources: Record<RateLimitResource, ResourceSnapshot> = {
+    core: snapshotResource("core", now),
+    graphql: snapshotResource("graphql", now),
+    search: snapshotResource("search", now),
+  };
+
+  if (resource) {
+    return { ...resources[resource], resources };
   }
-  if (resetAt.getTime() <= now) {
-    resetAt = null;
-    return { limited: false, resetAt: null, recentlyLimited, lastLimitedAt };
-  }
-  return { limited: true, resetAt, recentlyLimited, lastLimitedAt };
+
+  const limitedResources = RESOURCES.filter((r) => resources[r].limited);
+  const limited = limitedResources.length > 0;
+  const resetAt = limited
+    ? limitedResources
+        .map((r) => resources[r].resetAt!)
+        .reduce((a, b) => (a.getTime() >= b.getTime() ? a : b))
+    : null;
+  const recentlyLimited = RESOURCES.some((r) => resources[r].recentlyLimited);
+  const lastLimitedAt = RESOURCES
+    .map((r) => resources[r].lastLimitedAt)
+    .filter((d): d is Date => d !== null)
+    .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
+
+  return { limited, resetAt, recentlyLimited, lastLimitedAt, resources };
 }
 
-export function clearRateLimited(): void {
-  if (resetAt) {
-    log.info({}, "GitHub rate limit cleared by a successful request");
-    resetAt = null;
+export function clearRateLimited(resource: RateLimitResource = "core"): void {
+  const entry = state[resource];
+  if (entry.resetAt) {
+    log.info({ resource }, "GitHub rate limit cleared by a successful request");
+    entry.resetAt = null;
   }
 }
 
 export function clearRateLimitStateForTests(): void {
-  resetAt = null;
-  lastLimitedAt = null;
+  for (const resource of RESOURCES) {
+    state[resource].resetAt = null;
+    state[resource].lastLimitedAt = null;
+  }
 }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -229,16 +229,23 @@ test("GET /api/github-rate-limit reports the current reset time", async () => {
     const response = await fetch(`${harness.baseUrl}/api/github-rate-limit`);
     assert.equal(response.status, 200);
 
-    const body = await response.json() as {
+    type ResourceBody = {
       limited: boolean;
       resetAt: string | null;
       recentlyLimited: boolean;
       lastLimitedAt: string | null;
     };
+    const body = await response.json() as ResourceBody & {
+      resources: { core: ResourceBody; graphql: ResourceBody; search: ResourceBody };
+    };
     assert.equal(body.limited, true);
     assert.equal(body.resetAt, resetAt.toISOString());
     assert.equal(body.recentlyLimited, true);
     assert.ok(body.lastLimitedAt);
+    assert.equal(body.resources.core.limited, true);
+    assert.equal(body.resources.core.resetAt, resetAt.toISOString());
+    assert.equal(body.resources.graphql.limited, false);
+    assert.equal(body.resources.search.limited, false);
   } finally {
     clearRateLimited();
     await harness.close();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -268,11 +268,22 @@ export async function registerRoutes(
 
   app.get("/api/github-rate-limit", async (_req, res) => {
     const state = getRateLimitState();
+    const serializeResource = (snapshot: typeof state.resources[keyof typeof state.resources]) => ({
+      limited: snapshot.limited,
+      resetAt: snapshot.resetAt ? snapshot.resetAt.toISOString() : null,
+      recentlyLimited: snapshot.recentlyLimited,
+      lastLimitedAt: snapshot.lastLimitedAt ? snapshot.lastLimitedAt.toISOString() : null,
+    });
     res.json({
       limited: state.limited,
       resetAt: state.resetAt ? state.resetAt.toISOString() : null,
       recentlyLimited: state.recentlyLimited,
       lastLimitedAt: state.lastLimitedAt ? state.lastLimitedAt.toISOString() : null,
+      resources: {
+        core: serializeResource(state.resources.core),
+        graphql: serializeResource(state.resources.graphql),
+        search: serializeResource(state.resources.search),
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

Split `rateLimitState` into per-resource (core/graphql/search) gates so a limit hit on one resource no longer freezes every sync path. Today, a single 403 on `/graphql` or `/search` trips the global gate and stops the babysitter, REST sync, and on-demand routes alike — until reset.

This is **P2 of a sequence** addressing ongoing throttle/quota issues. P1 (ETag/304), P3 (protected babysitter budget), and P5 (GraphQL cost tracking) all build on this per-resource awareness.

## Changes

- `server/rateLimitState.ts`
  - New `RateLimitResource = "core" | "graphql" | "search"`.
  - `markRateLimited(reset, resource?)` and `clearRateLimited(resource?)` default to `"core"` for callers that don't care.
  - `getRateLimitState(resource?)` returns either a single resource's snapshot or an aggregate `{ limited, resetAt, recentlyLimited, lastLimitedAt, resources: { core, graphql, search } }`. Aggregate `resetAt` is the latest among limited resources.
  - New `deriveRateLimitResource(urlOrHeader)` helper — pure function, exported for testing.
- `server/github.ts`
  - `attachRateLimitHook` derives the resource pre-flight from `options.url`, gates only that resource, and after a response confirms the resource via `x-ratelimit-resource`. On 403/429, `markRateLimited` is called with the resource from the header (or URL fallback).
  - `RateLimitGateError` now carries a `resource` field and includes it in its response headers.
- `server/appRuntime.ts`
  - Watcher checks `getRateLimitState("core")` specifically, so a graphql trip no longer pauses REST sync.
- `server/routes.ts`
  - `GET /api/github-rate-limit` keeps top-level fields (existing UI consumers untouched) and adds a `resources` map.

## Tests

- `server/rateLimitState.test.ts` — per-resource isolation, aggregate `resetAt` math, `deriveRateLimitResource` routing.
- `server/rateLimitHook.test.ts` — hook-level regression: a graphql 403 gates only graphql; a subsequent REST call still reaches the fake fetch and succeeds.
- `server/routes.test.ts` — `/api/github-rate-limit` response includes the new `resources` map.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 633 pass, 1 skipped (pre-existing)

## Notes

- UI is intentionally untouched. The top-level `limited/resetAt/recentlyLimited/lastLimitedAt` fields are preserved so `AppHeader`, `OnboardingPanel`, and `settings` keep working unchanged. A follow-up can drill into the `resources` map if we want per-resource UI.
- This PR is small on purpose — it's the foundation for the next four (P1, P3, P5, etc.).