### PR TITLE
feat: extend the budget reserve to the GraphQL API

### DIFF
--- a/server/github.ts
+++ b/server/github.ts
@@ -9,9 +9,9 @@ import {
   clearRateLimited,
   deriveRateLimitResource,
   getRateLimitState,
-  isCoreBudgetBelowReserve,
+  isResourceBudgetBelowReserve,
   markRateLimited,
-  recordCoreBudget,
+  recordResourceBudget,
   type RateLimitResource,
 } from "./rateLimitState";
 import { getRequestPriority } from "./requestPriority";
@@ -777,13 +777,15 @@ async function withGitHubErrorHandling<T>(
  */
 class BudgetReserveError extends Error {
   readonly status = 403;
+  readonly resource: RateLimitResource;
   // `x-ratelimit-remaining: "0"` keeps shouldFallbackToGhAuth from retrying
   // this deliberate gate via the gh-auth fallback token (same marker the
   // RateLimitGateError uses).
   readonly response: { headers: Record<string, string> };
-  constructor() {
-    super("GitHub core REST budget is in the reserve band; deferring low-priority request");
+  constructor(resource: RateLimitResource) {
+    super(`GitHub ${resource} budget is in the reserve band; deferring low-priority request`);
     this.name = "BudgetReserveError";
+    this.resource = resource;
     this.response = { headers: { "x-ratelimit-remaining": "0" } };
   }
 }
@@ -1011,13 +1013,14 @@ function attachRateLimitHook(
       throw new RateLimitGateError(resourceState.resetAt, requestResource);
     }
 
-    // Hold a reserve of the core budget for high-priority work.
+    // Hold a reserve of the core REST and GraphQL budgets for high-priority
+    // work. Search has its own concurrency cap and is not budget-reserved.
     if (
-      requestResource === "core"
+      (requestResource === "core" || requestResource === "graphql")
       && getRequestPriority() === "low"
-      && isCoreBudgetBelowReserve()
+      && isResourceBudgetBelowReserve(requestResource)
     ) {
-      throw new BudgetReserveError();
+      throw new BudgetReserveError(requestResource);
     }
 
     const dispatch = async (): Promise<ReturnType<typeof request>> => {
@@ -1030,11 +1033,11 @@ function attachRateLimitHook(
         : requestResource;
       const remainingRaw = response.headers?.["x-ratelimit-remaining"];
       const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
-      if (responseResource === "core") {
+      if (responseResource === "core" || responseResource === "graphql") {
         const limitRaw = response.headers?.["x-ratelimit-limit"];
         const limit = typeof limitRaw === "string" ? Number.parseInt(limitRaw, 10) : Number.NaN;
         if (Number.isFinite(remaining) && Number.isFinite(limit)) {
-          recordCoreBudget(remaining, limit);
+          recordResourceBudget(responseResource, remaining, limit);
         }
       }
       if (Number.isFinite(remaining) && remaining > 0) {

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -5,9 +5,9 @@ import { buildOctokit } from "./github";
 import {
   clearRateLimitStateForTests,
   clearRateLimited,
-  getCoreBudget,
   getRateLimitState,
-  recordCoreBudget,
+  getResourceBudget,
+  recordResourceBudget,
 } from "./rateLimitState";
 import { runWithRequestPriority } from "./requestPriority";
 
@@ -126,7 +126,7 @@ test("low-priority requests are gated while the core budget sits in the reserve 
     },
   );
 
-  recordCoreBudget(100, 5000); // 2% remaining — well inside the reserve
+  recordResourceBudget("core", 100, 5000); // 2% remaining — well inside the reserve
 
   await assert.rejects(
     () => runWithRequestPriority("low", () => octokit.request("GET /user")),
@@ -140,27 +140,94 @@ test("low-priority requests are gated while the core budget sits in the reserve 
   assert.equal(fetchCalls, 1);
 });
 
-test("the hook records the core budget from response headers", async () => {
+test("a low core budget does not gate low-priority GraphQL requests", async () => {
+  let graphqlCalls = 0;
   const octokit = await buildOctokit(
     { ...config, githubToken: "ghp_fake" },
     {
       ignoreCache: true,
-      requestFetch: async () =>
-        new Response(JSON.stringify({ login: "octo" }), {
+      requestFetch: async (input) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/graphql")) {
+          graphqlCalls += 1;
+        }
+        return new Response(JSON.stringify({ data: { viewer: { login: "octo" } } }), {
           status: 200,
           headers: {
             "content-type": "application/json",
-            "x-ratelimit-remaining": "1234",
+            "x-ratelimit-remaining": "4999",
             "x-ratelimit-limit": "5000",
-            "x-ratelimit-resource": "core",
+            "x-ratelimit-resource": "graphql",
           },
-        }),
+        });
+      },
     },
   );
 
-  assert.equal(getCoreBudget(), null);
+  // Core budget is exhausted, but the GraphQL budget is healthy.
+  recordResourceBudget("core", 100, 5000);
+
+  await runWithRequestPriority("low", () => octokit.graphql("query { viewer { login } }"));
+  assert.equal(graphqlCalls, 1, "GraphQL has its own budget — a low core budget must not gate it");
+});
+
+test("low-priority GraphQL requests are gated while the GraphQL budget is in the reserve", async () => {
+  let graphqlCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        graphqlCalls += 1;
+        return new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json", "x-ratelimit-resource": "graphql" },
+        });
+      },
+    },
+  );
+
+  recordResourceBudget("graphql", 100, 5000); // GraphQL budget in the reserve
+
+  await assert.rejects(
+    () => runWithRequestPriority("low", () => octokit.graphql("query { viewer { login } }")),
+    /graphql budget/i,
+  );
+  assert.equal(graphqlCalls, 0, "a gated low-priority GraphQL request must not reach GitHub");
+});
+
+test("the hook records core and GraphQL budgets from response headers", async () => {
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async (input) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL ? input.toString() : input.url;
+        const resource = url.includes("/graphql") ? "graphql" : "core";
+        const remaining = resource === "graphql" ? "4321" : "1234";
+        return new Response(JSON.stringify({ data: {}, login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": remaining,
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-resource": resource,
+          },
+        });
+      },
+    },
+  );
+
+  assert.equal(getResourceBudget("core"), null);
+  assert.equal(getResourceBudget("graphql"), null);
   await octokit.request("GET /user");
