### PR TITLE
feat: per-endpoint concurrency caps for the GitHub throttle

### DIFF
--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -5,6 +5,7 @@ import {
   addLabelsToIssue,
   buildGitHubCloneUrl,
   buildOctokit,
+  classifyGitHubConcurrency,
   GitHubIntegrationError,
   buildFeedbackAuditToken,
   checkOnboardingStatus,
@@ -884,6 +885,21 @@ test("listOpenIssuesForRepo continues pagination when a page contains pull reque
   assert.equal(page.items.length, 51);
   assert.equal(page.items[0]?.number, 51);
   assert.equal(page.items[50]?.number, 101);
+});
+
+test("classifyGitHubConcurrency buckets search, writes, and default reads", () => {
+  assert.equal(classifyGitHubConcurrency({ method: "GET", url: "/search/issues" }), "search");
+  // A search URL outranks the HTTP method.
+  assert.equal(classifyGitHubConcurrency({ method: "POST", url: "/search/code" }), "search");
+  assert.equal(
+    classifyGitHubConcurrency({ method: "POST", url: "/repos/o/r/issues/1/comments" }),
+    "write",
+  );
+  assert.equal(classifyGitHubConcurrency({ method: "PATCH", url: "/repos/o/r/pulls/1" }), "write");
+  assert.equal(classifyGitHubConcurrency({ method: "DELETE", url: "/repos/o/r/git/refs/heads/x" }), "write");
+  assert.equal(classifyGitHubConcurrency({ method: "PUT", url: "/repos/o/r/contents/file" }), "write");
+  assert.equal(classifyGitHubConcurrency({ method: "GET", url: "/repos/o/r/pulls" }), "default");
+  assert.equal(classifyGitHubConcurrency({}), "default");
 });
 
 test("probeRepoIssuesChanged returns the response etag on a 200", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -173,6 +173,12 @@ const GH_AUTH_CACHE_TTL_MS = 15000;
 const GITHUB_MAX_CONCURRENT_REQUESTS = 20;
 const GITHUB_REST_POINT_INTERVAL_MS = 67;
 const GITHUB_CONTENT_REQUEST_INTERVAL_MS = 750;
+
+// Per-endpoint-class concurrency caps. The global cap above protects against
+// connection-count secondary limits; these tighter caps keep the burst-prone
+// endpoints (search, content-creating writes) under their own abuse limits.
+const GITHUB_SEARCH_MAX_CONCURRENT = 2;
+const GITHUB_WRITE_MAX_CONCURRENT = 4;
 const REVIEW_THREADS_QUERY = `
   query CodeFactoryReviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -782,6 +788,32 @@ const RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS = 15_000;
 
 type GitHubRequestOptions = {
   method?: string;
+  url?: string;
+};
+
+export type GitHubConcurrencyClass = "search" | "write" | "default";
+
+/**
+ * Buckets a request for per-endpoint concurrency limiting. Search has a strict
+ * secondary limit; content-creating writes have their own abuse limit.
+ */
+export function classifyGitHubConcurrency(
+  options: { method?: string; url?: string },
+): GitHubConcurrencyClass {
+  if ((options.url ?? "").toLowerCase().includes("/search/")) {
+    return "search";
+  }
+  const method = options.method?.toUpperCase() ?? "GET";
+  if (method === "POST" || method === "PATCH" || method === "PUT" || method === "DELETE") {
+    return "write";
+  }
+  return "default";
+}
+
+const GITHUB_CONCURRENCY_CAPS: Record<GitHubConcurrencyClass, number> = {
+  search: GITHUB_SEARCH_MAX_CONCURRENT,
+  write: GITHUB_WRITE_MAX_CONCURRENT,
+  default: GITHUB_MAX_CONCURRENT_REQUESTS,
 };
 
 type GitHubRateLimitResourceSnapshot = {
@@ -807,6 +839,11 @@ class GitHubRequestThrottle {
   private active = 0;
   private pointReadyAt = 0;
   private contentReadyAt = 0;
+  private readonly activeByClass: Record<GitHubConcurrencyClass, number> = {
+    search: 0,
+    write: 0,
+    default: 0,
+  };
   private readonly queue: Array<QueuedGitHubRequest<unknown>> = [];
 
   schedule<T>(options: GitHubRequestOptions, run: () => Promise<T>): Promise<T> {
@@ -822,11 +859,20 @@ class GitHubRequestThrottle {
   }
 
   private drain(): void {
-    while (this.active < GITHUB_MAX_CONCURRENT_REQUESTS && this.queue.length > 0) {
-      const item = this.queue.shift();
-      if (!item) return;
+    while (this.active < GITHUB_MAX_CONCURRENT_REQUESTS) {
+      // Pick the first queued request whose endpoint class is below its cap.
+      // Skipping a capped class keeps a search burst from blocking the queue.
+      const index = this.queue.findIndex((item) => {
+        const cls = classifyGitHubConcurrency(item.options);
+        return this.activeByClass[cls] < GITHUB_CONCURRENCY_CAPS[cls];
+      });
+      if (index === -1) break;
+
+      const [item] = this.queue.splice(index, 1);
+      const cls = classifyGitHubConcurrency(item.options);
 
       this.active += 1;
+      this.activeByClass[cls] += 1;
       const delayMs = this.reserveDelay(item.options);
       setTimeout(() => {
         item.run()
@@ -834,6 +880,7 @@ class GitHubRequestThrottle {
           .catch(item.reject)
           .finally(() => {
             this.active -= 1;
+            this.activeByClass[cls] -= 1;
             this.drain();
           });
       }, delayMs);

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -64,6 +64,41 @@ test("octokit hook spaces concurrent REST requests under GitHub secondary limits
   );
 });
 
+test("octokit throttle caps concurrent search requests below the secondary limit", async () => {
+  let active = 0;
+  let peak = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async (input) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/search/")) {
+          active += 1;
+          peak = Math.max(peak, active);
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          active -= 1;
+        }
+        return new Response(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json", "x-ratelimit-remaining": "4999" },
+        });
+      },
+    },
+  );
+
+  await Promise.all(
+    Array.from({ length: 6 }, () => octokit.request("GET /search/issues", { q: "is:open is:pr" })),
+  );
+
+  // 200ms fetches with ~67ms point spacing would overlap 3-deep uncapped;
+  // the search cap of 2 must hold the peak at 2.
+  assert.ok(peak >= 2, `expected search requests to overlap, peak was ${peak}`);
+  assert.ok(peak <= 2, `expected search concurrency capped at 2, peak was ${peak}`);
+});
+
 test("octokit hook records rate-limit reset from 403 response headers", async () => {
   const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
   const octokit = await buildOctokit(


### PR DESCRIPTION
## Summary

The request throttle had one global concurrency cap (20). That guards against connection-count secondary limits but not GitHub's **per-endpoint** abuse limits — search especially has a strict secondary limit that a burst of parallel queries trips.

Adds per-class caps on top of the global cap:

| Class | Cap | Why |
|-------|-----|-----|
| `search` | 2 | Strict search secondary limit |
| `write` (POST/PATCH/PUT/DELETE) | 4 | Content-creation abuse limit |
| `default` | 20 (global, unchanged) | — |

This is **P9** of the throttle/quota sequence. **Stacked on #74 → #73** — base branch is `feat/github-etag-conditional-reads`.

## Changes

- `classifyGitHubConcurrency(options)` — buckets a request by URL (`/search/`) and method.
- `GitHubRequestThrottle` tracks active count per class. `drain()` now picks the first queued request whose class is below its cap, so a saturated search burst no longer head-of-line blocks unrelated reads.
- `GitHubRequestOptions` gains `url` (already populated by Octokit; P2 relies on it too).

## Tests

- `github.test.ts` — `classifyGitHubConcurrency` bucketing across search / write / default.
- `rateLimitHook.test.ts` — integration: 6 parallel `/search/issues` requests never exceed 2 in flight (uncapped they'd overlap 3-deep given the fetch duration vs. point spacing).

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 642 pass, 1 skipped (pre-existing)