### PR TITLE
feat: persist per-repo sync backoff across restarts

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -667,3 +667,65 @@ test("start() defers the first watcher tick instead of firing it during start", 
   assert.equal(watcherRuns, 0, "the first watcher tick must be deferred, not run during start()");
   runtime.stop();
 });
+
+test("syncRepos persists an issue-sweep backoff when the probe fails", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        const error = new Error("not found") as Error & { status: number };
+        error.status = 404;
+        throw error;
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  const state = (await storage.getRepoSyncStates("issues")).find((s) => s.repo === "owner/repo");
+  assert.ok(state?.nextEligibleAt, "a failed issue sweep must persist a backoff");
+  assert.ok(
+    new Date(state!.nextEligibleAt!).getTime() > Date.now(),
+    "the persisted backoff must be in the future",
+  );
+});
+
+test("syncRepos skips an issue sweep for a repo whose persisted backoff is active", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.upsertRepoSyncState("owner/repo", "issues", {
+    nextEligibleAt: new Date(Date.now() + 600_000).toISOString(),
+  });
+
+  let listForRepoCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        listForRepoCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  assert.equal(listForRepoCalls, 0, "a backed-off repo must not be probed or synced");
+});

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -880,7 +880,6 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     lastSyncError: string | null;
   }>();
   const issueRepoSyncOffsets = new Map<string, number>();
