### PR TITLE
Throttle/quota: land the full stack into main

### DIFF
--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -7,6 +7,7 @@ import {
   issueWorkAttemptCountFromJobs,
   issueWorkPrFromLogs,
   mapMergedPullsToReleaseSummaries,
+  pickWatcherColdStartDelayMs,
   planAutomaticIssueQueueActions,
   type PlanAutomaticIssueQueueInput,
 } from "./appRuntime";
@@ -639,4 +640,30 @@ test("syncRepos syncs issues and persists the new etag when the issue list chang
     'W/"issues-v1"',
     "a successful sweep should persist the fresh etag for next tick",
   );
+});
+
+test("pickWatcherColdStartDelayMs stays within the 15-45s cold-start window", () => {
+  assert.equal(pickWatcherColdStartDelayMs(() => 0), 15_000);
+  assert.equal(pickWatcherColdStartDelayMs(() => 0.5), 30_000);
+  assert.equal(pickWatcherColdStartDelayMs(() => 0.999999999), 45_000);
+  for (let i = 0; i < 200; i += 1) {
+    const delay = pickWatcherColdStartDelayMs();
+    assert.ok(delay >= 15_000 && delay <= 45_000, `delay ${delay} out of range`);
+  }
+});
+
+test("start() defers the first watcher tick instead of firing it during start", async () => {
+  let watcherRuns = 0;
+  const runtime = createAppRuntime({
+    storage: new MemStorage(),
+    startBackgroundServices: false,
+    startWatcher: true,
+    babysitter: { resumeInterruptedRuns: async () => {} } as never,
+    watcherScheduler: { run: async () => { watcherRuns += 1; } } as never,
+  });
+
+  await runtime.start();
+
+  assert.equal(watcherRuns, 0, "the first watcher tick must be deferred, not run during start()");
+  runtime.stop();
 });

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -563,3 +563,80 @@ test("planAutomaticIssueQueueActions counts active work jobs against the work ca
   });
   assert.equal(plan.work.length, 0, "work cap already saturated");
 });
+
+test("syncRepos skips the issue sweep for a repo whose issue list responds 304", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"stale"');
+
+  let listForRepoCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        listForRepoCalls += 1;
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  assert.equal(listForRepoCalls, 1, "only the conditional probe should reach GitHub");
+  const synced = await storage.listSyncedIssues({ repos: ["owner/repo"], limit: 50, offset: 0 });
+  assert.equal(synced.items.length, 0, "a 304 must not sync any issues");
+});
+
+test("syncRepos syncs issues and persists the new etag when the issue list changed", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+
+  const issuePayload = {
+    number: 7,
+    title: "Issue 7",
+    body: "needs attention",
+    html_url: "https://github.com/owner/repo/issues/7",
+    user: { login: "alice" },
+    labels: [],
+    assignees: [],
+    comments: 0,
+    created_at: "2026-05-03T17:00:00.000Z",
+    updated_at: "2026-05-03T18:00:00.000Z",
+  };
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => ({
+        data: [issuePayload],
+        headers: { etag: 'W/"issues-v1"' },
+      }),
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  const synced = await storage.listSyncedIssues({ repos: ["owner/repo"], limit: 50, offset: 0 });
+  assert.equal(synced.items.length, 1);
+  assert.equal(synced.items[0]?.number, 7);
+  assert.equal(
+    await storage.getGithubEtag("issues:open:owner/repo"),
+    'W/"issues-v1"',
+    "a successful sweep should persist the fresh etag for next tick",
+  );
+});

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -729,3 +729,39 @@ test("syncRepos skips an issue sweep for a repo whose persisted backoff is activ
 
   assert.equal(listForRepoCalls, 0, "a backed-off repo must not be probed or synced");
 });
+
+test("syncRepos defers the next sweep for a repo whose issue list is unchanged", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"cached"');
+
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  const before = Date.now();
+  await runtime.syncRepos();
+
+  const state = (await storage.getRepoSyncStates("issues")).find((s) => s.repo === "owner/repo");
+  assert.ok(state?.lastSyncedAt, "a 304 still counts as a freshness check");
+  assert.ok(state?.nextEligibleAt, "an unchanged repo must be deprioritized");
+  const eligibleMs = new Date(state!.nextEligibleAt!).getTime();
+  assert.ok(
+    eligibleMs >= before + 9 * 60_000,
+    `expected a ~10min cooldown, got ${(eligibleMs - before) / 60_000}min`,
+  );
+});

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -667,3 +667,65 @@ test("start() defers the first watcher tick instead of firing it during start", 
   assert.equal(watcherRuns, 0, "the first watcher tick must be deferred, not run during start()");
   runtime.stop();
 });
+
+test("syncRepos persists an issue-sweep backoff when the probe fails", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        const error = new Error("not found") as Error & { status: number };
+        error.status = 404;
+        throw error;
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  const state = (await storage.getRepoSyncStates("issues")).find((s) => s.repo === "owner/repo");
+  assert.ok(state?.nextEligibleAt, "a failed issue sweep must persist a backoff");
+  assert.ok(
+    new Date(state!.nextEligibleAt!).getTime() > Date.now(),
+    "the persisted backoff must be in the future",
+  );
+});
+
+test("syncRepos skips an issue sweep for a repo whose persisted backoff is active", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.upsertRepoSyncState("owner/repo", "issues", {
+    nextEligibleAt: new Date(Date.now() + 600_000).toISOString(),
+  });
+
+  let listForRepoCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        listForRepoCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos();
+
+  assert.equal(listForRepoCalls, 0, "a backed-off repo must not be probed or synced");
+});

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -83,6 +83,19 @@ export class AppRuntimeError extends Error {
   }
 }
 
+const WATCHER_COLD_START_MIN_DELAY_MS = 15_000;
+const WATCHER_COLD_START_MAX_DELAY_MS = 45_000;
+
+/**
+ * The first watcher tick after boot runs at a random offset so several
+ * instances restarting together (a deploy) don't sync GitHub in lockstep,
+ * and so boot isn't competing with the dashboard's initial data load.
+ */
+export function pickWatcherColdStartDelayMs(random: () => number = Math.random): number {
+  const span = WATCHER_COLD_START_MAX_DELAY_MS - WATCHER_COLD_START_MIN_DELAY_MS;
+  return WATCHER_COLD_START_MIN_DELAY_MS + Math.floor(random() * (span + 1));
+}
+
 export type AppRuntimeDependencies = {
   storage?: IStorage;
   backgroundJobQueue?: BackgroundJobQueue;
@@ -806,6 +819,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   });
 
   let watcherTimer: NodeJS.Timeout | null = null;
+  let watcherColdStartTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
   let logsRetentionJob: RetentionJobHandle | null = null;
   const watcherScheduler = dependencies.watcherScheduler ?? createWatcherScheduler(
@@ -1838,7 +1852,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (startWatcher) {
         await refreshWatcherSchedule();
         void babysitter.resumeInterruptedRuns();
-        void runWatcher();
+        watcherColdStartTimer = setTimeout(() => {
+          watcherColdStartTimer = null;
+          void runWatcher();
+        }, pickWatcherColdStartDelayMs());
       }
     },
 
