### PR TITLE
fix: reduce GitHub budget pressure and correct PR merge-readiness

### DIFF
--- a/client/src/components/ActivityMenu.tsx
+++ b/client/src/components/ActivityMenu.tsx
@@ -1,5 +1,5 @@
 import { Activity as ActivityIcon } from "lucide-react";
-import type { ActivityItem, ActivitySnapshot } from "@shared/schema";
+import type { ActivityItem, ActivitySnapshot, BackgroundJobKind } from "@shared/schema";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import type { QueueStatusView } from "@/lib/activityQueue";
@@ -26,6 +26,29 @@ function formatPollLabel(pollIntervalMs?: number): string {
   return `${seconds}s`;
 }
 
+const ACTIVITY_KIND_META: Record<BackgroundJobKind, { label: string; className: string }> = {
+  evaluate_issue: { label: "issue", className: "border-sky-500/40 text-sky-400" },
+  verify_issue: { label: "issue", className: "border-sky-500/40 text-sky-400" },
+  work_issue: { label: "issue", className: "border-sky-500/40 text-sky-400" },
+  babysit_pr: { label: "pr", className: "border-emerald-500/40 text-emerald-400" },
+  answer_pr_question: { label: "pr", className: "border-emerald-500/40 text-emerald-400" },
+  process_release_run: { label: "release", className: "border-border text-muted-foreground" },
+  sync_watched_repos: { label: "sync", className: "border-border text-muted-foreground" },
+  generate_social_changelog: { label: "changelog", className: "border-border text-muted-foreground" },
+  heal_deployment: { label: "deploy", className: "border-border text-muted-foreground" },
+};
+
+function ActivityKindBadge({ kind }: { kind: BackgroundJobKind }) {
+  const meta = ACTIVITY_KIND_META[kind];
+  return (
+    <span
+      className={`shrink-0 border px-1 text-[9px] uppercase leading-4 tracking-wider ${meta.className}`}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
 function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueStatus: QueueStatusView | null }) {
   const timeLabel = activity.status === "failed"
     ? formatClock(activity.updatedAt)
@@ -45,7 +68,10 @@ function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueS
         }`}
       />
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
+        <span className="flex min-w-0 items-center gap-1.5">
+          <ActivityKindBadge kind={activity.kind} />
+          <span className="min-w-0 truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
+        </span>
         {activity.detail && (
           <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
         )}

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -23,6 +23,7 @@ import { getUiPollIntervalMs } from "@/lib/polling";
 const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v2";
 const ISSUES_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
 const ISSUES_PAGE_SIZE = 100;
+const LIVE_POLL_INTERVAL_MS = 5000;
 
 function readCachedIssues(): { data: IssueListPage; updatedAt: number } | null {
   if (typeof window === "undefined") return null;
@@ -687,10 +688,12 @@ class IssuesErrorBoundary extends Component<{ children: ReactNode }, IssuesError
 function IssuesPage() {
   const { data: runtime } = useQuery<RuntimeState>({
     queryKey: ["/api/runtime"],
+    refetchInterval: LIVE_POLL_INTERVAL_MS,
   });
   const globalDrainMode = runtime?.drainMode === true;
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
+    refetchInterval: LIVE_POLL_INTERVAL_MS,
   });
   const { data: config } = useQuery<Config>({ queryKey: ["/api/config"] });
   const uiPollIntervalMs = getUiPollIntervalMs(config);
@@ -727,6 +730,7 @@ function IssuesPage() {
     },
   });
 
+  const [extraPages, setExtraPages] = useState<IssueListPage[]>([]);
   const issuesQuery = useQuery<IssueListPage>({
     queryKey: ["/api/issues", ISSUES_PAGE_SIZE, 0],
     queryFn: async () => parseIssueListPageOrThrow(await fetchJson<unknown>(issueListUrl(ISSUES_PAGE_SIZE, 0))),
@@ -739,14 +743,16 @@ function IssuesPage() {
       if (globalDrainMode) {
         return false;
       }
-      const data = query.state.data?.items;
-      return Array.isArray(data) && data.some((issue) => isActiveWorkStatus(issue.workStatus))
-        ? 5000
+      const loaded = [
+        ...(query.state.data?.items ?? []),
+        ...extraPages.flatMap((page) => page.items),
+      ];
+      return loaded.some((issue) => isActiveWorkStatus(issue.workStatus))
+        ? LIVE_POLL_INTERVAL_MS
         : false;
     },
   });
   const { data: issuesPage, isLoading, isFetching } = issuesQuery;
-  const [extraPages, setExtraPages] = useState<IssueListPage[]>([]);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isSyncingRepos, setIsSyncingRepos] = useState(false);
   useEffect(() => {

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -38,6 +38,7 @@ const DEFAULT_SETTING_VALUES = {
   pollIntervalSeconds: 600,
   batchWindowSeconds: 600,
   maxChangesPerRun: 20,
+  maxConcurrentBabysitRuns: 3,
   maxHealingAttemptsPerSession: 3,
   maxHealingAttemptsPerFingerprint: 2,
   maxConcurrentHealingRuns: 1,
@@ -1276,6 +1277,14 @@ export default function Settings() {
                 value={config?.maxChangesPerRun ?? 20}
                 onChange={(v) => updateConfigMutation.mutate({ maxChangesPerRun: v })}
                 defaultValue={DEFAULT_SETTING_VALUES.maxChangesPerRun}
+                disabled={updateConfigMutation.isPending}
+              />
+              <SettingRow
+                label="Max concurrent babysit runs"
+                description="How many PRs the watcher babysits at once before queueing the rest"
+                value={config?.maxConcurrentBabysitRuns ?? 3}
+                onChange={(v) => updateConfigMutation.mutate({ maxConcurrentBabysitRuns: v })}
+                defaultValue={DEFAULT_SETTING_VALUES.maxConcurrentBabysitRuns}
                 disabled={updateConfigMutation.isPending}
               />
             </div>

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -69,6 +69,7 @@ The settings page in the dashboard provides a UI for:
 - **Priority issue authors** — Add GitHub logins whose issues should be evaluated and worked before the regular issue queue.
 - **PR comment branding** — Customize the app name shown in agent-authored GitHub PR comments, or remove that signature entirely. Toggle whether the signature links back to patchdeck and includes the `Posted by patchdeck` footer.
 - **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
+- **Babysitter run concurrency** — Set how many `babysit_pr` jobs can be in-flight (`queued` + `leased`) across watcher sweeps.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
 - **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
 - **Theme** — Toggle between light and dark mode.
@@ -151,6 +152,16 @@ patchdeck can track failing CI checks as first-class healing sessions and, when 
 | `Healing cooldown (ms)` | `300000` | Backoff window before a cooldowned session can retry |
 
 The dashboard shows healing state on each tracked PR, while the local API exposes `GET /api/healing-sessions` and `GET /api/healing-sessions/:id` for external tooling.
+
+## Babysitter Queue Settings
+
+patchdeck paces autonomous PR babysitter dispatch using a global in-flight cap for `babysit_pr` jobs.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `Max concurrent babysitter runs` | `3` | Limits total `babysit_pr` jobs in `queued` or `leased` states during watcher sweeps; additional eligible PRs are deferred to later sweeps instead of being enqueued immediately |
+
+This value maps to `maxConcurrentBabysitRuns` in `GET /api/config` and `PATCH /api/config`.
 
 ## Deployment Healing Settings
 

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -122,6 +122,7 @@ You can control babysitter behavior per repository:
 - **Poll interval** — How often to check for new reviews (default: 60 seconds).
 - **Auto-dispatch** — Whether to automatically dispatch agents or require approval.
 - **Agent preference** — Choose the global coding agent, with CLI fallback when the preferred tool is not installed.
+- **Max concurrent babysitter runs** — Cap how many autonomous `babysit_pr` jobs can be in-flight per watcher sweep before additional PRs are deferred.
 - **Per-PR watch toggle** — Pause one tracked PR's background automation while keeping manual runs available.
 
 See [Configuration](./configuration.md) for details.

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { NewPR } from "@shared/schema";
 import {
   createAppRuntime,
+  deriveWorkPrMergeable,
   getIssueAutoWorkEligibility,
   issueWorkAttemptCountFromJobs,
   issueWorkPrFromLogs,
@@ -332,6 +333,25 @@ test("getIssueAutoWorkEligibility requires a ready label, app approval, and no b
     autoWorkEligible: false,
     autoWorkBlockedReason: "missing ready-for-agent label",
   });
+});
+
+test("deriveWorkPrMergeable only treats a clean PR as ready to merge", () => {
+  // "clean" is the only state where conflicts, required checks, and required
+  // reviews are all satisfied — so it is the only one that counts as ready.
+  assert.equal(deriveWorkPrMergeable("clean"), true);
+
+  // A PR with red or pending CI must never read as ready to merge. "blocked"
+  // = a required check is failing/pending; "unstable" = a non-required check
+  // is failing; "dirty" = merge conflicts; "behind" = base moved on.
+  assert.equal(deriveWorkPrMergeable("blocked"), false);
+  assert.equal(deriveWorkPrMergeable("unstable"), false);
+  assert.equal(deriveWorkPrMergeable("dirty"), false);
+  assert.equal(deriveWorkPrMergeable("behind"), false);
+
+  // GitHub computes the state lazily; until it is known, stay undecided
+  // (null) rather than asserting the PR is not ready.
+  assert.equal(deriveWorkPrMergeable("unknown"), null);
+  assert.equal(deriveWorkPrMergeable(null), null);
 });
 
 // ── planAutomaticIssueQueueActions ───────────────────────────────────────────

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -440,6 +440,21 @@ export function getIssueAutoWorkEligibility(
   };
 }
 
+/**
+ * Maps a GitHub pull request `mergeable_state` to the "ready to merge" flag.
+ * GitHub's `mergeable` boolean only reflects merge conflicts — it stays true
+ * even when CI is red. Only `mergeable_state === "clean"` guarantees no
+ * conflicts AND that required checks and reviews pass, so that is the sole
+ * state treated as ready. "unknown" (GitHub has not finished computing the
+ * state) and a missing value resolve to null rather than false.
+ */
+export function deriveWorkPrMergeable(mergeableState: string | null): boolean | null {
+  if (mergeableState === null || mergeableState === "unknown") {
+    return null;
+  }
+  return mergeableState === "clean";
+}
+
 function getLatestBackgroundJob(jobs: BackgroundJob[]): BackgroundJob | undefined {
   return jobs
     .slice()
@@ -1188,7 +1203,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
           const config = await storage.getConfig();
           const octokit = await buildOctokit(config);
           const pull = await fetchPullSummary(octokit, parsedPr);
-          workPrMergeable = pull.mergeable;
+          workPrMergeable = deriveWorkPrMergeable(pull.mergeableState);
         } catch (error) {
           log.warn(
             { err: error instanceof Error ? error.message : String(error), repo: issue.repoFullName, prNumber: readyPr.workPrNumber },

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -51,6 +51,7 @@ function makePullSummary(pr: { url: string }, overrides?: Record<string, unknown
     baseRef: "main",
     baseSha: "base123",
     mergeable: true as boolean | null,
+    mergeableState: "clean" as string | null,
     ...overrides,
   };
 }
@@ -404,6 +405,7 @@ test("syncAndBabysitTrackedRepos deprioritizes a repo whose PR list is unchanged
     baseRef: "main",
     baseSha: "base1",
     mergeable: null,
+    mergeableState: null,
   };
 
   let deprioritizeConditionalCalls = 0;
@@ -478,6 +480,7 @@ test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304"
     baseRef: "main",
     baseSha: "base1",
     mergeable: null,
+    mergeableState: null,
   };
 
   const babysitter = new PRBabysitter(
@@ -795,7 +798,8 @@ function makeOctocatPull(n: number) {
 test("syncAndBabysitTrackedRepos caps babysit_pr enqueues per repo per sweep", async () => {
   clearRateLimitStateForTests();
   const storage = new MemStorage();
-  await storage.updateConfig({ watchedRepos: ["octo/example"] });
+  // Raise the concurrency ceiling so the per-sweep cap is the binding limit.
+  await storage.updateConfig({ watchedRepos: ["octo/example"], maxConcurrentBabysitRuns: 50 });
   const backgroundJobQueue = new BackgroundJobQueue(storage);
   const pulls = Array.from({ length: 15 }, (_, i) => makeOctocatPull(100 + i));
 
@@ -820,6 +824,40 @@ test("syncAndBabysitTrackedRepos caps babysit_pr enqueues per repo per sweep", a
 
   const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
   assert.equal(jobs.length, 10, "at most 10 babysit jobs are enqueued per repo per sweep");
+});
+
+test("syncAndBabysitTrackedRepos caps in-flight babysit_pr jobs at maxConcurrentBabysitRuns", async () => {
+  clearRateLimitStateForTests();
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"], maxConcurrentBabysitRuns: 3 });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pulls = Array.from({ length: 15 }, (_, i) => makeOctocatPull(100 + i));
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({ listOpenPullsForRepo: async () => pulls }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should enqueue, not babysit directly");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos();
+  const afterFirst = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.equal(afterFirst.length, 3, "first sweep enqueues no more than maxConcurrentBabysitRuns");
+
+  // A second sweep must count the still-queued jobs as in-flight and add none.
+  await babysitter.syncAndBabysitTrackedRepos();
+  const afterSecond = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.equal(afterSecond.length, 3, "already-queued babysit jobs count toward the cap");
 });
 
 test("syncAndBabysitTrackedRepos enqueues no babysit_pr jobs while the core budget is in the reserve", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -23,6 +23,7 @@ import {
   buildOctokit,
   checkCISettled,
   fetchCheckSnapshotsForRef,
+  fetchCiPollResult,
   fetchFeedbackItemsForPR,
   fetchPullCloseState,
   fetchPullSummary,
@@ -39,6 +40,7 @@ import {
   resolveGitHubAuthToken,
   updateStatusReply,
   APP_STATUS_COMMENT_PATTERN,
+  type CiPollResult,
   type GitHubPullSummary,
   type GitHubStatusFailure,
   type ParsedPRUrl,
@@ -52,6 +54,7 @@ import { runCIHealingRepairAttempt } from "./ciHealingAgent";
 import { childLogger } from "./logger";
 import { getCodeFactoryPaths } from "./paths";
 import { isResourceBudgetBelowReserve } from "./rateLimitState";
+import { runWithRequestPriority } from "./requestPriority";
 
 const log = childLogger("babysitter");
 import { ensureRepoCache, preparePrWorktree, removePrWorktree } from "./repoWorkspace";
@@ -108,6 +111,7 @@ type GitHubService = {
   fetchPullCloseState?: typeof fetchPullCloseState;
   fetchPullSummary: typeof fetchPullSummary;
   fetchCheckSnapshotsForRef?: typeof fetchCheckSnapshotsForRef;
+  fetchCiPollResult?: typeof fetchCiPollResult;
   getAuthenticatedLogin?: (octokit: Awaited<ReturnType<typeof buildOctokit>>) => Promise<string | null>;
   listFailingStatuses: typeof listFailingStatuses;
   listOpenPullsForRepo: typeof listOpenPullsForRepo;
@@ -182,6 +186,7 @@ const defaultGitHubService: GitHubService = {
   buildOctokit,
   checkCISettled,
   fetchCheckSnapshotsForRef,
+  fetchCiPollResult,
   fetchFeedbackItemsForPR,
   fetchPullCloseState,
   fetchPullSummary,
@@ -1957,6 +1962,15 @@ export class PRBabysitter {
           })
           .slice(0, 1);
 
+    // Cap concurrently in-flight babysit_pr jobs across the whole sweep. Count
+    // jobs already queued or leased so the sweep never pushes the total past
+    // the configured ceiling; deferred PRs are dedupe-keyed and retried later.
+    const maxConcurrentBabysitRuns = currentConfig.maxConcurrentBabysitRuns;
+    let inFlightBabysitJobs = this.scheduleBackgroundJob
+      ? (await this.storage.listBackgroundJobs({ kind: "babysit_pr" }))
+          .filter((job) => job.status === "queued" || job.status === "leased").length
+      : 0;
+
     for (const repo of selectedRepos) {
       const repoSlug = formatRepoSlug(repo);
 
@@ -2312,13 +2326,19 @@ export class PRBabysitter {
         }
 
         if (this.scheduleBackgroundJob) {
-          // Defer this PR's babysit run when the budget is tight or this
-          // sweep already enqueued its quota for the repo.
-          if (babysitBudgetTight || babysitEnqueues >= MAX_BABYSIT_ENQUEUES_PER_SWEEP) {
+          // Defer this PR's babysit run when the core budget is tight, this
+          // sweep already enqueued its per-repo quota, or the in-flight
+          // babysit_pr concurrency ceiling is reached.
+          if (
+            babysitBudgetTight
+            || babysitEnqueues >= MAX_BABYSIT_ENQUEUES_PER_SWEEP
+            || inFlightBabysitJobs >= maxConcurrentBabysitRuns
+          ) {
             babysitDeferred += 1;
             continue;
           }
           babysitEnqueues += 1;
+          inFlightBabysitJobs += 1;
           await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
             phase: "watcher",
             metadata: { repo: repoSlug },
@@ -2350,7 +2370,11 @@ export class PRBabysitter {
             repo: repoSlug,
             deferred: babysitDeferred,
             enqueued: babysitEnqueues,
-            reason: babysitBudgetTight ? "core budget reserve" : "per-sweep cap",
+            reason: babysitBudgetTight
+              ? "core budget reserve"
+              : inFlightBabysitJobs >= maxConcurrentBabysitRuns
+                ? "concurrency cap"
+                : "per-sweep cap",
           },
           "Deferred babysit runs to a later sweep to pace GitHub usage",
         );
@@ -2374,12 +2398,25 @@ export class PRBabysitter {
     const MAX_ATTEMPTS = 10;
     const pollIntervalMs = this.runtime.ciPollIntervalMs ?? 30_000;
 
+    // One CI status check. Attempt 1 runs at default (high) priority; re-polls
+    // run at "low" so the GitHub budget-reserve guard can defer them when core
+    // quota is tight instead of draining it on a PR that hasn't settled yet.
+    const pollOnce = (priority: "high" | "low"): Promise<CiPollResult> => {
+      const fetchResult = (): Promise<CiPollResult> =>
+        this.github.fetchCiPollResult
+          ? this.github.fetchCiPollResult(octokit, repo, headSha)
+          : Promise.all([
+              this.github.checkCISettled(octokit, repo, headSha),
+              this.github.listFailingStatuses(octokit, repo, headSha),
+            ]).then(([settled, failures]) => ({ settled, failures }));
+      return priority === "high" ? fetchResult() : runWithRequestPriority("low", fetchResult);
+    };
+
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       await wait(pollIntervalMs);
 
       try {
-        const settled = await this.github.checkCISettled(octokit, repo, headSha);
-        const failures = await this.github.listFailingStatuses(octokit, repo, headSha);
+        const { settled, failures } = await pollOnce(attempt === 1 ? "high" : "low");
 
         await queueLog(prId, "info", `CI poll attempt ${attempt}/${MAX_ATTEMPTS}: ${failures.length} failure(s), settled=${settled}`, {
           phase: "verify.ci",

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -33,6 +33,7 @@ export const DEFAULT_CONFIG: Config = {
   deploymentCheckPollIntervalMs: 60000,
   maxConcurrentIssueEvaluations: 2,
   maxConcurrentIssueWork: 1,
+  maxConcurrentBabysitRuns: 3,
   watchedRepos: [],
   trustedReviewers: [],
   priorityIssueAuthors: [],

--- a/server/github.ts
+++ b/server/github.ts
@@ -57,6 +57,7 @@ export type GitHubPullSummary = {
   baseRef: string;
   baseSha: string;
   mergeable: boolean | null;
+  mergeableState: string | null;
 };
 
 export type GitHubIssueSummary = {
@@ -1398,6 +1399,7 @@ export async function fetchPullSummary(
     baseRef,
     baseSha: pull.base?.sha || "",
     mergeable: typeof pull.mergeable === "boolean" ? pull.mergeable : null,
+    mergeableState: typeof pull.mergeable_state === "string" ? pull.mergeable_state : null,
   };
 }
 
@@ -2132,6 +2134,7 @@ function mapPullToSummary(pull: GitHubPullListItem, repo: ParsedRepoSlug): GitHu
     baseRef: pull.base?.ref || pull.base?.repo?.default_branch || "",
     baseSha: pull.base?.sha || "",
     mergeable: null,
+    mergeableState: null,
   };
 }
 
@@ -2615,6 +2618,64 @@ export async function checkCISettled(
   } catch {
     return false;
   }
+}
+
+export type CiPollResult = {
+  settled: boolean;
+  failures: GitHubStatusFailure[];
+};
+
+/**
+ * Single-fetch CI status check for the verification poll loop. Fetches commit
+ * statuses and check runs once, then derives both "settled" and the failure
+ * list — replacing a separate checkCISettled + listFailingStatuses pair that
+ * fetched the same two endpoints twice per poll attempt.
+ */
+export async function fetchCiPollResult(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  headSha: string,
+): Promise<CiPollResult> {
+  if (!headSha) return { settled: false, failures: [] };
+
+  const [statusResponse, checkRunsResponse] = await Promise.all([
+    withGitHubErrorHandling("commit statuses", repo, () => octokit.repos.getCombinedStatusForRef({
+      owner: repo.owner,
+      repo: repo.repo,
+      ref: headSha,
+    })),
+    withGitHubErrorHandling("check runs", repo, () => octokit.checks.listForRef({
+      owner: repo.owner,
+      repo: repo.repo,
+      ref: headSha,
+    })),
+  ]);
+
+  const statuses = statusResponse.data.statuses;
+  const checkRuns = checkRunsResponse.data.check_runs;
+
+  const failures: GitHubStatusFailure[] = [
+    ...statuses
+      .filter((status) => status.state === "failure" || status.state === "error")
+      .map((status) => ({
+        context: status.context || "status-check",
+        description: status.description || "Failed status check",
+        targetUrl: status.target_url || null,
+      })),
+    ...checkRuns
+      .filter((run) => run.conclusion === "failure" || run.conclusion === "timed_out" || run.conclusion === "cancelled")
+      .map((run) => ({
+        context: run.name,
+        description: run.output?.summary || run.output?.title || `Check run ${run.conclusion}`,
+        targetUrl: run.html_url || null,
+      })),
+  ];
+
+  const hasAnyChecks = statuses.length > 0 || checkRuns.length > 0;
+  const hasPending = statuses.some((s) => s.state === "pending")
+    || checkRuns.some((r) => r.status !== "completed");
+
+  return { settled: hasAnyChecks && !hasPending, failures };
 }
 
 export type MergedPRSummary = {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -100,6 +100,7 @@ type ConfigRow = {
   deployment_check_poll_interval_ms: number;
   max_concurrent_issue_evaluations: number;
   max_concurrent_issue_work: number;
+  max_concurrent_babysit_runs: number;
   trusted_reviewers_json: string;
   priority_issue_authors_json: string;
   ignored_bots_json: string;
@@ -967,6 +968,7 @@ export class SqliteStorage implements IStorage {
     this.exec("UPDATE watched_repos SET issue_auto_evaluate = 1 WHERE issue_auto_work = 1 AND issue_auto_evaluate = 0");
     this.ensureColumn("config", "max_concurrent_issue_evaluations", "INTEGER NOT NULL DEFAULT 2");
     this.ensureColumn("config", "max_concurrent_issue_work", "INTEGER NOT NULL DEFAULT 1");
+    this.ensureColumn("config", "max_concurrent_babysit_runs", "INTEGER NOT NULL DEFAULT 3");
     this.ensureColumn("config", "priority_issue_authors_json", "TEXT NOT NULL DEFAULT '[]'");
     this.ensureColumn("synced_issues", "is_worked", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("release_runs", "source", "TEXT NOT NULL DEFAULT 'automatic'");
@@ -1087,6 +1089,7 @@ export class SqliteStorage implements IStorage {
       deploymentCheckPollIntervalMs: row.deployment_check_poll_interval_ms ?? DEFAULT_CONFIG.deploymentCheckPollIntervalMs,
       maxConcurrentIssueEvaluations: row.max_concurrent_issue_evaluations ?? DEFAULT_CONFIG.maxConcurrentIssueEvaluations,
       maxConcurrentIssueWork: row.max_concurrent_issue_work ?? DEFAULT_CONFIG.maxConcurrentIssueWork,
+      maxConcurrentBabysitRuns: row.max_concurrent_babysit_runs ?? DEFAULT_CONFIG.maxConcurrentBabysitRuns,
       watchedRepos,
       trustedReviewers: JSON.parse(row.trusted_reviewers_json),
       priorityIssueAuthors: parseStringArrayJson(row.priority_issue_authors_json),
@@ -1140,10 +1143,11 @@ export class SqliteStorage implements IStorage {
           deployment_check_poll_interval_ms,
           max_concurrent_issue_evaluations,
           max_concurrent_issue_work,
+          max_concurrent_babysit_runs,
           trusted_reviewers_json,
           priority_issue_authors_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -1179,6 +1183,7 @@ export class SqliteStorage implements IStorage {
           deployment_check_poll_interval_ms = excluded.deployment_check_poll_interval_ms,
           max_concurrent_issue_evaluations = excluded.max_concurrent_issue_evaluations,
           max_concurrent_issue_work = excluded.max_concurrent_issue_work,
+          max_concurrent_babysit_runs = excluded.max_concurrent_babysit_runs,
           trusted_reviewers_json = excluded.trusted_reviewers_json,
           priority_issue_authors_json = excluded.priority_issue_authors_json,
           ignored_bots_json = excluded.ignored_bots_json
@@ -1218,6 +1223,7 @@ export class SqliteStorage implements IStorage {
         config.deploymentCheckPollIntervalMs,
         config.maxConcurrentIssueEvaluations,
         config.maxConcurrentIssueWork,
+        config.maxConcurrentBabysitRuns,
         JSON.stringify(config.trustedReviewers),
         JSON.stringify(config.priorityIssueAuthors),
         JSON.stringify(config.ignoredBots),
@@ -2003,6 +2009,7 @@ export class SqliteStorage implements IStorage {
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,
              auto_heal_deployments, deployment_check_delay_ms, deployment_check_timeout_ms,
              deployment_check_poll_interval_ms, max_concurrent_issue_evaluations, max_concurrent_issue_work,
+             max_concurrent_babysit_runs,
              trusted_reviewers_json, priority_issue_authors_json, ignored_bots_json
       FROM config
       WHERE id = 1

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -652,6 +652,7 @@ export const configSchema = z.object({
   deploymentCheckPollIntervalMs: z.number(),
   maxConcurrentIssueEvaluations: z.number().int().positive().default(2),
   maxConcurrentIssueWork: z.number().int().positive().default(1),
+  maxConcurrentBabysitRuns: z.number().int().positive().default(3),
   watchedRepos: z.array(z.string()),
   trustedReviewers: z.array(z.string()),
   priorityIssueAuthors: z.array(z.string()),


### PR DESCRIPTION
## Summary

Bundles fixes from a GitHub rate-limit debugging session. The app's core REST budget was draining into its reserve band under heavy background work; separately, work PRs were being shown "ready to merge" while CI was red.

**GitHub budget pressure**
- **Dedup CI verification fetches** — `verifyCi` polled `checkCISettled` + `listFailingStatuses` back-to-back, which fetched the same statuses + check-runs endpoints twice. New `fetchCiPollResult` does one fetch per attempt, ~halving a 10-attempt round's core REST cost.
- **Cap babysitter concurrency** — `babysit_pr` had no concurrency limit; N PRs babysat in parallel unbounded. New `maxConcurrentBabysitRuns` config (default 3) caps in-flight jobs across the watcher sweep; excess PRs defer to a later sweep. Exposed in Settings → Agent → Tuning.
- **Low-priority CI re-polls** — poll attempts 2-10 now run at `"low"` request priority so the budget-reserve guard can defer them under core-quota pressure instead of only throttling the background sweep.

**Merge-readiness accuracy**
- A work PR was marked "ready to merge" from GitHub's `mergeable` boolean, which only reflects merge conflicts and stays `true` when CI is failing. Now uses `mergeable_state`, treating only `"clean"` as ready (`"unknown"`/missing → undecided).

**Issues page liveness**
- The activity panel and runtime state now poll local-only endpoints every 5s, so counts update without a manual refresh (no GitHub cost).
- The issue-list poll now considers all loaded pages, not just page 1.
- Each activity row shows a PR/issue work-type badge.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Full server suite passes (615 tests), incl. new `deriveWorkPrMergeable` and babysitter concurrency-cap tests
- [ ] Browser-verify: activity panel updates live; Settings "Max concurrent babysit runs" saves; a PR with red CI no longer shows under the READY TO MERGE filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)