### PR TITLE
feat: deprioritize quiet repos in the sync rotation

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -729,3 +729,39 @@ test("syncRepos skips an issue sweep for a repo whose persisted backoff is activ
 
   assert.equal(listForRepoCalls, 0, "a backed-off repo must not be probed or synced");
 });
+
+test("syncRepos defers the next sweep for a repo whose issue list is unchanged", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"cached"');
+
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  const before = Date.now();
+  await runtime.syncRepos();
+
+  const state = (await storage.getRepoSyncStates("issues")).find((s) => s.repo === "owner/repo");
+  assert.ok(state?.lastSyncedAt, "a 304 still counts as a freshness check");
+  assert.ok(state?.nextEligibleAt, "an unchanged repo must be deprioritized");
+  const eligibleMs = new Date(state!.nextEligibleAt!).getTime();
+  assert.ok(
+    eligibleMs >= before + 9 * 60_000,
+    `expected a ~10min cooldown, got ${(eligibleMs - before) / 60_000}min`,
+  );
+});

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -240,6 +240,10 @@ const AUTO_WORK_READY_LABELS = new Set([
 const DEFAULT_ISSUES_PAGE_SIZE = 100;
 const MAX_ISSUES_PAGE_SIZE = 100;
 const MAX_AUTO_ISSUE_SWEEP_PAGES = 50;
+// After a repo's sweep comes back unchanged, defer its next sweep by this long
+// so quiet repos yield watcher slots and rate-limit budget to active ones. Any
+// observed change clears the cooldown and the repo returns to every-tick.
+const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 const AUTO_WORK_BLOCKED_LABELS = new Set([
   "blocked",
   "question",
@@ -1257,11 +1261,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           const cachedEtag = (await storage.getGithubEtag(etagKey)) ?? null;
           const probe = await probeRepoIssuesChanged(octokit, parsed, cachedEtag);
           if (probe.notModified) {
-            // A 304 confirms the repo's issue list is current — clear backoff
-            // and record the freshness check as a successful sync.
+            // A 304 confirms the repo's issue list is current. Record the
+            // freshness check and defer the next sweep — a quiet repo does not
+            // need an every-tick slot.
             await storage.upsertRepoSyncState(repoSlug, "issues", {
               lastSyncedAt: new Date().toISOString(),
-              nextEligibleAt: null,
+              nextEligibleAt: new Date(Date.now() + QUIET_REPO_COOLDOWN_MS).toISOString(),
             });
             const index = config.watchedRepos.indexOf(repoSlug);
             issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -366,6 +366,78 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
 });
 
+test("syncAndBabysitTrackedRepos deprioritizes a repo whose PR list is unchanged", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 1,
+    title: "Tracked PR",
+    repo: "octo/example",
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  const deprioritizeSamplePull = {
+    number: 1,
+    title: "Tracked PR",
+    body: null,
+    bodyHtml: null,
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    repoFullName: "octo/example",
+    repoCloneUrl: "https://github.com/octo/example.git",
+    headSha: "head1",
+    headRef: "feature/x",
+    headRepoFullName: "octo/example",
+    headRepoCloneUrl: "https://github.com/octo/example.git",
+    baseRef: "main",
+    baseSha: "base1",
+    mergeable: null,
+  };
+
+  let deprioritizeConditionalCalls = 0;
+  const deprioritizeBabysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepoConditional: async () => {
+        deprioritizeConditionalCalls += 1;
+        return deprioritizeConditionalCalls === 1
+          ? { notModified: false as const, etag: 'W/"pulls-v1"', pulls: [deprioritizeSamplePull] }
+          : { notModified: true as const };
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await deprioritizeBabysitter.syncAndBabysitTrackedRepos(); // 200 — the list changed
+  let deprioritizeState = (await storage.getRepoSyncStates("prs")).find((s) => s.repo === "octo/example");
+  assert.equal(deprioritizeState?.nextEligibleAt, null, "a changed repo stays in the every-tick rotation");
+
+  await deprioritizeBabysitter.syncAndBabysitTrackedRepos(); // 304 — the list is unchanged
+  deprioritizeState = (await storage.getRepoSyncStates("prs")).find((s) => s.repo === "octo/example");
+  assert.ok(deprioritizeState?.nextEligibleAt, "an unchanged repo must be deprioritized");
+  assert.ok(
+    new Date(deprioritizeState!.nextEligibleAt!).getTime() > Date.now() + 9 * 60_000,
+    "the quiet cooldown should be ~10 minutes out",
+  );
+});
+
 test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304", async () => {
   const storage = new MemStorage();
   await storage.addPR({

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -80,6 +80,9 @@ const AGENT_STREAM_LOG_LINE_LIMIT = 120;
 const MAX_FEEDBACK_SYNCS_PER_TICK = 20;
 const FEEDBACK_SYNC_RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000;
 const REPO_SYNC_FAILURE_BACKOFF_MS = 60_000;
+// After a repo's PR list comes back unchanged, defer its next sweep by this
+// long so quiet repos yield watcher slots and rate-limit budget to active ones.
+const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 const APP_NAME = "patchdeck";
 const APP_REPOSITORY_URL = "https://github.com/jeremymcs/patchdeck";
 export const APP_COMMENT_FOOTER = formatAppCommentFooter(APP_NAME, true);
@@ -1964,8 +1967,10 @@ export class PRBabysitter {
           repo,
           cachedPrList?.etag ?? null,
         );
+        let prListUnchanged = false;
         if (conditional.notModified && cachedPrList) {
           openPulls = cachedPrList.pulls;
+          prListUnchanged = true;
         } else if (conditional.notModified) {
           // Etag hit without a cached list (should not happen, since both are
           // stored together) — fall back to a full fetch.
@@ -1974,9 +1979,13 @@ export class PRBabysitter {
           openPulls = conditional.pulls;
           this.prListCache.set(repoSlug, { etag: conditional.etag, pulls: conditional.pulls });
         }
+        // When the PR list is unchanged, defer the next sweep — a quiet repo
+        // does not need an every-tick slot. Any change returns it to every-tick.
         await this.storage.upsertRepoSyncState(repoSlug, "prs", {
           lastSyncedAt: this.now().toISOString(),
-          nextEligibleAt: null,
+          nextEligibleAt: prListUnchanged
+            ? new Date(this.now().getTime() + QUIET_REPO_COOLDOWN_MS).toISOString()
+            : null,
         });
         const repoIndex = repos.findIndex((entry) => formatRepoSlug(entry) === repoSlug);
         if (repoIndex >= 0) {


### PR DESCRIPTION
## Summary

Every watched repo was swept on the same round-robin cadence regardless of activity. A repo that keeps coming back unchanged consumed an every-tick slot — and a conditional request — for nothing.

When a sweep finds a repo unchanged (a 304 from the issue probe or the conditional PR list), its next sweep is deferred by a **10-minute quiet cooldown**. Any observed change clears the cooldown and the repo returns to the every-tick rotation.

This is **P8** (lean scope) of the throttle/quota sequence — the final PR. **Stacked on #81 → #80 → #79 → #78 → #77 → #75 → #74 → #73** — base branch is `feat/pr-conditional-reads`.

## Scope

Lean P8, as agreed: instead of a new 30s/2min/30min scheduler with a dedicated fast lane, this is **two effective tiers via smarter round-robin selection** — active repos every tick, quiet repos every ~10min. No new timers. It reuses P6's persisted `repo_sync_state.nextEligibleAt`, so the cooldown survives a restart, and reuses the existing "skip if `nextEligibleAt` is in the future" check.

The full-P8 fast lane was dropped deliberately: actively-babysat PRs already run as `babysit_pr` jobs with their own CI-poll loop, so a 30s sweep lane would largely duplicate existing machinery.

## Changes

- Issue sweep (`syncStoredIssuesStep`): a 304 from the probe now sets `nextEligibleAt = now + 10min` instead of clearing it.
- Babysitter PR sweep: a `notModified` conditional result sets the 10-min cooldown; a changed (`200`) result keeps `nextEligibleAt: null` (every-tick).

## Tradeoff (called out honestly)

A fully-quiet repo's first change is noticed up to ~10min late. For PRs that includes a CI-only transition, since check-runs don't bump `updated_at`. Actively-babysat PRs are unaffected — they run as their own `babysit_pr` jobs with a dedicated CI poll. The 10-min figure is deliberately moderate to bound this.

## Tests

- `appRuntime.test.ts` — the issue sweep defers an unchanged repo ~10min and still records `lastSyncedAt`.
- `babysitter.test.ts` — the PR sweep keeps a changed repo every-tick and defers an unchanged repo ~10min.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 666 pass, 1 skipped (pre-existing)