### PR TITLE
fix: stop registering out-of-scope and unwatched-repo PRs

### DIFF
--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -2083,7 +2083,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       }
 
       const fullSweep = options?.fullSweep === true;
-      await babysitter.syncAndBabysitTrackedRepos({ includeAllOpenPrs: true, fullSweep });
+      await babysitter.syncAndBabysitTrackedRepos({ fullSweep });
       await syncStoredIssuesStep({ fullSweep });
       notifyChange();
       return { ok: true as const };

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -369,6 +369,7 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
 
 test("syncAndBabysitTrackedRepos deprioritizes a repo whose PR list is unchanged", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   await storage.addPR({
     number: 1,
     title: "Tracked PR",
@@ -441,6 +442,7 @@ test("syncAndBabysitTrackedRepos deprioritizes a repo whose PR list is unchanged
 
 test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   await storage.addPR({
     number: 1,
     title: "Tracked PR",
@@ -512,6 +514,7 @@ test("syncAndBabysitTrackedRepos reuses the cached PR list on a conditional 304"
 
 test("syncAndBabysitTrackedRepos persists a backoff when listing open PRs fails", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   await storage.addPR({
     number: 7,
     title: "Tracked PR",
@@ -609,6 +612,7 @@ test("syncAndBabysitTrackedRepos queues release evaluation for merged archived P
 
 test("syncAndBabysitTrackedRepos supersedes active healing sessions when archiving closed PRs", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const pr = await storage.addPR({
     number: 43,
     title: "Closed PR with active healing",
@@ -716,6 +720,7 @@ test("syncAndBabysitTrackedRepos does not enqueue social changelog generation", 
 
 test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background scheduler is provided", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const backgroundJobQueue = new BackgroundJobQueue(storage);
 
   const pr = await storage.addPR({
@@ -1051,6 +1056,7 @@ test("syncAndBabysitTrackedRepos does not duplicate drain sync after metadata re
 
 test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const backgroundJobQueue = new BackgroundJobQueue(storage);
   const pr = await storage.addPR({
     number: 42,
@@ -1149,6 +1155,7 @@ test("syncAndBabysitTrackedRepos skips same-head dependency preflight failures",
 
 test("syncAndBabysitTrackedRepos skips terminal conflict repair failures for the same head and base", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const backgroundJobQueue = new BackgroundJobQueue(storage);
   const pr = await storage.addPR({
     number: 42,
@@ -1240,6 +1247,7 @@ test("syncAndBabysitTrackedRepos skips terminal conflict repair failures for the
 
 test("syncAndBabysitTrackedRepos does not repeat terminal conflict logs for PRs already in error", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const backgroundJobQueue = new BackgroundJobQueue(storage);
   const pr = await storage.addPR({
     number: 42,
@@ -1334,6 +1342,7 @@ test("syncAndBabysitTrackedRepos does not repeat terminal conflict logs for PRs 
 
 test("syncAndBabysitTrackedRepos resumes after terminal conflict repair when head or base changes", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const backgroundJobQueue = new BackgroundJobQueue(storage);
   const now = new Date().toISOString();
   const prs = await Promise.all([43, 44].map((number) => storage.addPR({
@@ -1584,7 +1593,7 @@ test("syncAndBabysitTrackedRepos skips automatic babysits when pr watch is pause
 
 test("syncAndBabysitTrackedRepos caps feedback sync attempts per tick while automation is paused", async () => {
   const storage = new MemStorage();
-  await storage.updateConfig({ autoPrs: false, autoIssues: true });
+  await storage.updateConfig({ autoPrs: false, autoIssues: true, watchedRepos: ["octo/example"] });
   const feedbackFetchTargets: number[] = [];
 
   const pulls = Array.from({ length: 30 }, (_, index) => ({
@@ -1764,6 +1773,7 @@ test("syncAndBabysitTrackedRepos returns early while drain mode is enabled", asy
 
 test("syncAndBabysitTrackedRepos resumes automatic babysits when pr watch is re-enabled", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const babysitCalls: string[] = [];
 
   const pr = await storage.addPR({
@@ -1958,6 +1968,7 @@ test("syncAndBabysitTrackedRepos does not enter drain mode for transient agent h
 
 test("syncAndBabysitTrackedRepos does not queue release evaluation for closed-unmerged PRs", async () => {
   const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"] });
   const queued: Array<Record<string, string | number>> = [];
 
   const pr = await storage.addPR({

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1850,8 +1850,7 @@ export class PRBabysitter {
     return updated;
   }
 
-  async syncAndBabysitTrackedRepos(options?: { includeAllOpenPrs?: boolean; fullSweep?: boolean }): Promise<void> {
-    const includeAllOpenPrs = options?.includeAllOpenPrs === true;
+  async syncAndBabysitTrackedRepos(options?: { fullSweep?: boolean }): Promise<void> {
     const fullSweep = options?.fullSweep === true;
     const [runtimeState, configEarly] = await Promise.all([
       this.storage.getRuntimeState(),
@@ -1885,10 +1884,10 @@ export class PRBabysitter {
 
     const currentConfig = await this.storage.getConfig();
     const tracked = await this.storage.getPRs();
-    const repoCandidates = new Set<string>([
-      ...tracked.map((pr) => pr.repo),
-      ...currentConfig.watchedRepos,
-    ]);
+    // Only sweep repos that are currently watched. A repo removed from
+    // settings must drop out of scope even if it still has tracked PRs —
+    // otherwise an unwatched repo can never actually leave automation.
+    const repoCandidates = new Set<string>(currentConfig.watchedRepos);
     const selectedAgent = currentConfig.codingAgent as CodingAgent;
     const watchedPrIds = tracked
       .filter((pr) => pr.watchEnabled !== false && pr.status !== "archived")
@@ -2164,7 +2163,10 @@ export class PRBabysitter {
       for (const pull of openPulls) {
         let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
         if (!local) {
-          if (!automationScopeNumbers.has(pull.number) && !includeAllOpenPrs) {
+          // Register only PRs in automation scope — automationScopeNumbers
+          // already honors the repo's ownPrsOnly setting, so a manual sync
+          // never persists pull requests authored by other people.
+          if (!automationScopeNumbers.has(pull.number)) {
             continue;
           }
 


### PR DESCRIPTION
## Summary

A manual SYNC (or FULL SWEEP) was registering **every open PR** on every repo PatchDeck knew about — including PRs authored by other people, and PRs in repos no longer in watched settings. This is why PRs from an unwatched repo (`gsd-build/get-shit-done`) appeared in the PR list.

Two root causes, both fixed:

**A — registration ignored `ownPrsOnly`.** `syncRepos()` always called the babysitter with `includeAllOpenPrs: true`, which bypassed the registration gate in `syncAndBabysitTrackedRepos`. So `addPR` ran for every open PR regardless of author; the `ownPrsOnly` check only gated *babysitting*, after the PR was already persisted. Registration is now gated solely by `automationScopeNumbers`, which already honors `ownPrsOnly`. The now-unused `includeAllOpenPrs` option is removed.

**B — unwatched repos never left scope.** The sweep built `repoCandidates` from every tracked PR's repo plus the watched repos. A repo removed from settings stayed in scope as long as it had any tracked PR — and since (A) kept registering strangers' PRs there, it pinned itself in scope permanently. `repoCandidates` is now the watched repos only.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Full server suite passes (613) — 12 `syncAndBabysitTrackedRepos` tests updated to watch their PR's repo (they previously relied on the tracked-repo fallback that B removes)
- [ ] After deploy: confirm a manual sync no longer registers non-authored PRs

## Follow-up: data cleanup

Existing orphaned rows are not removed by this change. After deploying, hard-remove the orphaned repo:

```
DELETE /api/repos/settings/gsd-build%2Fget-shit-done?mode=hard
```

(deletes its ~18 stored PRs; do this *after* the server is on the new code so a sync doesn't re-add them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)