### PR TITLE
feat: conditional GET for the babysitter PR sweep

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -127,7 +127,7 @@ function makeGitRunCommand(params?: {
 }
 
 function makeWatcherGitHubService(overrides?: Record<string, unknown>) {
-  return {
+  const service: Record<string, unknown> = {
     buildOctokit: async () => ({}) as never,
     fetchFeedbackItemsForPR: async () => [],
     fetchPullSummary: async () => {
@@ -159,6 +159,16 @@ function makeWatcherGitHubService(overrides?: Record<string, unknown>) {
     postPRComment: async () => undefined,
     ...overrides,
   };
+  // Default the conditional PR list to delegate to listOpenPullsForRepo so a
+  // test that overrides only listOpenPullsForRepo still drives the sweep.
+  if (!service.listOpenPullsForRepoConditional) {
+    service.listOpenPullsForRepoConditional = async (octokit: unknown, repo: unknown) => ({
+      notModified: false as const,
+      etag: null,
+      pulls: await (service.listOpenPullsForRepo as (o: unknown, r: unknown) => Promise<unknown>)(octokit, repo),
+    });
+  }
+  return service;
 }
 
 function makeCheckSnapshot(overrides: Partial<CheckSnapshot> = {}): CheckSnapshot {
@@ -354,6 +364,77 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
 
   assert.equal(updated.status, "watching");
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
+});
+
+test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 1,
+    title: "Tracked PR",
+    repo: "octo/example",
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  let conditionalCalls = 0;
+  let fullFetchCalls = 0;
+  const samplePull = {
+    number: 1,
+    title: "Tracked PR",
+    body: null,
+    bodyHtml: null,
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    repoFullName: "octo/example",
+    repoCloneUrl: "https://github.com/octo/example.git",
+    headSha: "head1",
+    headRef: "feature/x",
+    headRepoFullName: "octo/example",
+    headRepoCloneUrl: "https://github.com/octo/example.git",
+    baseRef: "main",
+    baseSha: "base1",
+    mergeable: null,
+  };
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        fullFetchCalls += 1;
+        return [];
+      },
+      listOpenPullsForRepoConditional: async () => {
+        conditionalCalls += 1;
+        return conditionalCalls === 1
+          ? { notModified: false as const, etag: 'W/"pulls-v1"', pulls: [samplePull] }
+          : { notModified: true as const };
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos(); // 200 — populates the cache
+  await babysitter.syncAndBabysitTrackedRepos(); // 304 — must reuse the cache
+
+  assert.equal(conditionalCalls, 2);
+  assert.equal(fullFetchCalls, 0, "a 304 with a warm cache must not trigger a full PR-list fetch");
 });
 
 test("syncAndBabysitTrackedRepos persists a backoff when listing open PRs fails", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -30,6 +30,7 @@ import {
   GitHubIntegrationError,
   listFailingStatuses,
   listOpenPullsForRepo,
+  listOpenPullsForRepoConditional,
   parseRepoSlug,
   postFollowUpForFeedbackItem,
   postPRComment,
@@ -102,6 +103,7 @@ type GitHubService = {
   getAuthenticatedLogin?: (octokit: Awaited<ReturnType<typeof buildOctokit>>) => Promise<string | null>;
   listFailingStatuses: typeof listFailingStatuses;
   listOpenPullsForRepo: typeof listOpenPullsForRepo;
+  listOpenPullsForRepoConditional: typeof listOpenPullsForRepoConditional;
   postFollowUpForFeedbackItem: typeof postFollowUpForFeedbackItem;
   postPRComment: typeof postPRComment;
   postStatusReplyForFeedbackItem: typeof postStatusReplyForFeedbackItem;
@@ -182,6 +184,7 @@ const defaultGitHubService: GitHubService = {
   },
   listFailingStatuses,
   listOpenPullsForRepo,
+  listOpenPullsForRepoConditional,
   postFollowUpForFeedbackItem,
   postPRComment,
   postStatusReplyForFeedbackItem,
@@ -1330,6 +1333,10 @@ export class PRBabysitter {
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
   private repoSyncCursor = 0;
+  // Per-repo open-PR list snapshot + its etag, kept together so a conditional
+  // 304 always has a list to reuse. In-memory only — a restart simply
+  // re-fetches once.
+  private readonly prListCache = new Map<string, { etag: string | null; pulls: GitHubPullSummary[] }>();
 
   constructor(
     storage: IStorage,
@@ -1947,7 +1954,26 @@ export class PRBabysitter {
 
       let openPulls;
       try {
-        openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
+        // Conditional GET: a 304 means no PR's `updated_at` changed since the
+        // last sweep, so the cached list is reused and the fetch costs no
+        // primary rate-limit budget. The etag and list are cached together in
+        // memory so they cannot drift out of sync across a restart.
+        const cachedPrList = this.prListCache.get(repoSlug);
+        const conditional = await this.github.listOpenPullsForRepoConditional(
+          octokit,
+          repo,
+          cachedPrList?.etag ?? null,
+        );
+        if (conditional.notModified && cachedPrList) {
+          openPulls = cachedPrList.pulls;
+        } else if (conditional.notModified) {
+          // Etag hit without a cached list (should not happen, since both are
+          // stored together) — fall back to a full fetch.
+          openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
+        } else {
+          openPulls = conditional.pulls;
+          this.prListCache.set(repoSlug, { etag: conditional.etag, pulls: conditional.pulls });
+        }
         await this.storage.upsertRepoSyncState(repoSlug, "prs", {
           lastSyncedAt: this.now().toISOString(),
           nextEligibleAt: null,

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -20,6 +20,7 @@ import {
   listOpenLinkedPullRequestsForIssue,
   listOpenIssuesForRepo,
   listOpenPullsForRepo,
+  listOpenPullsForRepoConditional,
   probeRepoIssuesChanged,
   listMergedPullsSince,
   listReleasesForRepo,
@@ -900,6 +901,68 @@ test("classifyGitHubConcurrency buckets search, writes, and default reads", () =
   assert.equal(classifyGitHubConcurrency({ method: "PUT", url: "/repos/o/r/contents/file" }), "write");
   assert.equal(classifyGitHubConcurrency({ method: "GET", url: "/repos/o/r/pulls" }), "default");
   assert.equal(classifyGitHubConcurrency({}), "default");
+});
+
+test("listOpenPullsForRepoConditional returns pulls and the page-1 etag on a 200", async () => {
+  let sentIfNoneMatch: string | undefined;
+  const octokit = {
+    pulls: {
+      list: async (params: { page: number; headers?: Record<string, string> }) => {
+        if (params.page === 1) {
+          sentIfNoneMatch = params.headers?.["if-none-match"];
+        }
+        return {
+          data: [
+            {
+              number: 5,
+              title: "PR 5",
+              body: "body",
+              head: { ref: "feature", sha: "head5" },
+              base: { ref: "main", sha: "base5" },
+              user: { login: "alice" },
+              html_url: "https://github.com/owner/repo/pull/5",
+            },
+          ],
+          headers: { etag: 'W/"pulls-v1"' },
+        };
+      },
+    },
+  };
+
+  const result = await listOpenPullsForRepoConditional(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    'W/"cached"',
+  );
+
+  assert.equal(result.notModified, false);
+  if (!result.notModified) {
+    assert.equal(result.etag, 'W/"pulls-v1"');
+    assert.equal(result.pulls.length, 1);
+    assert.equal(result.pulls[0]?.number, 5);
+    assert.equal(result.pulls[0]?.headSha, "head5");
+  }
+  assert.equal(sentIfNoneMatch, 'W/"cached"');
+});
+
+test("listOpenPullsForRepoConditional reports notModified on a 304", async () => {
+  const octokit = {
+    pulls: {
+      list: async () => {
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const result = await listOpenPullsForRepoConditional(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    'W/"cached"',
+  );
+
+  assert.equal(result.notModified, true);
 });
 
 test("probeRepoIssuesChanged returns the response etag on a 200", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -2105,22 +2105,11 @@ export async function fetchFeedbackItemsForPR(
   return combined;
 }
 
-export async function listOpenPullsForRepo(
-  octokit: Octokit,
-  repo: ParsedRepoSlug,
-): Promise<GitHubPullSummary[]> {
-  const pulls = await withGitHubErrorHandling("open pull requests", repo, () => octokit.paginate(octokit.pulls.list, {
-    owner: repo.owner,
-    repo: repo.repo,
-    state: "open",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
-  }));
+type GitHubPullListItem = Awaited<ReturnType<Octokit["pulls"]["list"]>>["data"][number];
 
-  return pulls.map((pull) => {
-    const body = typeof pull.body === "string" ? pull.body : null;
-    return {
+function mapPullToSummary(pull: GitHubPullListItem, repo: ParsedRepoSlug): GitHubPullSummary {
+  const body = typeof pull.body === "string" ? pull.body : null;
+  return {
     number: pull.number,
     title: pull.title || `PR #${pull.number}`,
     body,
@@ -2137,6 +2126,78 @@ export async function listOpenPullsForRepo(
     baseRef: pull.base?.ref || pull.base?.repo?.default_branch || "",
     baseSha: pull.base?.sha || "",
     mergeable: null,
+  };
+}
+
+export async function listOpenPullsForRepo(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+): Promise<GitHubPullSummary[]> {
+  const pulls = await withGitHubErrorHandling("open pull requests", repo, () => octokit.paginate(octokit.pulls.list, {
+    owner: repo.owner,
+    repo: repo.repo,
+    state: "open",
+    sort: "updated",
+    direction: "desc",
+    per_page: 100,
+  }));
+
+  return pulls.map((pull) => mapPullToSummary(pull, repo));
+}
+
+export type ConditionalPullList =
+  | { notModified: true }
+  | { notModified: false; etag: string | null; pulls: GitHubPullSummary[] };
+
+/**
+ * Conditional GET of a repo's open pull requests. Page 1 carries an
+ * `If-None-Match`; a 304 means no PR's `updated_at` changed since `cachedEtag`
+ * and costs no primary rate-limit budget. Note a 304 does *not* imply CI
+ * check-runs are unchanged — those do not bump `updated_at` — so callers must
+ * still poll CI separately.
+ */
+export async function listOpenPullsForRepoConditional(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  cachedEtag: string | null,
+): Promise<ConditionalPullList> {
+  return withGitHubErrorHandling("open pull requests", repo, async () => {
+    const perPage = 100;
+    const collected: GitHubPullListItem[] = [];
+    let firstPageEtag: string | null = null;
+
+    for (let page = 1; ; page += 1) {
+      let response;
+      try {
+        response = await octokit.pulls.list({
+          owner: repo.owner,
+          repo: repo.repo,
+          state: "open",
+          sort: "updated",
+          direction: "desc",
+          per_page: perPage,
+          page,
+          ...(page === 1 && cachedEtag ? { headers: { "if-none-match": cachedEtag } } : {}),
+        });
+      } catch (error) {
+        if (page === 1 && (error as { status?: number } | undefined)?.status === 304) {
+          return { notModified: true };
+        }
+        throw error;
+      }
+
+      if (page === 1) {
+        const etag = response.headers?.etag;
+        firstPageEtag = typeof etag === "string" ? etag : null;
+      }
+      collected.push(...response.data);
+      if (response.data.length < perPage) break;
+    }
+
+    return {
+      notModified: false,
+      etag: firstPageEtag,
+      pulls: collected.map((pull) => mapPullToSummary(pull, repo)),
     };
   });
 }


### PR DESCRIPTION
## Summary

The babysitter sweep fetched every tracked repo's open-PR list in full on every tick. This adds a conditional GET so an unchanged list costs no primary rate-limit budget.

This is **P1b** of the throttle/quota sequence (the PR-side companion that P1 deferred). **Stacked on #80 → #79 → #78 → #77 → #75 → #74 → #73** — base branch is `feat/persistent-repo-sync-state`.

## Why this was deferred from P1

P1 noted that a PR-list etag **cannot gate the babysitter sweep** — CI check-runs are a separate resource and don't bump a PR's `updated_at`, so a 304 doesn't mean "nothing to do." This PR respects that: a 304 only skips the **list fetch**, not per-PR processing.

## Changes

- `listOpenPullsForRepoConditional` — manual page-1 `If-None-Match` request; a 304 means no PR's `updated_at` changed since the cached etag. `mapPullToSummary` is extracted and shared with the existing `listOpenPullsForRepo`.
- The babysitter keeps a per-repo `{ etag, pulls }` snapshot in memory. On a 304 it reuses the cached list and skips the fetch; on a 200 it refreshes the snapshot. Etag and list are cached **together** in memory so they can't drift apart across a restart (no half-state where the etag persists but the list is gone).
- Per-PR processing runs against the cached list exactly as before — the only thing skipped is the list fetch.

## Honest scope note

The budget saving is modest at the steady 1-repo-per-tick cadence (one list request saved per quiet repo per tick). It's larger on `fullSweep`. The other deliverable is a clean per-repo "unchanged" signal, which the follow-up sync-prioritisation PR uses to sweep quiet repos less often.

## Tests

- `github.test.ts` — `listOpenPullsForRepoConditional` 200 (returns pulls + etag, forwards `If-None-Match`) and 304 paths.
- `babysitter.test.ts` — the sweep reuses its cached PR list on a 304 instead of re-fetching.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 664 pass, 1 skipped (pre-existing)