### PR TITLE
feat: conditional GET (ETag/304) for repo issue sync

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -563,3 +563,80 @@ test("planAutomaticIssueQueueActions counts active work jobs against the work ca
   });
   assert.equal(plan.work.length, 0, "work cap already saturated");
 });
+
+test("syncRepos skips the issue sweep for a repo whose issue list responds 304", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"stale"');
+
+  let listForRepoCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        listForRepoCalls += 1;
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  assert.equal(listForRepoCalls, 1, "only the conditional probe should reach GitHub");
+  const synced = await storage.listSyncedIssues({ repos: ["owner/repo"], limit: 50, offset: 0 });
+  assert.equal(synced.items.length, 0, "a 304 must not sync any issues");
+});
+
+test("syncRepos syncs issues and persists the new etag when the issue list changed", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+
+  const issuePayload = {
+    number: 7,
+    title: "Issue 7",
+    body: "needs attention",
+    html_url: "https://github.com/owner/repo/issues/7",
+    user: { login: "alice" },
+    labels: [],
+    assignees: [],
+    comments: 0,
+    created_at: "2026-05-03T17:00:00.000Z",
+    updated_at: "2026-05-03T18:00:00.000Z",
+  };
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => ({
+        data: [issuePayload],
+        headers: { etag: 'W/"issues-v1"' },
+      }),
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  const synced = await storage.listSyncedIssues({ repos: ["owner/repo"], limit: 50, offset: 0 });
+  assert.equal(synced.items.length, 1);
+  assert.equal(synced.items[0]?.number, 7);
+  assert.equal(
+    await storage.getGithubEtag("issues:open:owner/repo"),
+    'W/"issues-v1"',
+    "a successful sweep should persist the fresh etag for next tick",
+  );
+});

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -67,6 +67,7 @@ import {
   type MergedPRSummary,
   parsePRUrl,
   parseRepoSlug,
+  probeRepoIssuesChanged,
   addLabelsToIssue,
   removeLabelsFromIssue,
   resolveNextSemverTag,
@@ -90,6 +91,7 @@ export type AppRuntimeDependencies = {
   deploymentHealingManager?: DeploymentHealingManager;
   babysitter?: PRBabysitter;
   watcherScheduler?: WatcherScheduler;
+  buildOctokitFn?: typeof buildOctokit;
   startBackgroundServices?: boolean;
   startWatcher?: boolean;
 };
@@ -690,6 +692,7 @@ export function mapMergedPullsToReleaseSummaries(pulls: MergedPRSummary[]): Rele
 
 export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): AppRuntime {
   const storage = dependencies.storage ?? getDefaultStorage();
+  const buildOctokitImpl = dependencies.buildOctokitFn ?? buildOctokit;
   const events = new EventEmitter();
   const socialPostJobs = new Map<string, ReleaseSocialPost>();
   const backgroundJobQueue = dependencies.backgroundJobQueue ?? new BackgroundJobQueue(storage);
@@ -1202,7 +1205,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   async function syncStoredIssuesStep(options?: { fullSweep?: boolean }): Promise<void> {
     const config = await storage.getConfig();
     if (config.watchedRepos.length === 0) return;
-    const octokit = await buildOctokit(config);
+    const octokit = await buildOctokitImpl(config);
     const nowMs = Date.now();
     const repoCount = config.watchedRepos.length;
     const candidates = options?.fullSweep
@@ -1218,6 +1221,24 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         const limit = MAX_ISSUES_PAGE_SIZE;
         const loops = options?.fullSweep ? MAX_AUTO_ISSUE_SWEEP_PAGES : 1;
         let nextOffset = options?.fullSweep ? 0 : (issueRepoSyncOffsets.get(repoSlug) ?? 0);
+
+        // At the start of a repo's sweep, a conditional GET tells us whether
+        // anything changed. A 304 costs no primary rate-limit budget, so on an
+        // unchanged repo we skip the whole sweep instead of paginating it.
+        const etagKey = `issues:open:${repoSlug}`;
+        let pendingEtag: string | null = null;
+        if (nextOffset === 0) {
+          const cachedEtag = (await storage.getGithubEtag(etagKey)) ?? null;
+          const probe = await probeRepoIssuesChanged(octokit, parsed, cachedEtag);
+          if (probe.notModified) {
+            issueRepoBackoffUntilMs.delete(repoSlug);
+            const index = config.watchedRepos.indexOf(repoSlug);
+            issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
+            continue;
+          }
+          pendingEtag = probe.etag;
+        }
+
         let didWork = false;
         for (let i = 0; i < loops; i += 1) {
           const page = await listOpenIssuesForRepo(octokit, parsed, { limit, offset: nextOffset });
@@ -1233,6 +1254,11 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         }
         if (didWork) {
           issueRepoBackoffUntilMs.delete(repoSlug);
+          // Persist the etag only after a successful sync so a failure mid-sweep
+          // re-probes and re-syncs next tick instead of 304-skipping stale data.
+          if (pendingEtag) {
+            await storage.setGithubEtag(etagKey, pendingEtag);
+          }
           const index = config.watchedRepos.indexOf(repoSlug);
           issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
           if (!options?.fullSweep) return;

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -19,6 +19,7 @@ import {
   listOpenLinkedPullRequestsForIssue,
   listOpenIssuesForRepo,
   listOpenPullsForRepo,
+  probeRepoIssuesChanged,
   listMergedPullsSince,
   listReleasesForRepo,
   listTagsForRepo,
@@ -883,6 +884,63 @@ test("listOpenIssuesForRepo continues pagination when a page contains pull reque
   assert.equal(page.items.length, 51);
   assert.equal(page.items[0]?.number, 51);
   assert.equal(page.items[50]?.number, 101);
+});
+
+test("probeRepoIssuesChanged returns the response etag on a 200", async () => {
+  const octokit = {
+    issues: {
+      listForRepo: async () => ({
+        data: [],
+        headers: { etag: 'W/"fresh"' },
+      }),
+    },
+  };
+
+  const result = await probeRepoIssuesChanged(octokit as never, { owner: "owner", repo: "repo" }, null);
+
+  assert.equal(result.notModified, false);
+  if (!result.notModified) {
+    assert.equal(result.etag, 'W/"fresh"');
+  }
+});
+
+test("probeRepoIssuesChanged reports notModified on a 304 and forwards If-None-Match", async () => {
+  let sentIfNoneMatch: string | undefined;
+  const octokit = {
+    issues: {
+      listForRepo: async (params: { headers?: Record<string, string> }) => {
+        sentIfNoneMatch = params.headers?.["if-none-match"];
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const result = await probeRepoIssuesChanged(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    'W/"cached"',
+  );
+
+  assert.equal(result.notModified, true);
+  assert.equal(sentIfNoneMatch, 'W/"cached"');
+});
+
+test("probeRepoIssuesChanged rethrows non-304 errors instead of skipping the sweep", async () => {
+  const octokit = {
+    issues: {
+      listForRepo: async () => {
+        const error = new Error("not found") as Error & { status: number };
+        error.status = 404;
+        throw error;
+      },
+    },
+  };
+
+  await assert.rejects(() =>
+    probeRepoIssuesChanged(octokit as never, { owner: "owner", repo: "repo" }, null),
+  );
 });
 
 test("listOpenLinkedPullRequestsForIssue returns unique open cross-referenced PRs", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -2154,6 +2154,48 @@ export async function listOpenIssuesForRepo(
   return { items, hasMore };
 }
 
+export type RepoIssuesProbeResult =
+  | { notModified: true }
+  | { notModified: false; etag: string | null };
+
+/**
+ * Conditional GET of a repo's open-issue list (page 1, sorted by `updated`).
+ * A 304 means no issue has changed since `cachedEtag` was stored, so the
+ * caller can skip the whole sweep. 304 responses do not decrement the
+ * primary REST rate limit.
+ */
+export async function probeRepoIssuesChanged(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  cachedEtag: string | null,
+): Promise<RepoIssuesProbeResult> {
+  if (typeof octokit.issues?.listForRepo !== "function") {
+    // Mocked/partial Octokit (tests) — can't probe, treat as changed.
+    return { notModified: false, etag: null };
+  }
+  return withGitHubErrorHandling("open issues", repo, async () => {
+    try {
+      const response = await octokit.issues.listForRepo({
+        owner: repo.owner,
+        repo: repo.repo,
+        state: "open",
+        sort: "updated",
+        direction: "desc",
+        per_page: 100,
+        page: 1,
+        ...(cachedEtag ? { headers: { "if-none-match": cachedEtag } } : {}),
+      });
+      const etag = response.headers?.etag;
+      return { notModified: false, etag: typeof etag === "string" ? etag : null };
+    } catch (error) {
+      if ((error as { status?: number } | undefined)?.status === 304) {
+        return { notModified: true };
+      }
+      throw error;
+    }
+  });
+}
+
 export async function listOpenLinkedPullRequestsForIssue(
   octokit: Octokit,
   repo: ParsedRepoSlug,

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -80,6 +80,7 @@ export class MemStorage implements IStorage {
   private issueEvaluations: Map<string, IssueEvaluation> = new Map();
   private issueSubtaskSets: Map<string, IssueSubtaskSet> = new Map();
   private syncedIssues: Map<string, StoredIssueRecord> = new Map();
+  private githubEtags: Map<string, string> = new Map();
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -398,6 +399,18 @@ export class MemStorage implements IStorage {
     const existing = this.syncedIssues.get(key);
     if (!existing) return;
     this.syncedIssues.set(key, { ...existing, isWorked: true });
+  }
+
+  async getGithubEtag(url: string): Promise<string | undefined> {
+    return this.githubEtags.get(url);
+  }
+
+  async setGithubEtag(url: string, etag: string): Promise<void> {
+    this.githubEtags.set(url, etag);
+  }
+
+  async clearGithubEtag(url: string): Promise<void> {
+    this.githubEtags.delete(url);
   }
 
   private syncRepoSettings(): void {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -882,6 +882,12 @@ export class SqliteStorage implements IStorage {
         UNIQUE(repo, merge_sha)
       );
 
+      CREATE TABLE IF NOT EXISTS github_etags (
+        url TEXT PRIMARY KEY,
+        etag TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
       CREATE INDEX IF NOT EXISTS idx_logs_pr_id_timestamp ON logs(pr_id, timestamp);
       CREATE INDEX IF NOT EXISTS idx_agent_runs_status_updated_at ON agent_runs(status, updated_at);
@@ -2271,6 +2277,29 @@ export class SqliteStorage implements IStorage {
   async markSyncedIssueWorked(repo: string, number: number): Promise<void> {
     this.withWriteTransaction(() => {
       this.run("UPDATE synced_issues SET is_worked = 1 WHERE repo = ? AND issue_number = ?", repo, number);
+    });
+  }
+
+  async getGithubEtag(url: string): Promise<string | undefined> {
+    const row = this.get<{ etag: string }>("SELECT etag FROM github_etags WHERE url = ?", url);
+    return row?.etag;
+  }
+
+  async setGithubEtag(url: string, etag: string): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run(
+        `INSERT INTO github_etags (url, etag, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(url) DO UPDATE SET etag = excluded.etag, updated_at = excluded.updated_at`,
+        url,
+        etag,
+        new Date().toISOString(),
+      );
+    });
+  }
+
+  async clearGithubEtag(url: string): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run("DELETE FROM github_etags WHERE url = ?", url);
     });
   }
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -9,6 +9,7 @@ import { DatabaseSync } from "node:sqlite";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 import { getCodeFactoryPaths } from "./paths";
 import { SQLITE_LOCK_TIMEOUT_MS, SqliteStorage } from "./sqliteStorage";
+import { MemStorage } from "./memoryStorage";
 
 function createRawDatabase(root: string): DatabaseSync {
   const db = new DatabaseSync(getCodeFactoryPaths(root).stateDbPath, {
@@ -1162,4 +1163,41 @@ try {
   } finally {
     storage.close();
   }
+});
+
+test("SqliteStorage stores, overwrites, and clears GitHub etags across reopen", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const first = new SqliteStorage(root);
+  try {
+    assert.equal(await first.getGithubEtag("issues:open:owner/repo"), undefined);
+
+    await first.setGithubEtag("issues:open:owner/repo", 'W/"abc"');
+    assert.equal(await first.getGithubEtag("issues:open:owner/repo"), 'W/"abc"');
+
+    // Overwrite keeps a single row per url.
+    await first.setGithubEtag("issues:open:owner/repo", 'W/"def"');
+    assert.equal(await first.getGithubEtag("issues:open:owner/repo"), 'W/"def"');
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    assert.equal(await second.getGithubEtag("issues:open:owner/repo"), 'W/"def"');
+    await second.clearGithubEtag("issues:open:owner/repo");
+    assert.equal(await second.getGithubEtag("issues:open:owner/repo"), undefined);
+  } finally {
+    second.close();
+  }
+});
+
+test("MemStorage GitHub etag round-trip matches the SqliteStorage contract", async () => {
+  const storage = new MemStorage();
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), undefined);
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"abc"');
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), 'W/"abc"');
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"def"');
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), 'W/"def"');
+  await storage.clearGithubEtag("issues:open:owner/repo");
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), undefined);
 });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -112,6 +112,11 @@ export interface IStorage {
   getSyncedIssue(repo: string, number: number): Promise<StoredIssueRecord | undefined>;
   markSyncedIssueWorked(repo: string, number: number): Promise<void>;
 
+  // GitHub conditional-request etags (If-None-Match), keyed by a stable request URL.
+  getGithubEtag(url: string): Promise<string | undefined>;
+  setGithubEtag(url: string, etag: string): Promise<void>;
+  clearGithubEtag(url: string): Promise<void>;
+
   // CI healing
   getHealingSession(id: string): Promise<HealingSession | undefined>;
   getHealingSessionByPrAndHead(prId: string, initialHeadSha: string): Promise<HealingSession | undefined>;


### PR DESCRIPTION
## Summary

Adds ETag / `If-None-Match` conditional requests to the **issue sync** path. GitHub does not decrement the primary REST rate limit on a `304 Not Modified`, so an unchanged repo now costs effectively nothing per watcher tick instead of a full paginated sweep. The cold-start `fullSweep` benefits most — when nothing has changed, every watched repo `304`s.

This is **P1** of the throttle/quota sequence. **Stacked on #73 (P2)** — review/merge that first; the base branch is `fix/rate-limit-per-resource-gate`.

## Changes

- **Schema/storage:** new `github_etags(url, etag, updated_at)` table + `getGithubEtag` / `setGithubEtag` / `clearGithubEtag` on both `SqliteStorage` and `MemStorage`.
- **`github.ts`:** `probeRepoIssuesChanged(octokit, repo, cachedEtag)` — a conditional GET of a repo's open-issue list (page 1, sorted by `updated`). Returns `{ notModified: true }` on a 304, otherwise the fresh etag.
- **`appRuntime.ts`:** `syncStoredIssuesStep` probes at the start of a repo's sweep. On 304 it skips the repo entirely (no `markRepoIssuesStale`, no `upsertSyncedIssues`). The fresh etag is persisted **only after a successful sweep**, so a mid-sweep failure re-probes and re-syncs next tick rather than 304-skipping stale data.
- **`AppRuntimeDependencies.buildOctokitFn`:** small DI seam so the watcher can be exercised with a fake Octokit in tests.

## Scope note — why issues only

ETag-304 on a *list* endpoint means "no record's `updated_at` changed." That's a complete signal for issue sync, which is a pure mirror-into-DB operation. It is **not** complete for the babysitter: CI check-runs are a separate resource and do **not** bump a PR's `updated_at`, so a list-level etag can't gate the babysitter sweep without missing CI transitions. PR-side conditional reads need per-PR change detection and are tracked as a separate follow-up (depends on P6).

## Tests

- `storage.test.ts` — etag round-trip across reopen (Sqlite) + Mem parity.
- `github.test.ts` — `probeRepoIssuesChanged` for 200 (returns etag), 304 (returns `notModified`, forwards `If-None-Match`), and non-304 error (rethrows).
- `appRuntime.test.ts` — `syncRepos` skips the sweep on 304 (only the probe hits GitHub) and syncs + persists the fresh etag when changed.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 640 pass, 1 skipped (pre-existing)