### PR TITLE
feat: reserve core REST budget for high-priority work

### DIFF
--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -46,6 +46,7 @@ import { buildActivityPayload, readActivityPayload } from "./activityPayload";
 import { createWatcherScheduler, type WatcherScheduler } from "./watcherScheduler";
 import { startLogsRetentionJob, type RetentionJobHandle } from "./logsRetention";
 import { getRateLimitState } from "./rateLimitState";
+import { runWithRequestPriority } from "./requestPriority";
 import { ReleaseManager } from "./releaseManager";
 import type { ReleaseAgentPullSummary } from "./releaseAgent";
 import { DeploymentHealingManager } from "./deploymentHealingManager";
@@ -851,7 +852,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         "runtime:1",
         buildBackgroundJobDedupeKey("sync_watched_repos", "runtime:1"),
       );
-      await syncStoredIssuesStep();
+      // The routine issue sweep is low priority — it yields core REST budget
+      // to interactive routes and active babysitter sessions. A manual
+      // syncRepos() stays high priority.
+      await runWithRequestPriority("low", () => syncStoredIssuesStep());
       await queueAutomaticIssueWorkInternal();
     },
     (error) => {

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -24,6 +24,7 @@ import { verifySubtasksAgainstPr } from "./issueVerify";
 import { runIssueWorkRepair } from "./issueWorkAgent";
 import { answerPRQuestion } from "./prQuestionAgent";
 import type { ReleaseManager } from "./releaseManager";
+import { runWithRequestPriority } from "./requestPriority";
 import type { IStorage } from "./storage";
 
 type BackgroundJobHandlerDeps = {
@@ -124,7 +125,9 @@ export function createBackgroundJobHandlers(params: {
   return {
     sync_watched_repos: babysitter
       ? async () => {
-        await babysitter.syncAndBabysitTrackedRepos();
+        // The routine sweep runs at low priority so it yields core REST
+        // budget to interactive routes and active babysitter sessions.
+        await runWithRequestPriority("low", () => babysitter.syncAndBabysitTrackedRepos());
       }
       : undefined,
 

--- a/server/github.ts
+++ b/server/github.ts
@@ -9,9 +9,12 @@ import {
   clearRateLimited,
   deriveRateLimitResource,
   getRateLimitState,
+  isCoreBudgetBelowReserve,
   markRateLimited,
+  recordCoreBudget,
   type RateLimitResource,
 } from "./rateLimitState";
+import { getRequestPriority } from "./requestPriority";
 
 const octokitLog = childLogger("octokit");
 
@@ -766,6 +769,25 @@ async function withGitHubErrorHandling<T>(
   throw toGitHubIntegrationError(lastError, context, resource);
 }
 
+/**
+ * Thrown before dispatch when a low-priority (background sweep) request would
+ * eat into the core REST budget reserved for high-priority work. Callers in the
+ * sweep paths already treat thrown errors as a transient failure and back off,
+ * so the sweep simply retries on a later tick once the budget recovers.
+ */
+class BudgetReserveError extends Error {
+  readonly status = 403;
+  // `x-ratelimit-remaining: "0"` keeps shouldFallbackToGhAuth from retrying
+  // this deliberate gate via the gh-auth fallback token (same marker the
+  // RateLimitGateError uses).
+  readonly response: { headers: Record<string, string> };
+  constructor() {
+    super("GitHub core REST budget is in the reserve band; deferring low-priority request");
+    this.name = "BudgetReserveError";
+    this.response = { headers: { "x-ratelimit-remaining": "0" } };
+  }
+}
+
 class RateLimitGateError extends Error {
   readonly status = 403;
   readonly response: { headers: Record<string, string> };
@@ -989,6 +1011,15 @@ function attachRateLimitHook(
       throw new RateLimitGateError(resourceState.resetAt, requestResource);
     }
 
+    // Hold a reserve of the core budget for high-priority work.
+    if (
+      requestResource === "core"
+      && getRequestPriority() === "low"
+      && isCoreBudgetBelowReserve()
+    ) {
+      throw new BudgetReserveError();
+    }
+
     const dispatch = async (): Promise<ReturnType<typeof request>> => {
       const response = await request(options);
       const headerResourceRaw = typeof response.headers?.["x-ratelimit-resource"] === "string"
@@ -999,6 +1030,13 @@ function attachRateLimitHook(
         : requestResource;
       const remainingRaw = response.headers?.["x-ratelimit-remaining"];
       const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
+      if (responseResource === "core") {
+        const limitRaw = response.headers?.["x-ratelimit-limit"];
+        const limit = typeof limitRaw === "string" ? Number.parseInt(limitRaw, 10) : Number.NaN;
+        if (Number.isFinite(remaining) && Number.isFinite(limit)) {
+          recordCoreBudget(remaining, limit);
+        }
+      }
       if (Number.isFinite(remaining) && remaining > 0) {
         clearRateLimited(responseResource);
       }

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -2,7 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { Config } from "@shared/schema";
 import { buildOctokit } from "./github";
-import { clearRateLimitStateForTests, clearRateLimited, getRateLimitState } from "./rateLimitState";
+import {
+  clearRateLimitStateForTests,
+  clearRateLimited,
+  getCoreBudget,
+  getRateLimitState,
+  recordCoreBudget,
+} from "./rateLimitState";
+import { runWithRequestPriority } from "./requestPriority";
 
 const config: Config = {
   githubTokens: [],
@@ -97,6 +104,63 @@ test("octokit throttle caps concurrent search requests below the secondary limit
   // the search cap of 2 must hold the peak at 2.
   assert.ok(peak >= 2, `expected search requests to overlap, peak was ${peak}`);
   assert.ok(peak <= 2, `expected search concurrency capped at 2, peak was ${peak}`);
+});
+
+test("low-priority requests are gated while the core budget sits in the reserve band", async () => {
+  let fetchCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+            "x-ratelimit-limit": "5000",
+          },
+        });
+      },
+    },
+  );
+
+  recordCoreBudget(100, 5000); // 2% remaining — well inside the reserve
+
+  await assert.rejects(
+    () => runWithRequestPriority("low", () => octokit.request("GET /user")),
+    /budget/i,
+  );
+  assert.equal(fetchCalls, 0, "a gated low-priority request must not reach GitHub");
+
+  // High-priority work still goes through with the budget in the reserve band.
+  const ok = await runWithRequestPriority("high", () => octokit.request("GET /user"));
+  assert.equal(ok.data.login, "octo");
+  assert.equal(fetchCalls, 1);
+});
+
+test("the hook records the core budget from response headers", async () => {
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () =>
+        new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "1234",
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-resource": "core",
+          },
+        }),
+    },
+  );
+
+  assert.equal(getCoreBudget(), null);
+  await octokit.request("GET /user");
+  assert.deepEqual(getCoreBudget(), { remaining: 1234, limit: 5000 });
 });
 
 test("octokit hook records rate-limit reset from 403 response headers", async () => {

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -4,8 +4,11 @@ import {
   clearRateLimitStateForTests,
   clearRateLimited,
   deriveRateLimitResource,
+  getCoreBudget,
   getRateLimitState,
+  isCoreBudgetBelowReserve,
   markRateLimited,
+  recordCoreBudget,
 } from "./rateLimitState";
 
 test.beforeEach(() => clearRateLimitStateForTests());
@@ -110,4 +113,29 @@ test("aggregate resetAt is the latest among limited resources", () => {
 
   const aggregate = getRateLimitState();
   assert.equal(aggregate.resetAt!.getTime(), later * 1000);
+});
+
+test("recordCoreBudget keeps the latest observation", () => {
+  assert.equal(getCoreBudget(), null);
+  recordCoreBudget(4200, 5000);
+  assert.deepEqual(getCoreBudget(), { remaining: 4200, limit: 5000 });
+  recordCoreBudget(900, 5000);
+  assert.deepEqual(getCoreBudget(), { remaining: 900, limit: 5000 });
+});
+
+test("recordCoreBudget ignores non-finite or non-positive values", () => {
+  recordCoreBudget(Number.NaN, 5000);
+  assert.equal(getCoreBudget(), null);
+  recordCoreBudget(100, 0);
+  assert.equal(getCoreBudget(), null);
+});
+
+test("isCoreBudgetBelowReserve gates only inside the 30% reserve band", () => {
+  assert.equal(isCoreBudgetBelowReserve(), false, "an unknown budget never gates");
+  recordCoreBudget(2000, 5000); // 40% remaining
+  assert.equal(isCoreBudgetBelowReserve(), false);
+  recordCoreBudget(1500, 5000); // exactly 30% — at the reserve edge
+  assert.equal(isCoreBudgetBelowReserve(), true);
+  recordCoreBudget(200, 5000); // 4%
+  assert.equal(isCoreBudgetBelowReserve(), true);
 });

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -21,11 +21,19 @@ type ResourceState = { resetAt: Date | null; lastLimitedAt: Date | null };
 
 const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
+// Fraction of the core REST budget held in reserve for high-priority work
+// (interactive routes, active babysitter sessions). Low-priority requests are
+// gated once core `remaining` falls to or below this fraction of the limit.
+const CORE_BUDGET_RESERVE_FRACTION = 0.3;
+
 const state: Record<RateLimitResource, ResourceState> = {
   core: { resetAt: null, lastLimitedAt: null },
   graphql: { resetAt: null, lastLimitedAt: null },
   search: { resetAt: null, lastLimitedAt: null },
 };
+
+type CoreBudget = { remaining: number; limit: number };
+let coreBudget: CoreBudget | null = null;
 
 export function deriveRateLimitResource(
   urlOrHeader: string | null | undefined,
@@ -129,9 +137,36 @@ export function clearRateLimited(resource: RateLimitResource = "core"): void {
   }
 }
 
+/**
+ * Records the latest observed core REST budget from `x-ratelimit-*` response
+ * headers. Used to decide whether low-priority requests should be gated.
+ */
+export function recordCoreBudget(remaining: number, limit: number): void {
+  if (!Number.isFinite(remaining) || !Number.isFinite(limit) || limit <= 0) {
+    return;
+  }
+  coreBudget = { remaining: Math.max(0, remaining), limit };
+}
+
+export function getCoreBudget(): CoreBudget | null {
+  return coreBudget ? { ...coreBudget } : null;
+}
+
+/**
+ * True when the core REST budget has fallen into the reserve band. While true,
+ * low-priority (background sweep) requests are gated so the remaining budget is
+ * kept for high-priority work. Returns false when the budget is unknown — an
+ * unobserved budget must not block work.
+ */
+export function isCoreBudgetBelowReserve(): boolean {
+  if (!coreBudget) return false;
+  return coreBudget.remaining <= coreBudget.limit * CORE_BUDGET_RESERVE_FRACTION;
+}
+
 export function clearRateLimitStateForTests(): void {
   for (const resource of RESOURCES) {
     state[resource].resetAt = null;
     state[resource].lastLimitedAt = null;
   }
+  coreBudget = null;
 }

--- a/server/requestPriority.test.ts
+++ b/server/requestPriority.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getRequestPriority, runWithRequestPriority } from "./requestPriority";
+
+test("getRequestPriority defaults to high outside any scope", () => {
+  assert.equal(getRequestPriority(), "high");
+});
+
+test("runWithRequestPriority sets the priority for its callback and does not leak", () => {
+  const inside = runWithRequestPriority("low", () => getRequestPriority());
+  assert.equal(inside, "low");
+  assert.equal(getRequestPriority(), "high", "priority must not leak past the scope");
+});
+
+test("request priority propagates across awaits", async () => {
+  const observed = await runWithRequestPriority("low", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    return getRequestPriority();
+  });
+  assert.equal(observed, "low");
+});
+
+test("nested scopes restore the outer priority on exit", () => {
+  runWithRequestPriority("low", () => {
+    assert.equal(getRequestPriority(), "low");
+    runWithRequestPriority("high", () => {
+      assert.equal(getRequestPriority(), "high");
+    });
+    assert.equal(getRequestPriority(), "low", "inner scope must not clobber the outer one");
+  });
+});