-  const issueRepoBackoffUntilMs = new Map<string, number>();
   let issueRepoCursor = 0;
 
   function markIssueSyncAttempt(targetId: string): string {
@@ -1230,9 +1229,18 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       ? config.watchedRepos
       : Array.from({ length: repoCount }).map((_, i) => config.watchedRepos[(issueRepoCursor + i) % repoCount]).filter(Boolean) as string[];
 
+    // Backoff state is persisted, so a restart does not re-hammer a repo whose
+    // issue sweep was failing before the process went down.
+    const issueBackoffUntilMs = new Map<string, number>();
+    for (const syncState of await storage.getRepoSyncStates("issues")) {
+      if (syncState.nextEligibleAt) {
+        issueBackoffUntilMs.set(syncState.repo, new Date(syncState.nextEligibleAt).getTime());
+      }
+    }
+
     for (const repoSlug of candidates) {
       try {
-        const backoffUntilMs = issueRepoBackoffUntilMs.get(repoSlug) ?? 0;
+        const backoffUntilMs = issueBackoffUntilMs.get(repoSlug) ?? 0;
         if (backoffUntilMs > nowMs) continue;
         const parsed = parseRepoSlug(repoSlug);
         if (!parsed) continue;
@@ -1249,7 +1257,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           const cachedEtag = (await storage.getGithubEtag(etagKey)) ?? null;
           const probe = await probeRepoIssuesChanged(octokit, parsed, cachedEtag);
           if (probe.notModified) {
-            issueRepoBackoffUntilMs.delete(repoSlug);
+            // A 304 confirms the repo's issue list is current — clear backoff
+            // and record the freshness check as a successful sync.
+            await storage.upsertRepoSyncState(repoSlug, "issues", {
+              lastSyncedAt: new Date().toISOString(),
+              nextEligibleAt: null,
+            });
             const index = config.watchedRepos.indexOf(repoSlug);
             issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
             continue;
@@ -1271,7 +1284,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           if (!page.hasMore || !options?.fullSweep) break;
         }
         if (didWork) {
-          issueRepoBackoffUntilMs.delete(repoSlug);
+          await storage.upsertRepoSyncState(repoSlug, "issues", {
+            lastSyncedAt: new Date().toISOString(),
+            nextEligibleAt: null,
+          });
           // Persist the etag only after a successful sync so a failure mid-sweep
           // re-probes and re-syncs next tick instead of 304-skipping stale data.
           if (pendingEtag) {
@@ -1282,7 +1298,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           if (!options?.fullSweep) return;
         }
       } catch (error) {
-        issueRepoBackoffUntilMs.set(repoSlug, Date.now() + 60_000);
+        await storage.upsertRepoSyncState(repoSlug, "issues", {
+          nextEligibleAt: new Date(Date.now() + 60_000).toISOString(),
+        });
         log.warn(
           { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
           "Issue sync step failed; backing off",

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -356,6 +356,52 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
 });
 
+test("syncAndBabysitTrackedRepos persists a backoff when listing open PRs fails", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 7,
+    title: "Tracked PR",
+    repo: "octo/example",
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/7",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        throw new Error("list open PRs failed");
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const state = (await storage.getRepoSyncStates("prs")).find((s) => s.repo === "octo/example");
+  assert.ok(state?.nextEligibleAt, "a failed PR sweep must persist a backoff");
+  assert.ok(
+    new Date(state!.nextEligibleAt!).getTime() > Date.now(),
+    "the persisted backoff must be in the future",
+  );
+});
+
 test("syncAndBabysitTrackedRepos queues release evaluation for merged archived PRs", async () => {
   const storage = new MemStorage();
   const queued: Array<Record<string, string | number>> = [];

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1329,7 +1329,6 @@ export class PRBabysitter {
   private readonly clock: () => Date;
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
-  private readonly repoSyncBackoffUntilMs = new Map<string, number>();
   private repoSyncCursor = 0;
 
   constructor(
@@ -1923,6 +1922,14 @@ export class PRBabysitter {
     }
 
     const nowMs = this.now().getTime();
+    // Backoff state is persisted, so a restart does not re-hammer a repo that
+    // was failing before the process went down.
+    const prSyncBackoffUntilMs = new Map<string, number>();
+    for (const syncState of await this.storage.getRepoSyncStates("prs")) {
+      if (syncState.nextEligibleAt) {
+        prSyncBackoffUntilMs.set(syncState.repo, new Date(syncState.nextEligibleAt).getTime());
+      }
+    }
     const selectedRepos = fullSweep
       ? repos
       : Array.from({ length: repos.length })
@@ -1930,7 +1937,7 @@ export class PRBabysitter {
           .filter((repo): repo is NonNullable<typeof repo> => Boolean(repo))
           .filter((repo) => {
             const repoSlug = formatRepoSlug(repo);
-            const backoffUntilMs = this.repoSyncBackoffUntilMs.get(repoSlug) ?? 0;
+            const backoffUntilMs = prSyncBackoffUntilMs.get(repoSlug) ?? 0;
             return backoffUntilMs <= nowMs;
           })
           .slice(0, 1);
@@ -1941,13 +1948,18 @@ export class PRBabysitter {
       let openPulls;
       try {
         openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
-        this.repoSyncBackoffUntilMs.delete(repoSlug);
+        await this.storage.upsertRepoSyncState(repoSlug, "prs", {
+          lastSyncedAt: this.now().toISOString(),
+          nextEligibleAt: null,
+        });
         const repoIndex = repos.findIndex((entry) => formatRepoSlug(entry) === repoSlug);
         if (repoIndex >= 0) {
           this.repoSyncCursor = (repoIndex + 1) % repos.length;
         }
       } catch (error) {
-        this.repoSyncBackoffUntilMs.set(repoSlug, this.now().getTime() + REPO_SYNC_FAILURE_BACKOFF_MS);
+        await this.storage.upsertRepoSyncState(repoSlug, "prs", {
+          nextEligibleAt: new Date(this.now().getTime() + REPO_SYNC_FAILURE_BACKOFF_MS).toISOString(),
+        });
         log.warn(
           { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
           "Failed to list open PRs",

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -54,7 +54,7 @@ import {
   createSocialChangelog,
   touchAgentRun,
 } from "@shared/models";
-import type { IStorage, StoredIssueRecord } from "./storage";
+import type { IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 
 export class MemStorage implements IStorage {
@@ -81,6 +81,7 @@ export class MemStorage implements IStorage {
   private issueSubtaskSets: Map<string, IssueSubtaskSet> = new Map();
   private syncedIssues: Map<string, StoredIssueRecord> = new Map();
   private githubEtags: Map<string, string> = new Map();
+  private repoSyncStates: Map<string, RepoSyncState> = new Map();
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -411,6 +412,31 @@ export class MemStorage implements IStorage {
 
   async clearGithubEtag(url: string): Promise<void> {
     this.githubEtags.delete(url);
+  }
+
+  async getRepoSyncStates(kind: RepoSyncKind): Promise<RepoSyncState[]> {
+    return Array.from(this.repoSyncStates.values())
+      .filter((state) => state.kind === kind)
+      .map((state) => ({ ...state }));
+  }
+
+  async upsertRepoSyncState(
+    repo: string,
+    kind: RepoSyncKind,
+    updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
+  ): Promise<void> {
+    const key = `${repo}#${kind}`;
+    const existing = this.repoSyncStates.get(key);
+    this.repoSyncStates.set(key, {
+      repo,
+      kind,
+      lastSyncedAt: "lastSyncedAt" in updates
+        ? updates.lastSyncedAt ?? null
+        : existing?.lastSyncedAt ?? null,
+      nextEligibleAt: "nextEligibleAt" in updates
+        ? updates.nextEligibleAt ?? null
+        : existing?.nextEligibleAt ?? null,
+    });
   }
 
   private syncRepoSettings(): void {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -60,7 +60,7 @@ import {
   createReleaseRun,
   createSocialChangelog,
 } from "@shared/models";
-import type { IStorage, StoredIssueRecord } from "./storage";
+import type { IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
 import { getCodeFactoryPaths } from "./paths";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 import { appendLogFile } from "./logFiles";
@@ -886,6 +886,14 @@ export class SqliteStorage implements IStorage {
         url TEXT PRIMARY KEY,
         etag TEXT NOT NULL,
         updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS repo_sync_state (
+        repo TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        last_synced_at TEXT,
+        next_eligible_at TEXT,
+        PRIMARY KEY(repo, kind)
       );
 
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
@@ -2300,6 +2308,51 @@ export class SqliteStorage implements IStorage {
   async clearGithubEtag(url: string): Promise<void> {
     this.withWriteTransaction(() => {
       this.run("DELETE FROM github_etags WHERE url = ?", url);
+    });
+  }
+
+  async getRepoSyncStates(kind: RepoSyncKind): Promise<RepoSyncState[]> {
+    const rows = this.all<{
+      repo: string;
+      kind: string;
+      last_synced_at: string | null;
+      next_eligible_at: string | null;
+    }>("SELECT repo, kind, last_synced_at, next_eligible_at FROM repo_sync_state WHERE kind = ?", kind);
+    return rows.map((row) => ({
+      repo: row.repo,
+      kind: row.kind as RepoSyncKind,
+      lastSyncedAt: row.last_synced_at,
+      nextEligibleAt: row.next_eligible_at,
+    }));
+  }
+
+  async upsertRepoSyncState(
+    repo: string,
+    kind: RepoSyncKind,
+    updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
+  ): Promise<void> {
+    this.withWriteTransaction(() => {
+      const existing = this.get<{ last_synced_at: string | null; next_eligible_at: string | null }>(
+        "SELECT last_synced_at, next_eligible_at FROM repo_sync_state WHERE repo = ? AND kind = ?",
+        repo,
+        kind,
+      );
+      const lastSyncedAt = "lastSyncedAt" in updates
+        ? updates.lastSyncedAt ?? null
+        : existing?.last_synced_at ?? null;
+      const nextEligibleAt = "nextEligibleAt" in updates
+        ? updates.nextEligibleAt ?? null
+        : existing?.next_eligible_at ?? null;
+      this.run(
+        `INSERT INTO repo_sync_state (repo, kind, last_synced_at, next_eligible_at) VALUES (?, ?, ?, ?)
+         ON CONFLICT(repo, kind) DO UPDATE SET
+           last_synced_at = excluded.last_synced_at,
+           next_eligible_at = excluded.next_eligible_at`,
+        repo,
+        kind,
+        lastSyncedAt,
+        nextEligibleAt,
+      );
     });
   }
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1201,3 +1201,52 @@ test("MemStorage GitHub etag round-trip matches the SqliteStorage contract", asy
   await storage.clearGithubEtag("issues:open:owner/repo");
   assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), undefined);
 });
+
+test("SqliteStorage persists repo sync state with partial updates across reopen", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const first = new SqliteStorage(root);
+  try {
+    assert.deepEqual(await first.getRepoSyncStates("prs"), []);
+
+    await first.upsertRepoSyncState("o/r", "prs", {
+      lastSyncedAt: "2026-05-15T10:00:00.000Z",
+      nextEligibleAt: null,
+    });
+    await first.upsertRepoSyncState("o/r", "issues", {
+      nextEligibleAt: "2026-05-15T11:00:00.000Z",
+    });
+
+    // A partial update touches only nextEligibleAt; lastSyncedAt is preserved.
+    await first.upsertRepoSyncState("o/r", "prs", { nextEligibleAt: "2026-05-15T12:00:00.000Z" });
+
+    assert.deepEqual(await first.getRepoSyncStates("prs"), [{
+      repo: "o/r",
+      kind: "prs",
+      lastSyncedAt: "2026-05-15T10:00:00.000Z",
+      nextEligibleAt: "2026-05-15T12:00:00.000Z",
+    }]);
+    // `kind` partitions the rows.
+    assert.equal((await first.getRepoSyncStates("issues")).length, 1);
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    const prs = await second.getRepoSyncStates("prs");
+    assert.equal(prs[0]?.lastSyncedAt, "2026-05-15T10:00:00.000Z");
+    assert.equal(prs[0]?.nextEligibleAt, "2026-05-15T12:00:00.000Z");
+  } finally {
+    second.close();
+  }
+});
+
+test("MemStorage repo sync state matches the SqliteStorage contract", async () => {
+  const storage = new MemStorage();
+  assert.deepEqual(await storage.getRepoSyncStates("prs"), []);
+  await storage.upsertRepoSyncState("o/r", "prs", { lastSyncedAt: "t1", nextEligibleAt: "t2" });
+  await storage.upsertRepoSyncState("o/r", "prs", { nextEligibleAt: null });
+  assert.deepEqual(await storage.getRepoSyncStates("prs"), [
+    { repo: "o/r", kind: "prs", lastSyncedAt: "t1", nextEligibleAt: null },
+  ]);
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -53,6 +53,15 @@ export type StoredIssueRecord = {
   lastSeenAt: string;
 };
 
+export type RepoSyncKind = "prs" | "issues";
+
+export type RepoSyncState = {
+  repo: string;
+  kind: RepoSyncKind;
+  lastSyncedAt: string | null;
+  nextEligibleAt: string | null;
+};
+
 export interface IStorage {
   // PRs
   getPRs(): Promise<PR[]>;
@@ -116,6 +125,15 @@ export interface IStorage {
   getGithubEtag(url: string): Promise<string | undefined>;
   setGithubEtag(url: string, etag: string): Promise<void>;
   clearGithubEtag(url: string): Promise<void>;
+
+  // Per-repo sync state (backoff + last-synced), persisted so a restart does
+  // not re-hammer a backing-off repo. `kind` separates PR and issue sweeps.
+  getRepoSyncStates(kind: RepoSyncKind): Promise<RepoSyncState[]>;
+  upsertRepoSyncState(
+    repo: string,
+    kind: RepoSyncKind,
+    updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
+  ): Promise<void>;
 
   // CI healing
   getHealingSession(id: string): Promise<HealingSession | undefined>;


### PR DESCRIPTION
## Summary

The babysitter (`repoSyncBackoffUntilMs`) and the watcher (`issueRepoBackoffUntilMs`) tracked per-repo sync backoff in memory. A restart dropped it, so a repo that was failing got re-hammered on the next boot.

This persists backoff and last-synced timestamps in a new `repo_sync_state` table.

This is **P6** (lean scope) of the throttle/quota sequence. **Stacked on #79 → #78 → #77 → #75 → #74 → #73** — base branch is `feat/graphql-budget-tracking`.

## Scope

Lean P6, as agreed: **backoff + last-synced timestamps only**. The original P6 framing ("cold-start refetches known-fresh records") is already largely solved by P1's persistent `github_etags` table — a from-zero restart hits the conditional probe and 304s. So pagination cursors stay in memory; only the genuinely restart-sensitive state (backoff) and `lastSyncedAt` (useful for later sync-prioritisation work) are persisted.

## Changes

- New `repo_sync_state(repo, kind, last_synced_at, next_eligible_at)` table, `kind` ∈ `prs` | `issues`.
- Storage gains `getRepoSyncStates(kind)` and a partial-update `upsertRepoSyncState` on both `SqliteStorage` and `MemStorage`.
- The babysitter PR sweep and the watcher issue sweep pre-load the persisted backoff before their selection loop, write `nextEligibleAt` on failure, and clear it + stamp `lastSyncedAt` on success. The in-memory backoff maps are removed.
- A 304 from the issue probe counts as a successful sync — it confirms freshness — so it stamps `lastSyncedAt` and clears backoff.

## Tests

- `storage.test.ts` — `repo_sync_state` round-trip with partial updates, across reopen (Sqlite) + Mem parity.
- `appRuntime.test.ts` — `syncRepos` persists an issue-sweep backoff on failure; a repo with an active persisted backoff is skipped.
- `babysitter.test.ts` — `syncAndBabysitTrackedRepos` persists a backoff when listing open PRs fails.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 661 pass, 1 skipped (pre-existing)