@@ -1848,6 +1865,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (logsRetentionJob) {
         logsRetentionJob.stop();
         logsRetentionJob = null;
+      }
+      if (watcherColdStartTimer) {
+        clearTimeout(watcherColdStartTimer);
+        watcherColdStartTimer = null;
       }
       if (watcherTimer) {
         clearInterval(watcherTimer);

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -240,6 +240,10 @@ const AUTO_WORK_READY_LABELS = new Set([
 const DEFAULT_ISSUES_PAGE_SIZE = 100;
 const MAX_ISSUES_PAGE_SIZE = 100;
 const MAX_AUTO_ISSUE_SWEEP_PAGES = 50;
+// After a repo's sweep comes back unchanged, defer its next sweep by this long
+// so quiet repos yield watcher slots and rate-limit budget to active ones. Any
+// observed change clears the cooldown and the repo returns to every-tick.
+const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 const AUTO_WORK_BLOCKED_LABELS = new Set([
   "blocked",
   "question",
@@ -1257,11 +1261,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           const cachedEtag = (await storage.getGithubEtag(etagKey)) ?? null;
           const probe = await probeRepoIssuesChanged(octokit, parsed, cachedEtag);
           if (probe.notModified) {
-            // A 304 confirms the repo's issue list is current — clear backoff
-            // and record the freshness check as a successful sync.
+            // A 304 confirms the repo's issue list is current. Record the
+            // freshness check and defer the next sweep — a quiet repo does not
+            // need an every-tick slot.
             await storage.upsertRepoSyncState(repoSlug, "issues", {
               lastSyncedAt: new Date().toISOString(),
-              nextEligibleAt: null,
+              nextEligibleAt: new Date(Date.now() + QUIET_REPO_COOLDOWN_MS).toISOString(),
             });
             const index = config.watchedRepos.indexOf(repoSlug);
             issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -46,6 +46,7 @@ import { buildActivityPayload, readActivityPayload } from "./activityPayload";
 import { createWatcherScheduler, type WatcherScheduler } from "./watcherScheduler";
 import { startLogsRetentionJob, type RetentionJobHandle } from "./logsRetention";
 import { getRateLimitState } from "./rateLimitState";
+import { runWithRequestPriority } from "./requestPriority";
 import { ReleaseManager } from "./releaseManager";
 import type { ReleaseAgentPullSummary } from "./releaseAgent";
 import { DeploymentHealingManager } from "./deploymentHealingManager";
@@ -851,7 +852,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         "runtime:1",
         buildBackgroundJobDedupeKey("sync_watched_repos", "runtime:1"),
       );
-      await syncStoredIssuesStep();
+      // The routine issue sweep is low priority — it yields core REST budget
+      // to interactive routes and active babysitter sessions. A manual
+      // syncRepos() stays high priority.
+      await runWithRequestPriority("low", () => syncStoredIssuesStep());
       await queueAutomaticIssueWorkInternal();
     },
     (error) => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -880,7 +880,6 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     lastSyncError: string | null;
   }>();
   const issueRepoSyncOffsets = new Map<string, number>();
-  const issueRepoBackoffUntilMs = new Map<string, number>();
   let issueRepoCursor = 0;
 
   function markIssueSyncAttempt(targetId: string): string {
@@ -1230,9 +1229,18 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       ? config.watchedRepos
       : Array.from({ length: repoCount }).map((_, i) => config.watchedRepos[(issueRepoCursor + i) % repoCount]).filter(Boolean) as string[];
 
+    // Backoff state is persisted, so a restart does not re-hammer a repo whose
+    // issue sweep was failing before the process went down.
+    const issueBackoffUntilMs = new Map<string, number>();
+    for (const syncState of await storage.getRepoSyncStates("issues")) {
+      if (syncState.nextEligibleAt) {
+        issueBackoffUntilMs.set(syncState.repo, new Date(syncState.nextEligibleAt).getTime());
+      }
+    }
+
     for (const repoSlug of candidates) {
       try {
-        const backoffUntilMs = issueRepoBackoffUntilMs.get(repoSlug) ?? 0;
+        const backoffUntilMs = issueBackoffUntilMs.get(repoSlug) ?? 0;
         if (backoffUntilMs > nowMs) continue;
         const parsed = parseRepoSlug(repoSlug);
         if (!parsed) continue;
@@ -1249,7 +1257,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           const cachedEtag = (await storage.getGithubEtag(etagKey)) ?? null;
           const probe = await probeRepoIssuesChanged(octokit, parsed, cachedEtag);
           if (probe.notModified) {
-            issueRepoBackoffUntilMs.delete(repoSlug);
+            // A 304 confirms the repo's issue list is current — clear backoff
+            // and record the freshness check as a successful sync.
+            await storage.upsertRepoSyncState(repoSlug, "issues", {
+              lastSyncedAt: new Date().toISOString(),
+              nextEligibleAt: null,
+            });
             const index = config.watchedRepos.indexOf(repoSlug);
             issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
             continue;
@@ -1271,7 +1284,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           if (!page.hasMore || !options?.fullSweep) break;
         }
         if (didWork) {
-          issueRepoBackoffUntilMs.delete(repoSlug);
+          await storage.upsertRepoSyncState(repoSlug, "issues", {
+            lastSyncedAt: new Date().toISOString(),
+            nextEligibleAt: null,
+          });
           // Persist the etag only after a successful sync so a failure mid-sweep
           // re-probes and re-syncs next tick instead of 304-skipping stale data.
           if (pendingEtag) {
@@ -1282,7 +1298,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           if (!options?.fullSweep) return;
         }
       } catch (error) {
-        issueRepoBackoffUntilMs.set(repoSlug, Date.now() + 60_000);
+        await storage.upsertRepoSyncState(repoSlug, "issues", {
+          nextEligibleAt: new Date(Date.now() + 60_000).toISOString(),
+        });
         log.warn(
           { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
           "Issue sync step failed; backing off",

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -67,6 +67,7 @@ import {
   type MergedPRSummary,
   parsePRUrl,
   parseRepoSlug,
+  probeRepoIssuesChanged,
   addLabelsToIssue,
   removeLabelsFromIssue,
   resolveNextSemverTag,
@@ -90,6 +91,7 @@ export type AppRuntimeDependencies = {
   deploymentHealingManager?: DeploymentHealingManager;
   babysitter?: PRBabysitter;
   watcherScheduler?: WatcherScheduler;
+  buildOctokitFn?: typeof buildOctokit;
   startBackgroundServices?: boolean;
   startWatcher?: boolean;
 };
@@ -690,6 +692,7 @@ export function mapMergedPullsToReleaseSummaries(pulls: MergedPRSummary[]): Rele
 
 export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): AppRuntime {
   const storage = dependencies.storage ?? getDefaultStorage();
+  const buildOctokitImpl = dependencies.buildOctokitFn ?? buildOctokit;
   const events = new EventEmitter();
   const socialPostJobs = new Map<string, ReleaseSocialPost>();
   const backgroundJobQueue = dependencies.backgroundJobQueue ?? new BackgroundJobQueue(storage);
@@ -1202,7 +1205,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   async function syncStoredIssuesStep(options?: { fullSweep?: boolean }): Promise<void> {
     const config = await storage.getConfig();
     if (config.watchedRepos.length === 0) return;
-    const octokit = await buildOctokit(config);
+    const octokit = await buildOctokitImpl(config);
     const nowMs = Date.now();
     const repoCount = config.watchedRepos.length;
     const candidates = options?.fullSweep
@@ -1218,6 +1221,24 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         const limit = MAX_ISSUES_PAGE_SIZE;
         const loops = options?.fullSweep ? MAX_AUTO_ISSUE_SWEEP_PAGES : 1;
         let nextOffset = options?.fullSweep ? 0 : (issueRepoSyncOffsets.get(repoSlug) ?? 0);
+
+        // At the start of a repo's sweep, a conditional GET tells us whether
+        // anything changed. A 304 costs no primary rate-limit budget, so on an
+        // unchanged repo we skip the whole sweep instead of paginating it.
+        const etagKey = `issues:open:${repoSlug}`;
+        let pendingEtag: string | null = null;
+        if (nextOffset === 0) {
+          const cachedEtag = (await storage.getGithubEtag(etagKey)) ?? null;
+          const probe = await probeRepoIssuesChanged(octokit, parsed, cachedEtag);
+          if (probe.notModified) {
+            issueRepoBackoffUntilMs.delete(repoSlug);
+            const index = config.watchedRepos.indexOf(repoSlug);
+            issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
+            continue;
+          }
+          pendingEtag = probe.etag;
+        }
+
         let didWork = false;
         for (let i = 0; i < loops; i += 1) {
           const page = await listOpenIssuesForRepo(octokit, parsed, { limit, offset: nextOffset });
@@ -1233,6 +1254,11 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         }
         if (didWork) {
           issueRepoBackoffUntilMs.delete(repoSlug);
+          // Persist the etag only after a successful sync so a failure mid-sweep
+          // re-probes and re-syncs next tick instead of 304-skipping stale data.
+          if (pendingEtag) {
+            await storage.setGithubEtag(etagKey, pendingEtag);
+          }
           const index = config.watchedRepos.indexOf(repoSlug);
           issueRepoCursor = index === -1 ? issueRepoCursor : (index + 1) % repoCount;
           if (!options?.fullSweep) return;

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -366,6 +366,78 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
 });
 
+test("syncAndBabysitTrackedRepos deprioritizes a repo whose PR list is unchanged", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 1,
+    title: "Tracked PR",
+    repo: "octo/example",
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  const deprioritizeSamplePull = {
+    number: 1,
+    title: "Tracked PR",
+    body: null,
+    bodyHtml: null,
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    repoFullName: "octo/example",
+    repoCloneUrl: "https://github.com/octo/example.git",
+    headSha: "head1",
+    headRef: "feature/x",
+    headRepoFullName: "octo/example",
+    headRepoCloneUrl: "https://github.com/octo/example.git",
+    baseRef: "main",
+    baseSha: "base1",
+    mergeable: null,
+  };
+
+  let deprioritizeConditionalCalls = 0;
+  const deprioritizeBabysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepoConditional: async () => {
+        deprioritizeConditionalCalls += 1;
+        return deprioritizeConditionalCalls === 1
+          ? { notModified: false as const, etag: 'W/"pulls-v1"', pulls: [deprioritizeSamplePull] }
+          : { notModified: true as const };
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await deprioritizeBabysitter.syncAndBabysitTrackedRepos(); // 200 — the list changed
+  let deprioritizeState = (await storage.getRepoSyncStates("prs")).find((s) => s.repo === "octo/example");
+  assert.equal(deprioritizeState?.nextEligibleAt, null, "a changed repo stays in the every-tick rotation");
+
+  await deprioritizeBabysitter.syncAndBabysitTrackedRepos(); // 304 — the list is unchanged
+  deprioritizeState = (await storage.getRepoSyncStates("prs")).find((s) => s.repo === "octo/example");
+  assert.ok(deprioritizeState?.nextEligibleAt, "an unchanged repo must be deprioritized");
+  assert.ok(
+    new Date(deprioritizeState!.nextEligibleAt!).getTime() > Date.now() + 9 * 60_000,
+    "the quiet cooldown should be ~10 minutes out",
+  );
+});
+
 test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304", async () => {
   const storage = new MemStorage();
   await storage.addPR({

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -127,7 +127,7 @@ function makeGitRunCommand(params?: {
 }
 
 function makeWatcherGitHubService(overrides?: Record<string, unknown>) {
-  return {
+  const service: Record<string, unknown> = {
     buildOctokit: async () => ({}) as never,
     fetchFeedbackItemsForPR: async () => [],
     fetchPullSummary: async () => {
@@ -159,6 +159,16 @@ function makeWatcherGitHubService(overrides?: Record<string, unknown>) {
     postPRComment: async () => undefined,
     ...overrides,
   };
+  // Default the conditional PR list to delegate to listOpenPullsForRepo so a
+  // test that overrides only listOpenPullsForRepo still drives the sweep.
+  if (!service.listOpenPullsForRepoConditional) {
+    service.listOpenPullsForRepoConditional = async (octokit: unknown, repo: unknown) => ({
+      notModified: false as const,
+      etag: null,
+      pulls: await (service.listOpenPullsForRepo as (o: unknown, r: unknown) => Promise<unknown>)(octokit, repo),
+    });
+  }
+  return service;
 }
 
 function makeCheckSnapshot(overrides: Partial<CheckSnapshot> = {}): CheckSnapshot {
@@ -354,6 +364,77 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
 
   assert.equal(updated.status, "watching");
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
+});
+
+test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 1,
+    title: "Tracked PR",
+    repo: "octo/example",
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  let conditionalCalls = 0;
+  let fullFetchCalls = 0;
+  const samplePull = {
+    number: 1,
+    title: "Tracked PR",
+    body: null,
+    bodyHtml: null,
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/1",
+    repoFullName: "octo/example",
+    repoCloneUrl: "https://github.com/octo/example.git",
+    headSha: "head1",
+    headRef: "feature/x",
+    headRepoFullName: "octo/example",
+    headRepoCloneUrl: "https://github.com/octo/example.git",
+    baseRef: "main",
+    baseSha: "base1",
+    mergeable: null,
+  };
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        fullFetchCalls += 1;
+        return [];
+      },
+      listOpenPullsForRepoConditional: async () => {
+        conditionalCalls += 1;
+        return conditionalCalls === 1
+          ? { notModified: false as const, etag: 'W/"pulls-v1"', pulls: [samplePull] }
+          : { notModified: true as const };
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos(); // 200 — populates the cache
+  await babysitter.syncAndBabysitTrackedRepos(); // 304 — must reuse the cache
+
+  assert.equal(conditionalCalls, 2);
+  assert.equal(fullFetchCalls, 0, "a 304 with a warm cache must not trigger a full PR-list fetch");
 });
 
 test("syncAndBabysitTrackedRepos persists a backoff when listing open PRs fails", async () => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -356,6 +356,52 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
 });
 
+test("syncAndBabysitTrackedRepos persists a backoff when listing open PRs fails", async () => {
+  const storage = new MemStorage();
+  await storage.addPR({
+    number: 7,
+    title: "Tracked PR",
+    repo: "octo/example",
+    branch: "feature/x",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/7",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+    watchEnabled: false,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => {
+        throw new Error("list open PRs failed");
+      },
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const state = (await storage.getRepoSyncStates("prs")).find((s) => s.repo === "octo/example");
+  assert.ok(state?.nextEligibleAt, "a failed PR sweep must persist a backoff");
+  assert.ok(
+    new Date(state!.nextEligibleAt!).getTime() > Date.now(),
+    "the persisted backoff must be in the future",
+  );
+});
+
 test("syncAndBabysitTrackedRepos queues release evaluation for merged archived PRs", async () => {
   const storage = new MemStorage();
   const queued: Array<Record<string, string | number>> = [];

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1329,7 +1329,6 @@ export class PRBabysitter {
   private readonly clock: () => Date;
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
-  private readonly repoSyncBackoffUntilMs = new Map<string, number>();
   private repoSyncCursor = 0;
 
   constructor(
@@ -1923,6 +1922,14 @@ export class PRBabysitter {
     }
 
     const nowMs = this.now().getTime();
+    // Backoff state is persisted, so a restart does not re-hammer a repo that
+    // was failing before the process went down.
+    const prSyncBackoffUntilMs = new Map<string, number>();
+    for (const syncState of await this.storage.getRepoSyncStates("prs")) {
+      if (syncState.nextEligibleAt) {
+        prSyncBackoffUntilMs.set(syncState.repo, new Date(syncState.nextEligibleAt).getTime());
+      }
+    }
     const selectedRepos = fullSweep
       ? repos
       : Array.from({ length: repos.length })
@@ -1930,7 +1937,7 @@ export class PRBabysitter {
           .filter((repo): repo is NonNullable<typeof repo> => Boolean(repo))
           .filter((repo) => {
             const repoSlug = formatRepoSlug(repo);
-            const backoffUntilMs = this.repoSyncBackoffUntilMs.get(repoSlug) ?? 0;
+            const backoffUntilMs = prSyncBackoffUntilMs.get(repoSlug) ?? 0;
             return backoffUntilMs <= nowMs;
           })
           .slice(0, 1);
@@ -1941,13 +1948,18 @@ export class PRBabysitter {
       let openPulls;
       try {
         openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
-        this.repoSyncBackoffUntilMs.delete(repoSlug);
+        await this.storage.upsertRepoSyncState(repoSlug, "prs", {
+          lastSyncedAt: this.now().toISOString(),
+          nextEligibleAt: null,
+        });
         const repoIndex = repos.findIndex((entry) => formatRepoSlug(entry) === repoSlug);
         if (repoIndex >= 0) {
           this.repoSyncCursor = (repoIndex + 1) % repos.length;
         }
       } catch (error) {
-        this.repoSyncBackoffUntilMs.set(repoSlug, this.now().getTime() + REPO_SYNC_FAILURE_BACKOFF_MS);
+        await this.storage.upsertRepoSyncState(repoSlug, "prs", {
+          nextEligibleAt: new Date(this.now().getTime() + REPO_SYNC_FAILURE_BACKOFF_MS).toISOString(),
+        });
         log.warn(
           { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
           "Failed to list open PRs",

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -30,6 +30,7 @@ import {
   GitHubIntegrationError,
   listFailingStatuses,
   listOpenPullsForRepo,
+  listOpenPullsForRepoConditional,
   parseRepoSlug,
   postFollowUpForFeedbackItem,
   postPRComment,
@@ -102,6 +103,7 @@ type GitHubService = {
   getAuthenticatedLogin?: (octokit: Awaited<ReturnType<typeof buildOctokit>>) => Promise<string | null>;
   listFailingStatuses: typeof listFailingStatuses;
   listOpenPullsForRepo: typeof listOpenPullsForRepo;
+  listOpenPullsForRepoConditional: typeof listOpenPullsForRepoConditional;
   postFollowUpForFeedbackItem: typeof postFollowUpForFeedbackItem;
   postPRComment: typeof postPRComment;
   postStatusReplyForFeedbackItem: typeof postStatusReplyForFeedbackItem;
@@ -182,6 +184,7 @@ const defaultGitHubService: GitHubService = {
   },
   listFailingStatuses,
   listOpenPullsForRepo,
+  listOpenPullsForRepoConditional,
   postFollowUpForFeedbackItem,
   postPRComment,
   postStatusReplyForFeedbackItem,
@@ -1330,6 +1333,10 @@ export class PRBabysitter {
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
   private repoSyncCursor = 0;
+  // Per-repo open-PR list snapshot + its etag, kept together so a conditional
+  // 304 always has a list to reuse. In-memory only — a restart simply
+  // re-fetches once.
+  private readonly prListCache = new Map<string, { etag: string | null; pulls: GitHubPullSummary[] }>();
 
   constructor(
     storage: IStorage,
@@ -1947,7 +1954,26 @@ export class PRBabysitter {
 
       let openPulls;
       try {
-        openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
+        // Conditional GET: a 304 means no PR's `updated_at` changed since the
+        // last sweep, so the cached list is reused and the fetch costs no
+        // primary rate-limit budget. The etag and list are cached together in
+        // memory so they cannot drift out of sync across a restart.
+        const cachedPrList = this.prListCache.get(repoSlug);
+        const conditional = await this.github.listOpenPullsForRepoConditional(
+          octokit,
+          repo,
+          cachedPrList?.etag ?? null,
+        );
+        if (conditional.notModified && cachedPrList) {
+          openPulls = cachedPrList.pulls;
+        } else if (conditional.notModified) {
+          // Etag hit without a cached list (should not happen, since both are
+          // stored together) — fall back to a full fetch.
+          openPulls = await this.github.listOpenPullsForRepo(octokit, repo);
+        } else {
+          openPulls = conditional.pulls;
+          this.prListCache.set(repoSlug, { etag: conditional.etag, pulls: conditional.pulls });
+        }
         await this.storage.upsertRepoSyncState(repoSlug, "prs", {
           lastSyncedAt: this.now().toISOString(),
           nextEligibleAt: null,

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -80,6 +80,9 @@ const AGENT_STREAM_LOG_LINE_LIMIT = 120;
 const MAX_FEEDBACK_SYNCS_PER_TICK = 20;
 const FEEDBACK_SYNC_RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000;
 const REPO_SYNC_FAILURE_BACKOFF_MS = 60_000;
+// After a repo's PR list comes back unchanged, defer its next sweep by this
+// long so quiet repos yield watcher slots and rate-limit budget to active ones.
+const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 const APP_NAME = "patchdeck";
 const APP_REPOSITORY_URL = "https://github.com/jeremymcs/patchdeck";
 export const APP_COMMENT_FOOTER = formatAppCommentFooter(APP_NAME, true);
@@ -1964,8 +1967,10 @@ export class PRBabysitter {
           repo,
           cachedPrList?.etag ?? null,
         );
+        let prListUnchanged = false;
         if (conditional.notModified && cachedPrList) {
           openPulls = cachedPrList.pulls;
+          prListUnchanged = true;
         } else if (conditional.notModified) {
           // Etag hit without a cached list (should not happen, since both are
           // stored together) — fall back to a full fetch.
@@ -1974,9 +1979,13 @@ export class PRBabysitter {
           openPulls = conditional.pulls;
           this.prListCache.set(repoSlug, { etag: conditional.etag, pulls: conditional.pulls });
         }
+        // When the PR list is unchanged, defer the next sweep — a quiet repo
+        // does not need an every-tick slot. Any change returns it to every-tick.
         await this.storage.upsertRepoSyncState(repoSlug, "prs", {
           lastSyncedAt: this.now().toISOString(),
-          nextEligibleAt: null,
+          nextEligibleAt: prListUnchanged
+            ? new Date(this.now().getTime() + QUIET_REPO_COOLDOWN_MS).toISOString()
+            : null,
         });
         const repoIndex = repos.findIndex((entry) => formatRepoSlug(entry) === repoSlug);
         if (repoIndex >= 0) {

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -24,6 +24,7 @@ import { verifySubtasksAgainstPr } from "./issueVerify";
 import { runIssueWorkRepair } from "./issueWorkAgent";
 import { answerPRQuestion } from "./prQuestionAgent";
 import type { ReleaseManager } from "./releaseManager";
+import { runWithRequestPriority } from "./requestPriority";
 import type { IStorage } from "./storage";
 
 type BackgroundJobHandlerDeps = {
@@ -124,7 +125,9 @@ export function createBackgroundJobHandlers(params: {
   return {
     sync_watched_repos: babysitter
       ? async () => {
-        await babysitter.syncAndBabysitTrackedRepos();
+        // The routine sweep runs at low priority so it yields core REST
+        // budget to interactive routes and active babysitter sessions.
+        await runWithRequestPriority("low", () => babysitter.syncAndBabysitTrackedRepos());
       }
       : undefined,
 

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -5,6 +5,7 @@ import {
   addLabelsToIssue,
   buildGitHubCloneUrl,
   buildOctokit,
+  classifyGitHubConcurrency,
   GitHubIntegrationError,
   buildFeedbackAuditToken,
   checkOnboardingStatus,
@@ -884,6 +885,21 @@ test("listOpenIssuesForRepo continues pagination when a page contains pull reque
   assert.equal(page.items.length, 51);
   assert.equal(page.items[0]?.number, 51);
   assert.equal(page.items[50]?.number, 101);
+});
+
+test("classifyGitHubConcurrency buckets search, writes, and default reads", () => {
+  assert.equal(classifyGitHubConcurrency({ method: "GET", url: "/search/issues" }), "search");
+  // A search URL outranks the HTTP method.
+  assert.equal(classifyGitHubConcurrency({ method: "POST", url: "/search/code" }), "search");
+  assert.equal(
+    classifyGitHubConcurrency({ method: "POST", url: "/repos/o/r/issues/1/comments" }),
+    "write",
+  );
+  assert.equal(classifyGitHubConcurrency({ method: "PATCH", url: "/repos/o/r/pulls/1" }), "write");
+  assert.equal(classifyGitHubConcurrency({ method: "DELETE", url: "/repos/o/r/git/refs/heads/x" }), "write");
+  assert.equal(classifyGitHubConcurrency({ method: "PUT", url: "/repos/o/r/contents/file" }), "write");
+  assert.equal(classifyGitHubConcurrency({ method: "GET", url: "/repos/o/r/pulls" }), "default");
+  assert.equal(classifyGitHubConcurrency({}), "default");
 });
 
 test("probeRepoIssuesChanged returns the response etag on a 200", async () => {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -20,6 +20,7 @@ import {
   listOpenLinkedPullRequestsForIssue,
   listOpenIssuesForRepo,
   listOpenPullsForRepo,
+  listOpenPullsForRepoConditional,
   probeRepoIssuesChanged,
   listMergedPullsSince,
   listReleasesForRepo,
@@ -900,6 +901,68 @@ test("classifyGitHubConcurrency buckets search, writes, and default reads", () =
   assert.equal(classifyGitHubConcurrency({ method: "PUT", url: "/repos/o/r/contents/file" }), "write");
   assert.equal(classifyGitHubConcurrency({ method: "GET", url: "/repos/o/r/pulls" }), "default");
   assert.equal(classifyGitHubConcurrency({}), "default");
+});
+
+test("listOpenPullsForRepoConditional returns pulls and the page-1 etag on a 200", async () => {
+  let sentIfNoneMatch: string | undefined;
+  const octokit = {
+    pulls: {
+      list: async (params: { page: number; headers?: Record<string, string> }) => {
+        if (params.page === 1) {
+          sentIfNoneMatch = params.headers?.["if-none-match"];
+        }
+        return {
+          data: [
+            {
+              number: 5,
+              title: "PR 5",
+              body: "body",
+              head: { ref: "feature", sha: "head5" },
+              base: { ref: "main", sha: "base5" },
+              user: { login: "alice" },
+              html_url: "https://github.com/owner/repo/pull/5",
+            },
+          ],
+          headers: { etag: 'W/"pulls-v1"' },
+        };
+      },
+    },
+  };
+
+  const result = await listOpenPullsForRepoConditional(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    'W/"cached"',
+  );
+
+  assert.equal(result.notModified, false);
+  if (!result.notModified) {
+    assert.equal(result.etag, 'W/"pulls-v1"');
+    assert.equal(result.pulls.length, 1);
+    assert.equal(result.pulls[0]?.number, 5);
+    assert.equal(result.pulls[0]?.headSha, "head5");
+  }
+  assert.equal(sentIfNoneMatch, 'W/"cached"');
+});
+
+test("listOpenPullsForRepoConditional reports notModified on a 304", async () => {
+  const octokit = {
+    pulls: {
+      list: async () => {
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const result = await listOpenPullsForRepoConditional(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    'W/"cached"',
+  );
+
+  assert.equal(result.notModified, true);
 });
 
 test("probeRepoIssuesChanged returns the response etag on a 200", async () => {

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -19,6 +19,7 @@ import {
   listOpenLinkedPullRequestsForIssue,
   listOpenIssuesForRepo,
   listOpenPullsForRepo,
+  probeRepoIssuesChanged,
   listMergedPullsSince,
   listReleasesForRepo,
   listTagsForRepo,
@@ -883,6 +884,63 @@ test("listOpenIssuesForRepo continues pagination when a page contains pull reque
   assert.equal(page.items.length, 51);
   assert.equal(page.items[0]?.number, 51);
   assert.equal(page.items[50]?.number, 101);
+});
+
+test("probeRepoIssuesChanged returns the response etag on a 200", async () => {
+  const octokit = {
+    issues: {
+      listForRepo: async () => ({
+        data: [],
+        headers: { etag: 'W/"fresh"' },
+      }),
+    },
+  };
+
+  const result = await probeRepoIssuesChanged(octokit as never, { owner: "owner", repo: "repo" }, null);
+
+  assert.equal(result.notModified, false);
+  if (!result.notModified) {
+    assert.equal(result.etag, 'W/"fresh"');
+  }
+});
+
+test("probeRepoIssuesChanged reports notModified on a 304 and forwards If-None-Match", async () => {
+  let sentIfNoneMatch: string | undefined;
+  const octokit = {
+    issues: {
+      listForRepo: async (params: { headers?: Record<string, string> }) => {
+        sentIfNoneMatch = params.headers?.["if-none-match"];
+        const error = new Error("Not modified") as Error & { status: number };
+        error.status = 304;
+        throw error;
+      },
+    },
+  };
+
+  const result = await probeRepoIssuesChanged(
+    octokit as never,
+    { owner: "owner", repo: "repo" },
+    'W/"cached"',
+  );
+
+  assert.equal(result.notModified, true);
+  assert.equal(sentIfNoneMatch, 'W/"cached"');
+});
+
+test("probeRepoIssuesChanged rethrows non-304 errors instead of skipping the sweep", async () => {
+  const octokit = {
+    issues: {
+      listForRepo: async () => {
+        const error = new Error("not found") as Error & { status: number };
+        error.status = 404;
+        throw error;
+      },
+    },
+  };
+
+  await assert.rejects(() =>
+    probeRepoIssuesChanged(octokit as never, { owner: "owner", repo: "repo" }, null),
+  );
 });
 
 test("listOpenLinkedPullRequestsForIssue returns unique open cross-referenced PRs", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -2105,22 +2105,11 @@ export async function fetchFeedbackItemsForPR(
   return combined;
 }
 
-export async function listOpenPullsForRepo(
-  octokit: Octokit,
-  repo: ParsedRepoSlug,
-): Promise<GitHubPullSummary[]> {
-  const pulls = await withGitHubErrorHandling("open pull requests", repo, () => octokit.paginate(octokit.pulls.list, {
-    owner: repo.owner,
-    repo: repo.repo,
-    state: "open",
-    sort: "updated",
-    direction: "desc",
-    per_page: 100,
-  }));
+type GitHubPullListItem = Awaited<ReturnType<Octokit["pulls"]["list"]>>["data"][number];
 
-  return pulls.map((pull) => {
-    const body = typeof pull.body === "string" ? pull.body : null;
-    return {
+function mapPullToSummary(pull: GitHubPullListItem, repo: ParsedRepoSlug): GitHubPullSummary {
+  const body = typeof pull.body === "string" ? pull.body : null;
+  return {
     number: pull.number,
     title: pull.title || `PR #${pull.number}`,
     body,
@@ -2137,6 +2126,78 @@ export async function listOpenPullsForRepo(
     baseRef: pull.base?.ref || pull.base?.repo?.default_branch || "",
     baseSha: pull.base?.sha || "",
     mergeable: null,
+  };
+}
+
+export async function listOpenPullsForRepo(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+): Promise<GitHubPullSummary[]> {
+  const pulls = await withGitHubErrorHandling("open pull requests", repo, () => octokit.paginate(octokit.pulls.list, {
+    owner: repo.owner,
+    repo: repo.repo,
+    state: "open",
+    sort: "updated",
+    direction: "desc",
+    per_page: 100,
+  }));
+
+  return pulls.map((pull) => mapPullToSummary(pull, repo));
+}
+
+export type ConditionalPullList =
+  | { notModified: true }
+  | { notModified: false; etag: string | null; pulls: GitHubPullSummary[] };
+
+/**
+ * Conditional GET of a repo's open pull requests. Page 1 carries an
+ * `If-None-Match`; a 304 means no PR's `updated_at` changed since `cachedEtag`
+ * and costs no primary rate-limit budget. Note a 304 does *not* imply CI
+ * check-runs are unchanged — those do not bump `updated_at` — so callers must
+ * still poll CI separately.
+ */
+export async function listOpenPullsForRepoConditional(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  cachedEtag: string | null,
+): Promise<ConditionalPullList> {
+  return withGitHubErrorHandling("open pull requests", repo, async () => {
+    const perPage = 100;
+    const collected: GitHubPullListItem[] = [];
+    let firstPageEtag: string | null = null;
+
+    for (let page = 1; ; page += 1) {
+      let response;
+      try {
+        response = await octokit.pulls.list({
+          owner: repo.owner,
+          repo: repo.repo,
+          state: "open",
+          sort: "updated",
+          direction: "desc",
+          per_page: perPage,
+          page,
+          ...(page === 1 && cachedEtag ? { headers: { "if-none-match": cachedEtag } } : {}),
+        });
+      } catch (error) {
+        if (page === 1 && (error as { status?: number } | undefined)?.status === 304) {
+          return { notModified: true };
+        }
+        throw error;
+      }
+
+      if (page === 1) {
+        const etag = response.headers?.etag;
+        firstPageEtag = typeof etag === "string" ? etag : null;
+      }
+      collected.push(...response.data);
+      if (response.data.length < perPage) break;
+    }
+
+    return {
+      notModified: false,
+      etag: firstPageEtag,
+      pulls: collected.map((pull) => mapPullToSummary(pull, repo)),
     };
   });
 }

--- a/server/github.ts
+++ b/server/github.ts
@@ -9,9 +9,12 @@ import {
   clearRateLimited,
   deriveRateLimitResource,
   getRateLimitState,
+  isCoreBudgetBelowReserve,
   markRateLimited,
+  recordCoreBudget,
   type RateLimitResource,
 } from "./rateLimitState";
+import { getRequestPriority } from "./requestPriority";
 
 const octokitLog = childLogger("octokit");
 
@@ -766,6 +769,25 @@ async function withGitHubErrorHandling<T>(
   throw toGitHubIntegrationError(lastError, context, resource);
 }
 
+/**
+ * Thrown before dispatch when a low-priority (background sweep) request would
+ * eat into the core REST budget reserved for high-priority work. Callers in the
+ * sweep paths already treat thrown errors as a transient failure and back off,
+ * so the sweep simply retries on a later tick once the budget recovers.
+ */
+class BudgetReserveError extends Error {
+  readonly status = 403;
+  // `x-ratelimit-remaining: "0"` keeps shouldFallbackToGhAuth from retrying
+  // this deliberate gate via the gh-auth fallback token (same marker the
+  // RateLimitGateError uses).
+  readonly response: { headers: Record<string, string> };
+  constructor() {
+    super("GitHub core REST budget is in the reserve band; deferring low-priority request");
+    this.name = "BudgetReserveError";
+    this.response = { headers: { "x-ratelimit-remaining": "0" } };
+  }
+}
+
 class RateLimitGateError extends Error {
   readonly status = 403;
   readonly response: { headers: Record<string, string> };
@@ -989,6 +1011,15 @@ function attachRateLimitHook(
       throw new RateLimitGateError(resourceState.resetAt, requestResource);
     }
 
+    // Hold a reserve of the core budget for high-priority work.
+    if (
+      requestResource === "core"
+      && getRequestPriority() === "low"
+      && isCoreBudgetBelowReserve()
+    ) {
+      throw new BudgetReserveError();
+    }
+
     const dispatch = async (): Promise<ReturnType<typeof request>> => {
       const response = await request(options);
       const headerResourceRaw = typeof response.headers?.["x-ratelimit-resource"] === "string"
@@ -999,6 +1030,13 @@ function attachRateLimitHook(
         : requestResource;
       const remainingRaw = response.headers?.["x-ratelimit-remaining"];
       const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
+      if (responseResource === "core") {
+        const limitRaw = response.headers?.["x-ratelimit-limit"];
+        const limit = typeof limitRaw === "string" ? Number.parseInt(limitRaw, 10) : Number.NaN;
+        if (Number.isFinite(remaining) && Number.isFinite(limit)) {
+          recordCoreBudget(remaining, limit);
+        }
+      }
       if (Number.isFinite(remaining) && remaining > 0) {
         clearRateLimited(responseResource);
       }

--- a/server/github.ts
+++ b/server/github.ts
@@ -173,6 +173,12 @@ const GH_AUTH_CACHE_TTL_MS = 15000;
 const GITHUB_MAX_CONCURRENT_REQUESTS = 20;
 const GITHUB_REST_POINT_INTERVAL_MS = 67;
 const GITHUB_CONTENT_REQUEST_INTERVAL_MS = 750;
+
+// Per-endpoint-class concurrency caps. The global cap above protects against
+// connection-count secondary limits; these tighter caps keep the burst-prone
+// endpoints (search, content-creating writes) under their own abuse limits.
+const GITHUB_SEARCH_MAX_CONCURRENT = 2;
+const GITHUB_WRITE_MAX_CONCURRENT = 4;
 const REVIEW_THREADS_QUERY = `
   query CodeFactoryReviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -782,6 +788,32 @@ const RATE_LIMIT_AUTO_RETRY_MAX_WAIT_MS = 15_000;
 
 type GitHubRequestOptions = {
   method?: string;
+  url?: string;
+};
+
+export type GitHubConcurrencyClass = "search" | "write" | "default";
+
+/**
+ * Buckets a request for per-endpoint concurrency limiting. Search has a strict
+ * secondary limit; content-creating writes have their own abuse limit.
+ */
+export function classifyGitHubConcurrency(
+  options: { method?: string; url?: string },
+): GitHubConcurrencyClass {
+  if ((options.url ?? "").toLowerCase().includes("/search/")) {
+    return "search";
+  }
+  const method = options.method?.toUpperCase() ?? "GET";
+  if (method === "POST" || method === "PATCH" || method === "PUT" || method === "DELETE") {
+    return "write";
+  }
+  return "default";
+}
+
+const GITHUB_CONCURRENCY_CAPS: Record<GitHubConcurrencyClass, number> = {
+  search: GITHUB_SEARCH_MAX_CONCURRENT,
+  write: GITHUB_WRITE_MAX_CONCURRENT,
+  default: GITHUB_MAX_CONCURRENT_REQUESTS,
 };
 
 type GitHubRateLimitResourceSnapshot = {
@@ -807,6 +839,11 @@ class GitHubRequestThrottle {
   private active = 0;
   private pointReadyAt = 0;
   private contentReadyAt = 0;
+  private readonly activeByClass: Record<GitHubConcurrencyClass, number> = {
+    search: 0,
+    write: 0,
+    default: 0,
+  };
   private readonly queue: Array<QueuedGitHubRequest<unknown>> = [];
 
   schedule<T>(options: GitHubRequestOptions, run: () => Promise<T>): Promise<T> {
@@ -822,11 +859,20 @@ class GitHubRequestThrottle {
   }
 
   private drain(): void {
-    while (this.active < GITHUB_MAX_CONCURRENT_REQUESTS && this.queue.length > 0) {
-      const item = this.queue.shift();
-      if (!item) return;
+    while (this.active < GITHUB_MAX_CONCURRENT_REQUESTS) {
+      // Pick the first queued request whose endpoint class is below its cap.
+      // Skipping a capped class keeps a search burst from blocking the queue.
+      const index = this.queue.findIndex((item) => {
+        const cls = classifyGitHubConcurrency(item.options);
+        return this.activeByClass[cls] < GITHUB_CONCURRENCY_CAPS[cls];
+      });
+      if (index === -1) break;
+
+      const [item] = this.queue.splice(index, 1);
+      const cls = classifyGitHubConcurrency(item.options);
 
       this.active += 1;
+      this.activeByClass[cls] += 1;
       const delayMs = this.reserveDelay(item.options);
       setTimeout(() => {
         item.run()
@@ -834,6 +880,7 @@ class GitHubRequestThrottle {
           .catch(item.reject)
           .finally(() => {
             this.active -= 1;
+            this.activeByClass[cls] -= 1;
             this.drain();
           });
       }, delayMs);

--- a/server/github.ts
+++ b/server/github.ts
@@ -9,9 +9,9 @@ import {
   clearRateLimited,
   deriveRateLimitResource,
   getRateLimitState,
-  isCoreBudgetBelowReserve,
+  isResourceBudgetBelowReserve,
   markRateLimited,
-  recordCoreBudget,
+  recordResourceBudget,
   type RateLimitResource,
 } from "./rateLimitState";
 import { getRequestPriority } from "./requestPriority";
@@ -777,13 +777,15 @@ async function withGitHubErrorHandling<T>(
  */
 class BudgetReserveError extends Error {
   readonly status = 403;
+  readonly resource: RateLimitResource;
   // `x-ratelimit-remaining: "0"` keeps shouldFallbackToGhAuth from retrying
   // this deliberate gate via the gh-auth fallback token (same marker the
   // RateLimitGateError uses).
   readonly response: { headers: Record<string, string> };
-  constructor() {
-    super("GitHub core REST budget is in the reserve band; deferring low-priority request");
+  constructor(resource: RateLimitResource) {
+    super(`GitHub ${resource} budget is in the reserve band; deferring low-priority request`);
     this.name = "BudgetReserveError";
+    this.resource = resource;
     this.response = { headers: { "x-ratelimit-remaining": "0" } };
   }
 }
@@ -1011,13 +1013,14 @@ function attachRateLimitHook(
       throw new RateLimitGateError(resourceState.resetAt, requestResource);
     }
 
-    // Hold a reserve of the core budget for high-priority work.
+    // Hold a reserve of the core REST and GraphQL budgets for high-priority
+    // work. Search has its own concurrency cap and is not budget-reserved.
     if (
-      requestResource === "core"
+      (requestResource === "core" || requestResource === "graphql")
       && getRequestPriority() === "low"
-      && isCoreBudgetBelowReserve()
+      && isResourceBudgetBelowReserve(requestResource)
     ) {
-      throw new BudgetReserveError();
+      throw new BudgetReserveError(requestResource);
     }
 
     const dispatch = async (): Promise<ReturnType<typeof request>> => {
@@ -1030,11 +1033,11 @@ function attachRateLimitHook(
         : requestResource;
       const remainingRaw = response.headers?.["x-ratelimit-remaining"];
       const remaining = typeof remainingRaw === "string" ? Number.parseInt(remainingRaw, 10) : Number.NaN;
-      if (responseResource === "core") {
+      if (responseResource === "core" || responseResource === "graphql") {
         const limitRaw = response.headers?.["x-ratelimit-limit"];
         const limit = typeof limitRaw === "string" ? Number.parseInt(limitRaw, 10) : Number.NaN;
         if (Number.isFinite(remaining) && Number.isFinite(limit)) {
-          recordCoreBudget(remaining, limit);
+          recordResourceBudget(responseResource, remaining, limit);
         }
       }
       if (Number.isFinite(remaining) && remaining > 0) {

--- a/server/github.ts
+++ b/server/github.ts
@@ -2154,6 +2154,48 @@ export async function listOpenIssuesForRepo(
   return { items, hasMore };
 }
 
+export type RepoIssuesProbeResult =
+  | { notModified: true }
+  | { notModified: false; etag: string | null };
+
+/**
+ * Conditional GET of a repo's open-issue list (page 1, sorted by `updated`).
+ * A 304 means no issue has changed since `cachedEtag` was stored, so the
+ * caller can skip the whole sweep. 304 responses do not decrement the
+ * primary REST rate limit.
+ */
+export async function probeRepoIssuesChanged(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  cachedEtag: string | null,
+): Promise<RepoIssuesProbeResult> {
+  if (typeof octokit.issues?.listForRepo !== "function") {
+    // Mocked/partial Octokit (tests) — can't probe, treat as changed.
+    return { notModified: false, etag: null };
+  }
+  return withGitHubErrorHandling("open issues", repo, async () => {
+    try {
+      const response = await octokit.issues.listForRepo({
+        owner: repo.owner,
+        repo: repo.repo,
+        state: "open",
+        sort: "updated",
+        direction: "desc",
+        per_page: 100,
+        page: 1,
+        ...(cachedEtag ? { headers: { "if-none-match": cachedEtag } } : {}),
+      });
+      const etag = response.headers?.etag;
+      return { notModified: false, etag: typeof etag === "string" ? etag : null };
+    } catch (error) {
+      if ((error as { status?: number } | undefined)?.status === 304) {
+        return { notModified: true };
+      }
+      throw error;
+    }
+  });
+}
+
 export async function listOpenLinkedPullRequestsForIssue(
   octokit: Octokit,
   repo: ParsedRepoSlug,

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -54,7 +54,7 @@ import {
   createSocialChangelog,
   touchAgentRun,
 } from "@shared/models";
-import type { IStorage, StoredIssueRecord } from "./storage";
+import type { IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 
 export class MemStorage implements IStorage {
@@ -81,6 +81,7 @@ export class MemStorage implements IStorage {
   private issueSubtaskSets: Map<string, IssueSubtaskSet> = new Map();
   private syncedIssues: Map<string, StoredIssueRecord> = new Map();
   private githubEtags: Map<string, string> = new Map();
+  private repoSyncStates: Map<string, RepoSyncState> = new Map();
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -411,6 +412,31 @@ export class MemStorage implements IStorage {
 
   async clearGithubEtag(url: string): Promise<void> {
     this.githubEtags.delete(url);
+  }
+
+  async getRepoSyncStates(kind: RepoSyncKind): Promise<RepoSyncState[]> {
+    return Array.from(this.repoSyncStates.values())
+      .filter((state) => state.kind === kind)
+      .map((state) => ({ ...state }));
+  }
+
+  async upsertRepoSyncState(
+    repo: string,
+    kind: RepoSyncKind,
+    updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
+  ): Promise<void> {
+    const key = `${repo}#${kind}`;
+    const existing = this.repoSyncStates.get(key);
+    this.repoSyncStates.set(key, {
+      repo,
+      kind,
+      lastSyncedAt: "lastSyncedAt" in updates
+        ? updates.lastSyncedAt ?? null
+        : existing?.lastSyncedAt ?? null,
+      nextEligibleAt: "nextEligibleAt" in updates
+        ? updates.nextEligibleAt ?? null
+        : existing?.nextEligibleAt ?? null,
+    });
   }
 
   private syncRepoSettings(): void {

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -80,6 +80,7 @@ export class MemStorage implements IStorage {
   private issueEvaluations: Map<string, IssueEvaluation> = new Map();
   private issueSubtaskSets: Map<string, IssueSubtaskSet> = new Map();
   private syncedIssues: Map<string, StoredIssueRecord> = new Map();
+  private githubEtags: Map<string, string> = new Map();
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -398,6 +399,18 @@ export class MemStorage implements IStorage {
     const existing = this.syncedIssues.get(key);
     if (!existing) return;
     this.syncedIssues.set(key, { ...existing, isWorked: true });
+  }
+
+  async getGithubEtag(url: string): Promise<string | undefined> {
+    return this.githubEtags.get(url);
+  }
+
+  async setGithubEtag(url: string, etag: string): Promise<void> {
+    this.githubEtags.set(url, etag);
+  }
+
+  async clearGithubEtag(url: string): Promise<void> {
+    this.githubEtags.delete(url);
   }
 
   private syncRepoSettings(): void {

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -64,6 +64,41 @@ test("octokit hook spaces concurrent REST requests under GitHub secondary limits
   );
 });
 
+test("octokit throttle caps concurrent search requests below the secondary limit", async () => {
+  let active = 0;
+  let peak = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async (input) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/search/")) {
+          active += 1;
+          peak = Math.max(peak, active);
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          active -= 1;
+        }
+        return new Response(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json", "x-ratelimit-remaining": "4999" },
+        });
+      },
+    },
+  );
+
+  await Promise.all(
+    Array.from({ length: 6 }, () => octokit.request("GET /search/issues", { q: "is:open is:pr" })),
+  );
+
+  // 200ms fetches with ~67ms point spacing would overlap 3-deep uncapped;
+  // the search cap of 2 must hold the peak at 2.
+  assert.ok(peak >= 2, `expected search requests to overlap, peak was ${peak}`);
+  assert.ok(peak <= 2, `expected search concurrency capped at 2, peak was ${peak}`);
+});
+
 test("octokit hook records rate-limit reset from 403 response headers", async () => {
   const resetUnixSeconds = Math.floor(Date.now() / 1000) + 600;
   const octokit = await buildOctokit(

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -2,7 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { Config } from "@shared/schema";
 import { buildOctokit } from "./github";
-import { clearRateLimitStateForTests, clearRateLimited, getRateLimitState } from "./rateLimitState";
+import {
+  clearRateLimitStateForTests,
+  clearRateLimited,
+  getCoreBudget,
+  getRateLimitState,
+  recordCoreBudget,
+} from "./rateLimitState";
+import { runWithRequestPriority } from "./requestPriority";
 
 const config: Config = {
   githubTokens: [],
@@ -97,6 +104,63 @@ test("octokit throttle caps concurrent search requests below the secondary limit
   // the search cap of 2 must hold the peak at 2.
   assert.ok(peak >= 2, `expected search requests to overlap, peak was ${peak}`);
   assert.ok(peak <= 2, `expected search concurrency capped at 2, peak was ${peak}`);
+});
+
+test("low-priority requests are gated while the core budget sits in the reserve band", async () => {
+  let fetchCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+            "x-ratelimit-limit": "5000",
+          },
+        });
+      },
+    },
+  );
+
+  recordCoreBudget(100, 5000); // 2% remaining — well inside the reserve
+
+  await assert.rejects(
+    () => runWithRequestPriority("low", () => octokit.request("GET /user")),
+    /budget/i,
+  );
+  assert.equal(fetchCalls, 0, "a gated low-priority request must not reach GitHub");
+
+  // High-priority work still goes through with the budget in the reserve band.
+  const ok = await runWithRequestPriority("high", () => octokit.request("GET /user"));
+  assert.equal(ok.data.login, "octo");
+  assert.equal(fetchCalls, 1);
+});
+
+test("the hook records the core budget from response headers", async () => {
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () =>
+        new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "1234",
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-resource": "core",
+          },
+        }),
+    },
+  );
+
+  assert.equal(getCoreBudget(), null);
+  await octokit.request("GET /user");
+  assert.deepEqual(getCoreBudget(), { remaining: 1234, limit: 5000 });
 });
 
 test("octokit hook records rate-limit reset from 403 response headers", async () => {

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -5,9 +5,9 @@ import { buildOctokit } from "./github";
 import {
   clearRateLimitStateForTests,
   clearRateLimited,
-  getCoreBudget,
   getRateLimitState,
-  recordCoreBudget,
+  getResourceBudget,
+  recordResourceBudget,
 } from "./rateLimitState";
 import { runWithRequestPriority } from "./requestPriority";
 
@@ -126,7 +126,7 @@ test("low-priority requests are gated while the core budget sits in the reserve 
     },
   );
 
-  recordCoreBudget(100, 5000); // 2% remaining — well inside the reserve
+  recordResourceBudget("core", 100, 5000); // 2% remaining — well inside the reserve
 
   await assert.rejects(
     () => runWithRequestPriority("low", () => octokit.request("GET /user")),
@@ -140,27 +140,94 @@ test("low-priority requests are gated while the core budget sits in the reserve 
   assert.equal(fetchCalls, 1);
 });
 
-test("the hook records the core budget from response headers", async () => {
+test("a low core budget does not gate low-priority GraphQL requests", async () => {
+  let graphqlCalls = 0;
   const octokit = await buildOctokit(
     { ...config, githubToken: "ghp_fake" },
     {
       ignoreCache: true,
-      requestFetch: async () =>
-        new Response(JSON.stringify({ login: "octo" }), {
+      requestFetch: async (input) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL ? input.toString() : input.url;
+        if (url.includes("/graphql")) {
+          graphqlCalls += 1;
+        }
+        return new Response(JSON.stringify({ data: { viewer: { login: "octo" } } }), {
           status: 200,
           headers: {
             "content-type": "application/json",
-            "x-ratelimit-remaining": "1234",
+            "x-ratelimit-remaining": "4999",
             "x-ratelimit-limit": "5000",
-            "x-ratelimit-resource": "core",
+            "x-ratelimit-resource": "graphql",
           },
-        }),
+        });
+      },
     },
   );
 
-  assert.equal(getCoreBudget(), null);
+  // Core budget is exhausted, but the GraphQL budget is healthy.
+  recordResourceBudget("core", 100, 5000);
+
+  await runWithRequestPriority("low", () => octokit.graphql("query { viewer { login } }"));
+  assert.equal(graphqlCalls, 1, "GraphQL has its own budget — a low core budget must not gate it");
+});
+
+test("low-priority GraphQL requests are gated while the GraphQL budget is in the reserve", async () => {
+  let graphqlCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        graphqlCalls += 1;
+        return new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json", "x-ratelimit-resource": "graphql" },
+        });
+      },
+    },
+  );
+
+  recordResourceBudget("graphql", 100, 5000); // GraphQL budget in the reserve
+
+  await assert.rejects(
+    () => runWithRequestPriority("low", () => octokit.graphql("query { viewer { login } }")),
+    /graphql budget/i,
+  );
+  assert.equal(graphqlCalls, 0, "a gated low-priority GraphQL request must not reach GitHub");
+});
+
+test("the hook records core and GraphQL budgets from response headers", async () => {
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async (input) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL ? input.toString() : input.url;
+        const resource = url.includes("/graphql") ? "graphql" : "core";
+        const remaining = resource === "graphql" ? "4321" : "1234";
+        return new Response(JSON.stringify({ data: {}, login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": remaining,
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-resource": resource,
+          },
+        });
+      },
+    },
+  );
+
+  assert.equal(getResourceBudget("core"), null);
+  assert.equal(getResourceBudget("graphql"), null);
   await octokit.request("GET /user");
-  assert.deepEqual(getCoreBudget(), { remaining: 1234, limit: 5000 });
+  await octokit.graphql("query { viewer { login } }");
+  assert.deepEqual(getResourceBudget("core"), { remaining: 1234, limit: 5000 });
+  assert.deepEqual(getResourceBudget("graphql"), { remaining: 4321, limit: 5000 });
 });
 
 test("octokit hook records rate-limit reset from 403 response headers", async () => {

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -4,8 +4,11 @@ import {
   clearRateLimitStateForTests,
   clearRateLimited,
   deriveRateLimitResource,
+  getCoreBudget,
   getRateLimitState,
+  isCoreBudgetBelowReserve,
   markRateLimited,
+  recordCoreBudget,
 } from "./rateLimitState";
 
 test.beforeEach(() => clearRateLimitStateForTests());
@@ -110,4 +113,29 @@ test("aggregate resetAt is the latest among limited resources", () => {
 
   const aggregate = getRateLimitState();
   assert.equal(aggregate.resetAt!.getTime(), later * 1000);
+});
+
+test("recordCoreBudget keeps the latest observation", () => {
+  assert.equal(getCoreBudget(), null);
+  recordCoreBudget(4200, 5000);
+  assert.deepEqual(getCoreBudget(), { remaining: 4200, limit: 5000 });
+  recordCoreBudget(900, 5000);
+  assert.deepEqual(getCoreBudget(), { remaining: 900, limit: 5000 });
+});
+
+test("recordCoreBudget ignores non-finite or non-positive values", () => {
+  recordCoreBudget(Number.NaN, 5000);
+  assert.equal(getCoreBudget(), null);
+  recordCoreBudget(100, 0);
+  assert.equal(getCoreBudget(), null);
+});
+
+test("isCoreBudgetBelowReserve gates only inside the 30% reserve band", () => {
+  assert.equal(isCoreBudgetBelowReserve(), false, "an unknown budget never gates");
+  recordCoreBudget(2000, 5000); // 40% remaining
+  assert.equal(isCoreBudgetBelowReserve(), false);
+  recordCoreBudget(1500, 5000); // exactly 30% — at the reserve edge
+  assert.equal(isCoreBudgetBelowReserve(), true);
+  recordCoreBudget(200, 5000); // 4%
+  assert.equal(isCoreBudgetBelowReserve(), true);
 });

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -4,11 +4,11 @@ import {
   clearRateLimitStateForTests,
   clearRateLimited,
   deriveRateLimitResource,
-  getCoreBudget,
   getRateLimitState,
-  isCoreBudgetBelowReserve,
+  getResourceBudget,
+  isResourceBudgetBelowReserve,
   markRateLimited,
-  recordCoreBudget,
+  recordResourceBudget,
 } from "./rateLimitState";
 
 test.beforeEach(() => clearRateLimitStateForTests());
@@ -115,27 +115,37 @@ test("aggregate resetAt is the latest among limited resources", () => {
   assert.equal(aggregate.resetAt!.getTime(), later * 1000);
 });
 
-test("recordCoreBudget keeps the latest observation", () => {
-  assert.equal(getCoreBudget(), null);
-  recordCoreBudget(4200, 5000);
-  assert.deepEqual(getCoreBudget(), { remaining: 4200, limit: 5000 });
-  recordCoreBudget(900, 5000);
-  assert.deepEqual(getCoreBudget(), { remaining: 900, limit: 5000 });
+test("recordResourceBudget keeps the latest observation per resource", () => {
+  assert.equal(getResourceBudget("core"), null);
+  recordResourceBudget("core", 4200, 5000);
+  assert.deepEqual(getResourceBudget("core"), { remaining: 4200, limit: 5000 });
+  recordResourceBudget("core", 900, 5000);
+  assert.deepEqual(getResourceBudget("core"), { remaining: 900, limit: 5000 });
 });
 
-test("recordCoreBudget ignores non-finite or non-positive values", () => {
-  recordCoreBudget(Number.NaN, 5000);
-  assert.equal(getCoreBudget(), null);
-  recordCoreBudget(100, 0);
-  assert.equal(getCoreBudget(), null);
+test("recordResourceBudget tracks core and graphql budgets independently", () => {
+  recordResourceBudget("core", 4000, 5000);
+  recordResourceBudget("graphql", 200, 5000);
+  assert.deepEqual(getResourceBudget("core"), { remaining: 4000, limit: 5000 });
+  assert.deepEqual(getResourceBudget("graphql"), { remaining: 200, limit: 5000 });
+  // graphql is in the reserve band; core is not.
+  assert.equal(isResourceBudgetBelowReserve("core"), false);
+  assert.equal(isResourceBudgetBelowReserve("graphql"), true);
 });
 
-test("isCoreBudgetBelowReserve gates only inside the 30% reserve band", () => {
-  assert.equal(isCoreBudgetBelowReserve(), false, "an unknown budget never gates");
-  recordCoreBudget(2000, 5000); // 40% remaining
-  assert.equal(isCoreBudgetBelowReserve(), false);
-  recordCoreBudget(1500, 5000); // exactly 30% — at the reserve edge
-  assert.equal(isCoreBudgetBelowReserve(), true);
-  recordCoreBudget(200, 5000); // 4%
-  assert.equal(isCoreBudgetBelowReserve(), true);
+test("recordResourceBudget ignores non-finite or non-positive values", () => {
+  recordResourceBudget("core", Number.NaN, 5000);
+  assert.equal(getResourceBudget("core"), null);
+  recordResourceBudget("core", 100, 0);
+  assert.equal(getResourceBudget("core"), null);
+});
+
+test("isResourceBudgetBelowReserve gates only inside the 30% reserve band", () => {
+  assert.equal(isResourceBudgetBelowReserve("core"), false, "an unknown budget never gates");
+  recordResourceBudget("core", 2000, 5000); // 40% remaining
+  assert.equal(isResourceBudgetBelowReserve("core"), false);
+  recordResourceBudget("core", 1500, 5000); // exactly 30% — at the reserve edge
+  assert.equal(isResourceBudgetBelowReserve("core"), true);
+  recordResourceBudget("core", 200, 5000); // 4%
+  assert.equal(isResourceBudgetBelowReserve("core"), true);
 });

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -21,11 +21,19 @@ type ResourceState = { resetAt: Date | null; lastLimitedAt: Date | null };
 
 const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
+// Fraction of the core REST budget held in reserve for high-priority work
+// (interactive routes, active babysitter sessions). Low-priority requests are
+// gated once core `remaining` falls to or below this fraction of the limit.
+const CORE_BUDGET_RESERVE_FRACTION = 0.3;
+
 const state: Record<RateLimitResource, ResourceState> = {
   core: { resetAt: null, lastLimitedAt: null },
   graphql: { resetAt: null, lastLimitedAt: null },
   search: { resetAt: null, lastLimitedAt: null },
 };
+
+type CoreBudget = { remaining: number; limit: number };
+let coreBudget: CoreBudget | null = null;
 
 export function deriveRateLimitResource(
   urlOrHeader: string | null | undefined,
@@ -129,9 +137,36 @@ export function clearRateLimited(resource: RateLimitResource = "core"): void {
   }
 }
 
+/**
+ * Records the latest observed core REST budget from `x-ratelimit-*` response
+ * headers. Used to decide whether low-priority requests should be gated.
+ */
+export function recordCoreBudget(remaining: number, limit: number): void {
+  if (!Number.isFinite(remaining) || !Number.isFinite(limit) || limit <= 0) {
+    return;
+  }
+  coreBudget = { remaining: Math.max(0, remaining), limit };
+}
+
+export function getCoreBudget(): CoreBudget | null {
+  return coreBudget ? { ...coreBudget } : null;
+}
+
+/**
+ * True when the core REST budget has fallen into the reserve band. While true,
+ * low-priority (background sweep) requests are gated so the remaining budget is
+ * kept for high-priority work. Returns false when the budget is unknown — an
+ * unobserved budget must not block work.
+ */
+export function isCoreBudgetBelowReserve(): boolean {
+  if (!coreBudget) return false;
+  return coreBudget.remaining <= coreBudget.limit * CORE_BUDGET_RESERVE_FRACTION;
+}
+
 export function clearRateLimitStateForTests(): void {
   for (const resource of RESOURCES) {
     state[resource].resetAt = null;
     state[resource].lastLimitedAt = null;
   }
+  coreBudget = null;
 }

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -21,10 +21,10 @@ type ResourceState = { resetAt: Date | null; lastLimitedAt: Date | null };
 
 const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 
-// Fraction of the core REST budget held in reserve for high-priority work
+// Fraction of a resource's budget held in reserve for high-priority work
 // (interactive routes, active babysitter sessions). Low-priority requests are
-// gated once core `remaining` falls to or below this fraction of the limit.
-const CORE_BUDGET_RESERVE_FRACTION = 0.3;
+// gated once `remaining` falls to or below this fraction of the limit.
+const BUDGET_RESERVE_FRACTION = 0.3;
 
 const state: Record<RateLimitResource, ResourceState> = {
   core: { resetAt: null, lastLimitedAt: null },
@@ -32,8 +32,13 @@ const state: Record<RateLimitResource, ResourceState> = {
   search: { resetAt: null, lastLimitedAt: null },
 };
 
-type CoreBudget = { remaining: number; limit: number };
-let coreBudget: CoreBudget | null = null;
+export type ResourceBudget = { remaining: number; limit: number };
+
+const budgets: Record<RateLimitResource, ResourceBudget | null> = {
+  core: null,
+  graphql: null,
+  search: null,
+};
 
 export function deriveRateLimitResource(
   urlOrHeader: string | null | undefined,
@@ -138,35 +143,42 @@ export function clearRateLimited(resource: RateLimitResource = "core"): void {
 }
 
 /**
- * Records the latest observed core REST budget from `x-ratelimit-*` response
- * headers. Used to decide whether low-priority requests should be gated.
+ * Records the latest observed budget for a resource from `x-ratelimit-*`
+ * response headers. Used to decide whether low-priority requests should be
+ * gated. The core REST and GraphQL APIs have independent budgets.
  */
-export function recordCoreBudget(remaining: number, limit: number): void {
+export function recordResourceBudget(
+  resource: RateLimitResource,
+  remaining: number,
+  limit: number,
+): void {
   if (!Number.isFinite(remaining) || !Number.isFinite(limit) || limit <= 0) {
     return;
   }
-  coreBudget = { remaining: Math.max(0, remaining), limit };
+  budgets[resource] = { remaining: Math.max(0, remaining), limit };
 }
 
-export function getCoreBudget(): CoreBudget | null {
-  return coreBudget ? { ...coreBudget } : null;
+export function getResourceBudget(resource: RateLimitResource): ResourceBudget | null {
+  const budget = budgets[resource];
+  return budget ? { ...budget } : null;
 }
 
 /**
- * True when the core REST budget has fallen into the reserve band. While true,
- * low-priority (background sweep) requests are gated so the remaining budget is
- * kept for high-priority work. Returns false when the budget is unknown — an
- * unobserved budget must not block work.
+ * True when a resource's budget has fallen into the reserve band. While true,
+ * low-priority (background sweep) requests against that resource are gated so
+ * the remaining budget is kept for high-priority work. Returns false when the
+ * budget is unknown — an unobserved budget must not block work.
  */
-export function isCoreBudgetBelowReserve(): boolean {
-  if (!coreBudget) return false;
-  return coreBudget.remaining <= coreBudget.limit * CORE_BUDGET_RESERVE_FRACTION;
+export function isResourceBudgetBelowReserve(resource: RateLimitResource): boolean {
+  const budget = budgets[resource];
+  if (!budget) return false;
+  return budget.remaining <= budget.limit * BUDGET_RESERVE_FRACTION;
 }
 
 export function clearRateLimitStateForTests(): void {
   for (const resource of RESOURCES) {
     state[resource].resetAt = null;
     state[resource].lastLimitedAt = null;
+    budgets[resource] = null;
   }
-  coreBudget = null;
 }

--- a/server/requestPriority.test.ts
+++ b/server/requestPriority.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getRequestPriority, runWithRequestPriority } from "./requestPriority";
+
+test("getRequestPriority defaults to high outside any scope", () => {
+  assert.equal(getRequestPriority(), "high");
+});
+
+test("runWithRequestPriority sets the priority for its callback and does not leak", () => {
+  const inside = runWithRequestPriority("low", () => getRequestPriority());
+  assert.equal(inside, "low");
+  assert.equal(getRequestPriority(), "high", "priority must not leak past the scope");
+});
+
+test("request priority propagates across awaits", async () => {
+  const observed = await runWithRequestPriority("low", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    return getRequestPriority();
+  });
+  assert.equal(observed, "low");
+});
+
+test("nested scopes restore the outer priority on exit", () => {
+  runWithRequestPriority("low", () => {
+    assert.equal(getRequestPriority(), "low");
+    runWithRequestPriority("high", () => {
+      assert.equal(getRequestPriority(), "high");
+    });
+    assert.equal(getRequestPriority(), "low", "inner scope must not clobber the outer one");
+  });
+});

--- a/server/requestPriority.ts
+++ b/server/requestPriority.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RequestPriority = "high" | "low";
+
+type RequestPriorityContext = { priority: RequestPriority };
+
+const requestPriorityStore = new AsyncLocalStorage<RequestPriorityContext>();
+
+/**
+ * Runs `fn` with an explicit request priority. GitHub requests made anywhere
+ * inside the callback — including transitively, across awaits — are tagged for
+ * budget-reserve gating. The default outside any scope is "high", so only the
+ * routine background sweep needs to opt into "low".
+ */
+export function runWithRequestPriority<T>(priority: RequestPriority, fn: () => T): T {
+  return requestPriorityStore.run({ priority }, fn);
+}
+
+export function getRequestPriority(): RequestPriority {
+  return requestPriorityStore.getStore()?.priority ?? "high";
+}

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -882,6 +882,12 @@ export class SqliteStorage implements IStorage {
         UNIQUE(repo, merge_sha)
       );
 
+      CREATE TABLE IF NOT EXISTS github_etags (
+        url TEXT PRIMARY KEY,
+        etag TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
       CREATE INDEX IF NOT EXISTS idx_logs_pr_id_timestamp ON logs(pr_id, timestamp);
       CREATE INDEX IF NOT EXISTS idx_agent_runs_status_updated_at ON agent_runs(status, updated_at);
@@ -2271,6 +2277,29 @@ export class SqliteStorage implements IStorage {
   async markSyncedIssueWorked(repo: string, number: number): Promise<void> {
     this.withWriteTransaction(() => {
       this.run("UPDATE synced_issues SET is_worked = 1 WHERE repo = ? AND issue_number = ?", repo, number);
+    });
+  }
+
+  async getGithubEtag(url: string): Promise<string | undefined> {
+    const row = this.get<{ etag: string }>("SELECT etag FROM github_etags WHERE url = ?", url);
+    return row?.etag;
+  }
+
+  async setGithubEtag(url: string, etag: string): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run(
+        `INSERT INTO github_etags (url, etag, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(url) DO UPDATE SET etag = excluded.etag, updated_at = excluded.updated_at`,
+        url,
+        etag,
+        new Date().toISOString(),
+      );
+    });
+  }
+
+  async clearGithubEtag(url: string): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run("DELETE FROM github_etags WHERE url = ?", url);
     });
   }
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -60,7 +60,7 @@ import {
   createReleaseRun,
   createSocialChangelog,
 } from "@shared/models";
-import type { IStorage, StoredIssueRecord } from "./storage";
+import type { IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
 import { getCodeFactoryPaths } from "./paths";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 import { appendLogFile } from "./logFiles";
@@ -886,6 +886,14 @@ export class SqliteStorage implements IStorage {
         url TEXT PRIMARY KEY,
         etag TEXT NOT NULL,
         updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS repo_sync_state (
+        repo TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        last_synced_at TEXT,
+        next_eligible_at TEXT,
+        PRIMARY KEY(repo, kind)
       );
 
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
@@ -2300,6 +2308,51 @@ export class SqliteStorage implements IStorage {
   async clearGithubEtag(url: string): Promise<void> {
     this.withWriteTransaction(() => {
       this.run("DELETE FROM github_etags WHERE url = ?", url);
+    });
+  }
+
+  async getRepoSyncStates(kind: RepoSyncKind): Promise<RepoSyncState[]> {
+    const rows = this.all<{
+      repo: string;
+      kind: string;
+      last_synced_at: string | null;
+      next_eligible_at: string | null;
+    }>("SELECT repo, kind, last_synced_at, next_eligible_at FROM repo_sync_state WHERE kind = ?", kind);
+    return rows.map((row) => ({
+      repo: row.repo,
+      kind: row.kind as RepoSyncKind,
+      lastSyncedAt: row.last_synced_at,
+      nextEligibleAt: row.next_eligible_at,
+    }));
+  }
+
+  async upsertRepoSyncState(
+    repo: string,
+    kind: RepoSyncKind,
+    updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
+  ): Promise<void> {
+    this.withWriteTransaction(() => {
+      const existing = this.get<{ last_synced_at: string | null; next_eligible_at: string | null }>(
+        "SELECT last_synced_at, next_eligible_at FROM repo_sync_state WHERE repo = ? AND kind = ?",
+        repo,
+        kind,
+      );
+      const lastSyncedAt = "lastSyncedAt" in updates
+        ? updates.lastSyncedAt ?? null
+        : existing?.last_synced_at ?? null;
+      const nextEligibleAt = "nextEligibleAt" in updates
+        ? updates.nextEligibleAt ?? null
+        : existing?.next_eligible_at ?? null;
+      this.run(
+        `INSERT INTO repo_sync_state (repo, kind, last_synced_at, next_eligible_at) VALUES (?, ?, ?, ?)
+         ON CONFLICT(repo, kind) DO UPDATE SET
+           last_synced_at = excluded.last_synced_at,
+           next_eligible_at = excluded.next_eligible_at`,
+        repo,
+        kind,
+        lastSyncedAt,
+        nextEligibleAt,
+      );
     });
   }
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1201,3 +1201,52 @@ test("MemStorage GitHub etag round-trip matches the SqliteStorage contract", asy
   await storage.clearGithubEtag("issues:open:owner/repo");
   assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), undefined);
 });
+
+test("SqliteStorage persists repo sync state with partial updates across reopen", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const first = new SqliteStorage(root);
+  try {
+    assert.deepEqual(await first.getRepoSyncStates("prs"), []);
+
+    await first.upsertRepoSyncState("o/r", "prs", {
+      lastSyncedAt: "2026-05-15T10:00:00.000Z",
+      nextEligibleAt: null,
+    });
+    await first.upsertRepoSyncState("o/r", "issues", {
+      nextEligibleAt: "2026-05-15T11:00:00.000Z",
+    });
+
+    // A partial update touches only nextEligibleAt; lastSyncedAt is preserved.
+    await first.upsertRepoSyncState("o/r", "prs", { nextEligibleAt: "2026-05-15T12:00:00.000Z" });
+
+    assert.deepEqual(await first.getRepoSyncStates("prs"), [{
+      repo: "o/r",
+      kind: "prs",
+      lastSyncedAt: "2026-05-15T10:00:00.000Z",
+      nextEligibleAt: "2026-05-15T12:00:00.000Z",
+    }]);
+    // `kind` partitions the rows.
+    assert.equal((await first.getRepoSyncStates("issues")).length, 1);
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    const prs = await second.getRepoSyncStates("prs");
+    assert.equal(prs[0]?.lastSyncedAt, "2026-05-15T10:00:00.000Z");
+    assert.equal(prs[0]?.nextEligibleAt, "2026-05-15T12:00:00.000Z");
+  } finally {
+    second.close();
+  }
+});
+
+test("MemStorage repo sync state matches the SqliteStorage contract", async () => {
+  const storage = new MemStorage();
+  assert.deepEqual(await storage.getRepoSyncStates("prs"), []);
+  await storage.upsertRepoSyncState("o/r", "prs", { lastSyncedAt: "t1", nextEligibleAt: "t2" });
+  await storage.upsertRepoSyncState("o/r", "prs", { nextEligibleAt: null });
+  assert.deepEqual(await storage.getRepoSyncStates("prs"), [
+    { repo: "o/r", kind: "prs", lastSyncedAt: "t1", nextEligibleAt: null },
+  ]);
+});

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -9,6 +9,7 @@ import { DatabaseSync } from "node:sqlite";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 import { getCodeFactoryPaths } from "./paths";
 import { SQLITE_LOCK_TIMEOUT_MS, SqliteStorage } from "./sqliteStorage";
+import { MemStorage } from "./memoryStorage";
 
 function createRawDatabase(root: string): DatabaseSync {
   const db = new DatabaseSync(getCodeFactoryPaths(root).stateDbPath, {
@@ -1162,4 +1163,41 @@ try {
   } finally {
     storage.close();
   }
+});
+
+test("SqliteStorage stores, overwrites, and clears GitHub etags across reopen", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const first = new SqliteStorage(root);
+  try {
+    assert.equal(await first.getGithubEtag("issues:open:owner/repo"), undefined);
+
+    await first.setGithubEtag("issues:open:owner/repo", 'W/"abc"');
+    assert.equal(await first.getGithubEtag("issues:open:owner/repo"), 'W/"abc"');
+
+    // Overwrite keeps a single row per url.
+    await first.setGithubEtag("issues:open:owner/repo", 'W/"def"');
+    assert.equal(await first.getGithubEtag("issues:open:owner/repo"), 'W/"def"');
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    assert.equal(await second.getGithubEtag("issues:open:owner/repo"), 'W/"def"');
+    await second.clearGithubEtag("issues:open:owner/repo");
+    assert.equal(await second.getGithubEtag("issues:open:owner/repo"), undefined);
+  } finally {
+    second.close();
+  }
+});
+
+test("MemStorage GitHub etag round-trip matches the SqliteStorage contract", async () => {
+  const storage = new MemStorage();
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), undefined);
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"abc"');
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), 'W/"abc"');
+  await storage.setGithubEtag("issues:open:owner/repo", 'W/"def"');
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), 'W/"def"');
+  await storage.clearGithubEtag("issues:open:owner/repo");
+  assert.equal(await storage.getGithubEtag("issues:open:owner/repo"), undefined);
 });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -112,6 +112,11 @@ export interface IStorage {
   getSyncedIssue(repo: string, number: number): Promise<StoredIssueRecord | undefined>;
   markSyncedIssueWorked(repo: string, number: number): Promise<void>;
 
+  // GitHub conditional-request etags (If-None-Match), keyed by a stable request URL.
+  getGithubEtag(url: string): Promise<string | undefined>;
+  setGithubEtag(url: string, etag: string): Promise<void>;
+  clearGithubEtag(url: string): Promise<void>;
+
   // CI healing
   getHealingSession(id: string): Promise<HealingSession | undefined>;
   getHealingSessionByPrAndHead(prId: string, initialHeadSha: string): Promise<HealingSession | undefined>;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -53,6 +53,15 @@ export type StoredIssueRecord = {
   lastSeenAt: string;
 };
 
+export type RepoSyncKind = "prs" | "issues";
+
+export type RepoSyncState = {
+  repo: string;
+  kind: RepoSyncKind;
+  lastSyncedAt: string | null;
+  nextEligibleAt: string | null;
+};
+
 export interface IStorage {
   // PRs
   getPRs(): Promise<PR[]>;
@@ -116,6 +125,15 @@ export interface IStorage {
   getGithubEtag(url: string): Promise<string | undefined>;
   setGithubEtag(url: string, etag: string): Promise<void>;
   clearGithubEtag(url: string): Promise<void>;
+
+  // Per-repo sync state (backoff + last-synced), persisted so a restart does
+  // not re-hammer a backing-off repo. `kind` separates PR and issue sweeps.
+  getRepoSyncStates(kind: RepoSyncKind): Promise<RepoSyncState[]>;
+  upsertRepoSyncState(
+    repo: string,
+    kind: RepoSyncKind,
+    updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
+  ): Promise<void>;
 
   // CI healing
   getHealingSession(id: string): Promise<HealingSession | undefined>;


### PR DESCRIPTION
## Why this PR exists

PRs #73–#82 were a stacked series. Each PR's base was the branch below it, so merging them advanced the **feature branches** — only #73 (P2) actually reached `main`. GitHub reports #74–#82 as "merged" (each merged into its base), but the work is sitting on this branch, `feat/pr-conditional-reads`, which is the tip of the chain and contains all 9 commits.

This PR lands the complete throttle/quota series into `main` in one merge.

## Contents (verified present on this branch)

- **P2** #73 — per-resource rate-limit gate (core/graphql/search)
- **P1** #74 — conditional GET (ETag/304) for issue sync
- **P9** #75 — per-endpoint concurrency caps
- **P7** #77 — cold-start watcher jitter
- **P3** #78 — core REST budget reserve (AsyncLocalStorage priority)
- **P5** #79 — GraphQL budget reserve
- **P6** #80 — persistent per-repo sync backoff
- **P1b** #81 — conditional GET for the PR sweep
- **P8** #82 — deprioritize quiet repos in the sync rotation

## Verify

Each change passed `npm run check` + `npm run test:all` independently as it was built (633 → 666 tests). Re-run `npm run test:all` on the merge result before cutting a release.