--- a/server/requestPriority.ts
+++ b/server/requestPriority.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RequestPriority = "high" | "low";
+
+type RequestPriorityContext = { priority: RequestPriority };
+
+const requestPriorityStore = new AsyncLocalStorage<RequestPriorityContext>();
+
+/**
+ * Runs `fn` with an explicit request priority. GitHub requests made anywhere
+ * inside the callback — including transitively, across awaits — are tagged for
+ * budget-reserve gating. The default outside any scope is "high", so only the
+ * routine background sweep needs to opt into "low".
+ */
+export function runWithRequestPriority<T>(priority: RequestPriority, fn: () => T): T {
+  return requestPriorityStore.run({ priority }, fn);
+}
+
+export function getRequestPriority(): RequestPriority {
+  return requestPriorityStore.getStore()?.priority ?? "high";
+}


### PR DESCRIPTION
## Summary

The routine background sweep and interactive / active-session work shared the core REST budget with no separation. A heavy sweep could drain the hourly limit and starve the babysitter and dashboard — the "long gates" and "babysitter failing" symptoms.

This holds **30% of the core budget in reserve** for high-priority requests.

This is **P3** of the throttle/quota sequence. **Stacked on #77 → #75 → #74 → #73** — base branch is `feat/watcher-cold-start-jitter`.

