### PR TITLE
feat: jitter the first watcher tick on boot

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -7,6 +7,7 @@ import {
   issueWorkAttemptCountFromJobs,
   issueWorkPrFromLogs,
   mapMergedPullsToReleaseSummaries,
+  pickWatcherColdStartDelayMs,
   planAutomaticIssueQueueActions,
   type PlanAutomaticIssueQueueInput,
 } from "./appRuntime";
@@ -639,4 +640,30 @@ test("syncRepos syncs issues and persists the new etag when the issue list chang
     'W/"issues-v1"',
     "a successful sweep should persist the fresh etag for next tick",
   );
+});
+
+test("pickWatcherColdStartDelayMs stays within the 15-45s cold-start window", () => {
+  assert.equal(pickWatcherColdStartDelayMs(() => 0), 15_000);
+  assert.equal(pickWatcherColdStartDelayMs(() => 0.5), 30_000);
+  assert.equal(pickWatcherColdStartDelayMs(() => 0.999999999), 45_000);
+  for (let i = 0; i < 200; i += 1) {
+    const delay = pickWatcherColdStartDelayMs();
+    assert.ok(delay >= 15_000 && delay <= 45_000, `delay ${delay} out of range`);
+  }
+});
+
+test("start() defers the first watcher tick instead of firing it during start", async () => {
+  let watcherRuns = 0;
+  const runtime = createAppRuntime({
+    storage: new MemStorage(),
+    startBackgroundServices: false,
+    startWatcher: true,
+    babysitter: { resumeInterruptedRuns: async () => {} } as never,
+    watcherScheduler: { run: async () => { watcherRuns += 1; } } as never,
+  });
+
+  await runtime.start();
+
+  assert.equal(watcherRuns, 0, "the first watcher tick must be deferred, not run during start()");
+  runtime.stop();
 });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -83,6 +83,19 @@ export class AppRuntimeError extends Error {
   }
 }
 
+const WATCHER_COLD_START_MIN_DELAY_MS = 15_000;
+const WATCHER_COLD_START_MAX_DELAY_MS = 45_000;
+
+/**
+ * The first watcher tick after boot runs at a random offset so several
+ * instances restarting together (a deploy) don't sync GitHub in lockstep,
+ * and so boot isn't competing with the dashboard's initial data load.
+ */
+export function pickWatcherColdStartDelayMs(random: () => number = Math.random): number {
+  const span = WATCHER_COLD_START_MAX_DELAY_MS - WATCHER_COLD_START_MIN_DELAY_MS;
+  return WATCHER_COLD_START_MIN_DELAY_MS + Math.floor(random() * (span + 1));
+}
+
 export type AppRuntimeDependencies = {
   storage?: IStorage;
   backgroundJobQueue?: BackgroundJobQueue;
@@ -806,6 +819,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   });
 
   let watcherTimer: NodeJS.Timeout | null = null;
+  let watcherColdStartTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
   let logsRetentionJob: RetentionJobHandle | null = null;
   const watcherScheduler = dependencies.watcherScheduler ?? createWatcherScheduler(
@@ -1838,7 +1852,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (startWatcher) {
         await refreshWatcherSchedule();
         void babysitter.resumeInterruptedRuns();
-        void runWatcher();
+        watcherColdStartTimer = setTimeout(() => {
+          watcherColdStartTimer = null;
+          void runWatcher();
+        }, pickWatcherColdStartDelayMs());
       }
     },
 
@@ -1848,6 +1865,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (logsRetentionJob) {
         logsRetentionJob.stop();
         logsRetentionJob = null;
+      }
+      if (watcherColdStartTimer) {
+        clearTimeout(watcherColdStartTimer);
+        watcherColdStartTimer = null;
       }
       if (watcherTimer) {
         clearInterval(watcherTimer);


### PR DESCRIPTION
## Summary

`start()` fired the watcher immediately. A deploy that restarts several instances had them all sync GitHub in lockstep, and the first sync competed with the dashboard's initial data load — part of the "first-load storm" symptom.

The first watcher tick now runs after a random **15-45s** delay. Subsequent ticks keep the configured interval unchanged.

This is **P7** of the throttle/quota sequence. **Stacked on #75 → #74 → #73** — base branch is `feat/per-endpoint-concurrency-caps`.

## Changes

- `pickWatcherColdStartDelayMs(random?)` — exported, injectable random source for deterministic tests; returns a value in [15s, 45s].
- `start()` schedules the first tick via `setTimeout` instead of calling `runWatcher()` synchronously.
- `stop()` clears the new cold-start timer alongside the interval timer.

## Scope note

The original P7 plan also mentioned a "ramp" (1→N repos over a few minutes). Dropped as unnecessary — the babysitter and issue sync already process **one repo per tick** (round-robin), so the sweep is inherently ramped. Adding a second ramp would be speculative complexity.

## Tests

- `pickWatcherColdStartDelayMs` — bounds at random 0 / 0.5 / ~1, plus a 200-sample range check.
- `start()` does not run the watcher synchronously (injected scheduler spy stays at 0 calls).

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 644 pass, 1 skipped (pre-existing)