### PR TITLE
fix: bound auto-mode GitHub budget consumption

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -7,6 +7,7 @@ import type { CheckSnapshot, FeedbackItem } from "@shared/schema";
 import { APP_COMMENT_FOOTER, PRBabysitter } from "./babysitter";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
+import { clearRateLimitStateForTests, recordResourceBudget } from "./rateLimitState";
 
 function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
   return {
@@ -776,6 +777,83 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
   assert.equal(jobs[0].payload.activityLabel, "Babysitting PR #42");
   assert.equal(jobs[0].payload.activityDetail, "octo/example - Example PR");
   assert.equal(jobs[0].payload.activityTargetUrl, pr.url);
+});
+
+function makeOctocatPull(n: number) {
+  return {
+    number: n,
+    title: `PR ${n}`,
+    branch: `feature/${n}`,
+    author: "octocat",
+    url: `https://github.com/octo/example/pull/${n}`,
+    headSha: `head${n}`,
+    baseRef: "main",
+    baseSha: "base",
+  };
+}
+
+test("syncAndBabysitTrackedRepos caps babysit_pr enqueues per repo per sweep", async () => {
+  clearRateLimitStateForTests();
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pulls = Array.from({ length: 15 }, (_, i) => makeOctocatPull(100 + i));
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({ listOpenPullsForRepo: async () => pulls }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should enqueue, not babysit directly");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.equal(jobs.length, 10, "at most 10 babysit jobs are enqueued per repo per sweep");
+});
+
+test("syncAndBabysitTrackedRepos enqueues no babysit_pr jobs while the core budget is in the reserve", async () => {
+  clearRateLimitStateForTests();
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pulls = Array.from({ length: 5 }, (_, i) => makeOctocatPull(200 + i));
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({ listOpenPullsForRepo: async () => pulls }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should not babysit while the budget is tight");
+  };
+
+  recordResourceBudget("core", 500, 5000); // 10% remaining — core budget in the reserve band
+  try {
+    await babysitter.syncAndBabysitTrackedRepos();
+    const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+    assert.equal(jobs.length, 0, "no new babysit jobs are enqueued while the budget is tight");
+  } finally {
+    clearRateLimitStateForTests();
+  }
 });
 
 test("syncAndBabysitTrackedRepos refreshes repository status during drain without queueing babysits", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -51,6 +51,7 @@ import { isFailingCheckSnapshot } from "./ciCheckIngestor";
 import { runCIHealingRepairAttempt } from "./ciHealingAgent";
 import { childLogger } from "./logger";
 import { getCodeFactoryPaths } from "./paths";
+import { isResourceBudgetBelowReserve } from "./rateLimitState";
 
 const log = childLogger("babysitter");
 import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
@@ -83,6 +84,10 @@ const REPO_SYNC_FAILURE_BACKOFF_MS = 60_000;
 // After a repo's PR list comes back unchanged, defer its next sweep by this
 // long so quiet repos yield watcher slots and rate-limit budget to active ones.
 const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
+// Most new babysit_pr jobs one sweep will enqueue for a single repo. Caps the
+// cold-start burst on a repo with hundreds of open PRs; the rest backfill on
+// later sweeps (babysit_pr jobs are dedupe-keyed, so nothing is lost).
+const MAX_BABYSIT_ENQUEUES_PER_SWEEP = 10;
 const APP_NAME = "patchdeck";
 const APP_REPOSITORY_URL = "https://github.com/jeremymcs/patchdeck";
 export const APP_COMMENT_FOOTER = formatAppCommentFooter(APP_NAME, true);
@@ -2148,6 +2153,14 @@ export class PRBabysitter {
           }
         }
       }
+      // Pace babysit_pr enqueueing: cap how many new jobs one sweep adds for a
+      // repo, and add none at all while the core budget sits in the reserve
+      // band. On a repo with hundreds of open PRs this turns a single
+      // budget-draining burst into a gradual backfill across sweeps. babysit_pr
+      // jobs are dedupe-keyed, so deferred PRs are simply picked up next sweep.
+      const babysitBudgetTight = isResourceBudgetBelowReserve("core");
+      let babysitEnqueues = 0;
+      let babysitDeferred = 0;
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {
@@ -2298,11 +2311,18 @@ export class PRBabysitter {
           continue;
         }
 
-        await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
-          phase: "watcher",
-          metadata: { repo: repoSlug },
-        });
         if (this.scheduleBackgroundJob) {
+          // Defer this PR's babysit run when the budget is tight or this
+          // sweep already enqueued its quota for the repo.
+          if (babysitBudgetTight || babysitEnqueues >= MAX_BABYSIT_ENQUEUES_PER_SWEEP) {
+            babysitDeferred += 1;
+            continue;
+          }
+          babysitEnqueues += 1;
+          await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
+            phase: "watcher",
+            metadata: { repo: repoSlug },
+          });
           await this.scheduleBackgroundJob(
             "babysit_pr",
             local.id,
@@ -2317,8 +2337,23 @@ export class PRBabysitter {
             },
           );
         } else {
+          await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
+            phase: "watcher",
+            metadata: { repo: repoSlug },
+          });
           await this.babysitPR(local.id, currentConfig.codingAgent as CodingAgent);
         }