-  assert.deepEqual(getCoreBudget(), { remaining: 1234, limit: 5000 });
+  await octokit.graphql("query { viewer { login } }");
+  assert.deepEqual(getResourceBudget("core"), { remaining: 1234, limit: 5000 });
+  assert.deepEqual(getResourceBudget("graphql"), { remaining: 4321, limit: 5000 });
 });
 
 test("octokit hook records rate-limit reset from 403 response headers", async () => {

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -4,11 +4,11 @@ import {
   clearRateLimitStateForTests,
   clearRateLimited,
   deriveRateLimitResource,
-  getCoreBudget,
   getRateLimitState,
-  isCoreBudgetBelowReserve,
+  getResourceBudget,
+  isResourceBudgetBelowReserve,
   markRateLimited,
-  recordCoreBudget,
+  recordResourceBudget,
 } from "./rateLimitState";
 
 test.beforeEach(() => clearRateLimitStateForTests());
@@ -115,27 +115,37 @@ test("aggregate resetAt is the latest among limited resources", () => {
   assert.equal(aggregate.resetAt!.getTime(), later * 1000);
 });
 
-test("recordCoreBudget keeps the latest observation", () => {
-  assert.equal(getCoreBudget(), null);
-  recordCoreBudget(4200, 5000);
-  assert.deepEqual(getCoreBudget(), { remaining: 4200, limit: 5000 });
-  recordCoreBudget(900, 5000);
-  assert.deepEqual(getCoreBudget(), { remaining: 900, limit: 5000 });
+test("recordResourceBudget keeps the latest observation per resource", () => {
+  assert.equal(getResourceBudget("core"), null);
+  recordResourceBudget("core", 4200, 5000);
+  assert.deepEqual(getResourceBudget("core"), { remaining: 4200, limit: 5000 });
+  recordResourceBudget("core", 900, 5000);
+  assert.deepEqual(getResourceBudget("core"), { remaining: 900, limit: 5000 });
 });
 
-test("recordCoreBudget ignores non-finite or non-positive values", () => {
-  recordCoreBudget(Number.NaN, 5000);
-  assert.equal(getCoreBudget(), null);
-  recordCoreBudget(100, 0);
-  assert.equal(getCoreBudget(), null);
+test("recordResourceBudget tracks core and graphql budgets independently", () => {
+  recordResourceBudget("core", 4000, 5000);
+  recordResourceBudget("graphql", 200, 5000);
+  assert.deepEqual(getResourceBudget("core"), { remaining: 4000, limit: 5000 });
+  assert.deepEqual(getResourceBudget("graphql"), { remaining: 200, limit: 5000 });
+  // graphql is in the reserve band; core is not.
+  assert.equal(isResourceBudgetBelowReserve("core"), false);
+  assert.equal(isResourceBudgetBelowReserve("graphql"), true);
 });
 
-test("isCoreBudgetBelowReserve gates only inside the 30% reserve band", () => {
-  assert.equal(isCoreBudgetBelowReserve(), false, "an unknown budget never gates");
-  recordCoreBudget(2000, 5000); // 40% remaining
-  assert.equal(isCoreBudgetBelowReserve(), false);
-  recordCoreBudget(1500, 5000); // exactly 30% — at the reserve edge
-  assert.equal(isCoreBudgetBelowReserve(), true);
-  recordCoreBudget(200, 5000); // 4%
-  assert.equal(isCoreBudgetBelowReserve(), true);
+test("recordResourceBudget ignores non-finite or non-positive values", () => {
+  recordResourceBudget("core", Number.NaN, 5000);
+  assert.equal(getResourceBudget("core"), null);
+  recordResourceBudget("core", 100, 0);
+  assert.equal(getResourceBudget("core"), null);
+});
+
+test("isResourceBudgetBelowReserve gates only inside the 30% reserve band", () => {
+  assert.equal(isResourceBudgetBelowReserve("core"), false, "an unknown budget never gates");
+  recordResourceBudget("core", 2000, 5000); // 40% remaining
+  assert.equal(isResourceBudgetBelowReserve("core"), false);
+  recordResourceBudget("core", 1500, 5000); // exactly 30% — at the reserve edge
+  assert.equal(isResourceBudgetBelowReserve("core"), true);
+  recordResourceBudget("core", 200, 5000); // 4%
+  assert.equal(isResourceBudgetBelowReserve("core"), true);
 });

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -21,10 +21,10 @@ type ResourceState = { resetAt: Date | null; lastLimitedAt: Date | null };
 
 const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
-// Fraction of the core REST budget held in reserve for high-priority work
+// Fraction of a resource's budget held in reserve for high-priority work
 // (interactive routes, active babysitter sessions). Low-priority requests are
-// gated once core `remaining` falls to or below this fraction of the limit.
-const CORE_BUDGET_RESERVE_FRACTION = 0.3;
+// gated once `remaining` falls to or below this fraction of the limit.
+const BUDGET_RESERVE_FRACTION = 0.3;
 
 const state: Record<RateLimitResource, ResourceState> = {
   core: { resetAt: null, lastLimitedAt: null },
@@ -32,8 +32,13 @@ const state: Record<RateLimitResource, ResourceState> = {
   search: { resetAt: null, lastLimitedAt: null },
 };
 
-type CoreBudget = { remaining: number; limit: number };
-let coreBudget: CoreBudget | null = null;
+export type ResourceBudget = { remaining: number; limit: number };
+
+const budgets: Record<RateLimitResource, ResourceBudget | null> = {
+  core: null,
+  graphql: null,
+  search: null,
+};
 
 export function deriveRateLimitResource(
   urlOrHeader: string | null | undefined,
@@ -138,35 +143,42 @@ export function clearRateLimited(resource: RateLimitResource = "core"): void {
 }
 
 /**
- * Records the latest observed core REST budget from `x-ratelimit-*` response
- * headers. Used to decide whether low-priority requests should be gated.
+ * Records the latest observed budget for a resource from `x-ratelimit-*`
+ * response headers. Used to decide whether low-priority requests should be
+ * gated. The core REST and GraphQL APIs have independent budgets.
  */
-export function recordCoreBudget(remaining: number, limit: number): void {
+export function recordResourceBudget(
+  resource: RateLimitResource,
+  remaining: number,
+  limit: number,
+): void {
   if (!Number.isFinite(remaining) || !Number.isFinite(limit) || limit <= 0) {
     return;
   }
-  coreBudget = { remaining: Math.max(0, remaining), limit };
+  budgets[resource] = { remaining: Math.max(0, remaining), limit };
 }
 
-export function getCoreBudget(): CoreBudget | null {
-  return coreBudget ? { ...coreBudget } : null;
+export function getResourceBudget(resource: RateLimitResource): ResourceBudget | null {
+  const budget = budgets[resource];
+  return budget ? { ...budget } : null;
 }
 
 /**
- * True when the core REST budget has fallen into the reserve band. While true,
- * low-priority (background sweep) requests are gated so the remaining budget is
- * kept for high-priority work. Returns false when the budget is unknown — an
- * unobserved budget must not block work.
+ * True when a resource's budget has fallen into the reserve band. While true,
+ * low-priority (background sweep) requests against that resource are gated so
+ * the remaining budget is kept for high-priority work. Returns false when the
+ * budget is unknown — an unobserved budget must not block work.
  */
-export function isCoreBudgetBelowReserve(): boolean {
-  if (!coreBudget) return false;
-  return coreBudget.remaining <= coreBudget.limit * CORE_BUDGET_RESERVE_FRACTION;
+export function isResourceBudgetBelowReserve(resource: RateLimitResource): boolean {
+  const budget = budgets[resource];
+  if (!budget) return false;
+  return budget.remaining <= budget.limit * BUDGET_RESERVE_FRACTION;
 }
 
 export function clearRateLimitStateForTests(): void {
   for (const resource of RESOURCES) {
     state[resource].resetAt = null;
     state[resource].lastLimitedAt = null;
+    budgets[resource] = null;
   }
-  coreBudget = null;
 }


### PR DESCRIPTION
## Summary

P3 (#78) reserved 30% of the **core REST** budget for high-priority work. GraphQL has an entirely separate point budget that was untracked — and the babysitter's review-thread reads/writes run on GraphQL, so during the low-priority sweep they could drain the GraphQL budget unchecked.

This extends the budget reserve to GraphQL.

This is **P5** of the throttle/quota sequence. **Stacked on #78 → #77 → #75 → #74 → #73** — base branch is `feat/babysitter-budget-reserve`.

## Changes

- **Generalized the budget API** — `recordCoreBudget` / `getCoreBudget` / `isCoreBudgetBelowReserve` become `recordResourceBudget` / `getResourceBudget` / `isResourceBudgetBelowReserve`, keyed by `RateLimitResource`. Core and GraphQL budgets are tracked independently. (P5 generalizes the API P3 introduced one PR earlier — same stack, coherent diff.)
- **Hook** records the budget for both `core` and `graphql` responses (keyed off `x-ratelimit-resource`); the pre-dispatch reserve gate now covers `graphql` as well as `core`. Search is left ungated — it has its own concurrency cap from #75.
- `BudgetReserveError` names the offending resource.

GraphQL budget comes straight from the `x-ratelimit-*` response headers GitHub sets on `/graphql` responses — no query changes needed.

## Scope note

The original P5 mentioned "feed the throttle with a graphql lane." The substantive protection is the per-resource **gate** (#73) plus the per-resource **budget reserve** here. GraphQL-specific request *spacing* (separate from the shared REST point spacing) wasn't added — GraphQL call volume is low (review-thread ops only) and the gate + reserve already protect its budget.

## Tests

- `rateLimitState.test.ts` — per-resource budget tracking, independent core/graphql reserve thresholds.
- `rateLimitHook.test.ts` — a low core budget does not gate GraphQL and vice versa; low-priority GraphQL gated when the GraphQL budget is in the reserve; both budgets recorded from headers.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 656 pass, 1 skipped (pre-existing)