## Approach (AsyncLocalStorage, as agreed)

- **`requestPriority.ts`** — an `AsyncLocalStorage` context tags work `high` or `low`. Default outside any scope is `high`, so only the routine sweep opts into `low`. Tagging propagates transitively across awaits, so every GitHub request made inside a low-priority scope is gated without touching call sites.
- **`rateLimitState`** — records the last observed core budget from `x-ratelimit-*` headers (`recordCoreBudget`) and exposes `isCoreBudgetBelowReserve()` (true once `remaining <= 30% of limit`).
- **Rate-limit hook** — records the core budget on every response; before dispatch, rejects low-priority core requests with `BudgetReserveError` once the budget is in the reserve band. The error carries `x-ratelimit-remaining: 0` so the gh-auth fallback hook doesn't retry around the gate (same marker `RateLimitGateError` uses).
- **Wrap sites** — the `sync_watched_repos` job handler and the watcher's issue sweep run inside `runWithRequestPriority("low")`. A manual `syncRepos()` stays high priority.

## Behavior when the budget is low

The sweep's first request fails fast (rejected before dispatch — no GitHub call). The existing per-repo backoff catches it and retries on a later tick once interactive load subsides and the budget recovers. No partial-sweep mess in the common case.

## Tests

- `requestPriority.test.ts` — default priority, scope isolation, await propagation, nesting.
- `rateLimitState.test.ts` — `recordCoreBudget` latest-wins + input validation, `isCoreBudgetBelowReserve` threshold.
- `rateLimitHook.test.ts` — low-priority request gated (never reaches GitHub), high-priority allowed, core budget recorded from headers.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 653 pass, 1 skipped (pre-existing)