+      }
+      if (babysitDeferred > 0) {
+        log.info(
+          {
+            repo: repoSlug,
+            deferred: babysitDeferred,
+            enqueued: babysitEnqueues,
+            reason: babysitBudgetTight ? "core budget reserve" : "per-sweep cap",
+          },
+          "Deferred babysit runs to a later sweep to pace GitHub usage",
+        );
       }
     }
   }

--- a/server/github.ts
+++ b/server/github.ts
@@ -9,6 +9,7 @@ import {
   clearRateLimited,
   deriveRateLimitResource,
   getRateLimitState,
+  isResourceBudgetBelowFloor,
   isResourceBudgetBelowReserve,
   markRateLimited,
   recordResourceBudget,
@@ -1013,14 +1014,19 @@ function attachRateLimitHook(
       throw new RateLimitGateError(resourceState.resetAt, requestResource);
     }
 
-    // Hold a reserve of the core REST and GraphQL budgets for high-priority
-    // work. Search has its own concurrency cap and is not budget-reserved.
-    if (
-      (requestResource === "core" || requestResource === "graphql")
-      && getRequestPriority() === "low"
-      && isResourceBudgetBelowReserve(requestResource)
-    ) {
-      throw new BudgetReserveError(requestResource);
+    // Budget gating for the core REST and GraphQL budgets. Search has its own
+    // concurrency cap and is not budget-reserved.
+    if (requestResource === "core" || requestResource === "graphql") {
+      // Hard floor: below it, gate every request regardless of priority so a
+      // burst of high-priority automation cannot drain the budget to zero.
+      if (isResourceBudgetBelowFloor(requestResource)) {
+        throw new BudgetReserveError(requestResource);
+      }
+      // Reserve band: hold budget for high-priority work by gating the
+      // low-priority background sweep.
+      if (getRequestPriority() === "low" && isResourceBudgetBelowReserve(requestResource)) {
+        throw new BudgetReserveError(requestResource);
+      }
     }
 
     const dispatch = async (): Promise<ReturnType<typeof request>> => {

--- a/server/rateLimitHook.test.ts
+++ b/server/rateLimitHook.test.ts
@@ -126,7 +126,7 @@ test("low-priority requests are gated while the core budget sits in the reserve 
     },
   );
 
-  recordResourceBudget("core", 100, 5000); // 2% remaining — well inside the reserve
+  recordResourceBudget("core", 500, 5000); // 10% remaining — reserve band, above the 5% floor
 
   await assert.rejects(
     () => runWithRequestPriority("low", () => octokit.request("GET /user")),
@@ -134,10 +134,39 @@ test("low-priority requests are gated while the core budget sits in the reserve 
   );
   assert.equal(fetchCalls, 0, "a gated low-priority request must not reach GitHub");
 
-  // High-priority work still goes through with the budget in the reserve band.
+  // High-priority work still goes through while the budget is in the reserve band.
   const ok = await runWithRequestPriority("high", () => octokit.request("GET /user"));
   assert.equal(ok.data.login, "octo");
   assert.equal(fetchCalls, 1);
+});
+
+test("the hard floor gates even high-priority requests when the budget is critically low", async () => {
+  let fetchCalls = 0;
+  const octokit = await buildOctokit(
+    { ...config, githubToken: "ghp_fake" },
+    {
+      ignoreCache: true,
+      requestFetch: async () => {
+        fetchCalls += 1;
+        return new Response(JSON.stringify({ login: "octo" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "x-ratelimit-remaining": "4999",
+            "x-ratelimit-limit": "5000",
+          },
+        });
+      },
+    },
+  );
+
+  recordResourceBudget("core", 100, 5000); // 2% remaining — below the 5% hard floor
+
+  await assert.rejects(
+    () => runWithRequestPriority("high", () => octokit.request("GET /user")),
+    /budget/i,
+  );
+  assert.equal(fetchCalls, 0, "below the floor, even high-priority work must not reach GitHub");
 });
 
 test("a low core budget does not gate low-priority GraphQL requests", async () => {
@@ -189,7 +218,7 @@ test("low-priority GraphQL requests are gated while the GraphQL budget is in the
     },
   );
 
-  recordResourceBudget("graphql", 100, 5000); // GraphQL budget in the reserve
+  recordResourceBudget("graphql", 1000, 5000); // 20% — reserve band, above the 5% floor
 
   await assert.rejects(
     () => runWithRequestPriority("low", () => octokit.graphql("query { viewer { login } }")),

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -6,6 +6,7 @@ import {
   deriveRateLimitResource,
   getRateLimitState,
   getResourceBudget,
+  isResourceBudgetBelowFloor,
   isResourceBudgetBelowReserve,
   markRateLimited,
   recordResourceBudget,
@@ -148,4 +149,14 @@ test("isResourceBudgetBelowReserve gates only inside the 30% reserve band", () =
   assert.equal(isResourceBudgetBelowReserve("core"), true);
   recordResourceBudget("core", 200, 5000); // 4%
   assert.equal(isResourceBudgetBelowReserve("core"), true);
+});
+
+test("isResourceBudgetBelowFloor gates only below the 5% hard floor", () => {
+  assert.equal(isResourceBudgetBelowFloor("core"), false, "an unknown budget never gates");
+  recordResourceBudget("core", 1500, 5000); // 30% — reserve band, but above the floor
+  assert.equal(isResourceBudgetBelowFloor("core"), false);
+  recordResourceBudget("core", 250, 5000); // exactly 5% — at the floor edge
+  assert.equal(isResourceBudgetBelowFloor("core"), true);
+  recordResourceBudget("core", 40, 5000); // 0.8%
+  assert.equal(isResourceBudgetBelowFloor("core"), true);
 });

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -26,6 +26,11 @@ const RECENT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 // gated once `remaining` falls to or below this fraction of the limit.
 const BUDGET_RESERVE_FRACTION = 0.3;
 
+// Hard floor: below this fraction every request is gated regardless of
+// priority, so a burst of high-priority automation cannot drain the budget to
+// zero. Leaves a sliver so the next hourly reset is not met from empty.
+const BUDGET_FLOOR_FRACTION = 0.05;
+
 const state: Record<RateLimitResource, ResourceState> = {
   core: { resetAt: null, lastLimitedAt: null },
   graphql: { resetAt: null, lastLimitedAt: null },
@@ -173,6 +178,18 @@ export function isResourceBudgetBelowReserve(resource: RateLimitResource): boole
   const budget = budgets[resource];
   if (!budget) return false;
   return budget.remaining <= budget.limit * BUDGET_RESERVE_FRACTION;
+}
+
+/**
+ * True when a resource's budget has fallen below the hard floor. While true,
+ * every request against that resource is gated regardless of priority — a
+ * burst of high-priority automation must not be able to drain the budget to
+ * zero. Returns false when the budget is unknown.
+ */
+export function isResourceBudgetBelowFloor(resource: RateLimitResource): boolean {
+  const budget = budgets[resource];
+  if (!budget) return false;
+  return budget.remaining <= budget.limit * BUDGET_FLOOR_FRACTION;
 }
 
 export function clearRateLimitStateForTests(): void {


### PR DESCRIPTION
## The bug

First run with everything on auto against `gsd-build/gsd-2` (hundreds of open PRs) exhausted the hourly REST budget within minutes — **5,772 babysitter failures** in the logs.

## Root cause

The budget reserve (P3/P5) only gates the **low-priority background sweep**. Every `babysit_pr` job runs at **high priority** (the default), so the reserve never touched them — `BudgetReserveError` fired **0 times** in the logs. With everything on auto, the babysitter enqueues one `babysit_pr` job per open PR; each makes several core REST + paginated GraphQL calls. Hundreds of PRs × several requests ≫ 5,000/hr. Nothing bounded high-priority automation volume, so the auto fan-out drained the budget to zero before P2's reactive gate tripped.

The earlier throttle series hardened *sync* and made the *sweep* yield — but never bounded the automation itself.

## Fix — two bounds

**Hard budget floor.** Below 5% of a resource's limit, the rate-limit hook gates **every** request regardless of priority (`isResourceBudgetBelowFloor`). The 30% reserve still gates only low-priority work.

| Budget remaining | Behavior |
|---|---|
| > 30% | everyone runs |
| 5–30% | high-priority only (low-priority sweep yields) |
| < 5% | everything pauses — graceful degradation, not a drain to zero |

**Paced `babysit_pr` enqueueing.** `syncAndBabysitTrackedRepos` now enqueues at most `MAX_BABYSIT_ENQUEUES_PER_SWEEP` (**10**) new jobs per repo per sweep, and **none** while the core budget is in the reserve band. `babysit_pr` jobs are dedupe-keyed, so a large repo's backlog backfills gradually across sweeps instead of in one budget-draining burst.

## Why not reclassify `babysit_pr` as low-priority

That would make the 30% reserve gate it — but P3's intent was to *protect* budget for active babysitting. Keeping babysit high-priority, pacing the enqueue, and adding the floor preserves that.

## Tests

- `rateLimitState.test.ts` — the 5% floor threshold.
- `rateLimitHook.test.ts` — a **high-priority** request is gated below the floor (previously high was never gated); the reserve-band tests adjusted to use 10–20% budgets so they exercise the reserve, not the floor.
- `babysitter.test.ts` — enqueues capped at 10/repo/sweep; zero enqueues while the core budget is in the reserve.

## Verify

- [x] `npm run check` — clean
- [x] `npm run test:all` — 670 pass, 1 skipped (pre-existing)

## Follow-up worth considering

This bounds *consumption*. It does not change that a 6,000-PR repo on full auto wants far more than an hourly budget allows — it will now backfill gradually over hours rather than failing. Scoping babysitting to PRs that actually need attention (recent activity / open feedback / failing CI) would be the deeper fix.