### PR TITLE
fix: match PR page layout to the Issues page

### DIFF
--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -940,8 +940,10 @@ function PRDescriptionPanel({ pr }: { pr: PR }) {
 function RightPanel({ prId }: { prId: string | null }) {
   return (
     <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
-      <div className="border-b border-border px-3 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
-        <span data-testid="tab-activity">Activity</span>
+      <div className="flex shrink-0 border-b border-border">
+        <div className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]">
+          <span data-testid="tab-activity">Activity</span>
+        </div>
       </div>
       <div className="flex-1 overflow-hidden">
         <LogPanel prId={prId} />
@@ -1382,7 +1384,7 @@ export default function Dashboard() {
       <DashboardDrainBanner runtimeState={runtimeState} />
 
       <div className="flex flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
-        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-y-auto border-b border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-b-0 lg:border-r">
+        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-y-auto border-b border-border lg:max-h-none lg:min-h-0 lg:w-[42rem] lg:border-b-0 lg:border-r">
           <div className="sticky top-0 z-10 flex shrink-0 border-b border-border bg-background">
             <button
               type="button"


### PR DESCRIPTION
## Summary

Two presentation tweaks to `client/src/pages/prs.tsx` so the PR page lines up with the Issues page:

- **Left list column** widened from `lg:w-80` (20rem) to `lg:w-[42rem]`, matching the Issues list pane.
- **Activity panel header** restyled as an active tab — `bg-muted`, foreground text, primary inset underline — instead of a plain muted label, matching the Issues "Activity" tab.

## Notes

Presentation only — no logic changes, `data-testid="tab-activity"` preserved. Matches styling already established on `issues.tsx` (`IssueLogPanel` / the issue list pane).

## Verify

- [x] `npm run check` — clean
- [x] `fullAppQaSurface.test.ts` — 9 pass
- Not browser-tested: pure Tailwind class changes mirroring an existing page.