### PR TITLE
chore: add username to PR bodies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,9 @@
 - Closes #<issue-number>
 - [#<issue-number> <issue-title>](<issue-url>)
 
+## User
+- @<username>
+
 ## Repo
 - <owner/repo>
 

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -312,6 +312,8 @@ test("work_issue handler opens a PR after a successful repair run", async () => 
   assert.match(String(pullsCreated[0]?.body), /## Summary/);
   assert.match(String(pullsCreated[0]?.body), /## Verification/);
   assert.match(String(pullsCreated[0]?.body), /Closes #17/);
+  assert.match(String(pullsCreated[0]?.body), /## User/);
+  assert.match(String(pullsCreated[0]?.body), /@alice/);
   assert.match(String(pullsCreated[0]?.body), /## Repo/);
   assert.match(String(pullsCreated[0]?.body), /## Branch/);
   assert.equal(commentsCreated.length, 3);

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -552,6 +552,7 @@ export function createBackgroundJobHandlers(params: {
           issueTitle: issue.title,
           issueUrl: issue.url,
           summary: repairResult.summary,
+          author: issue.author,
           branch: repairResult.fixBranch,
           subtasks: repairResult.subtasks,
         }),

--- a/server/issueFormatter.test.ts
+++ b/server/issueFormatter.test.ts
@@ -10,6 +10,7 @@ const input = {
   prNumber: 88,
   prUrl: "https://github.com/acme/widgets/pull/88",
   branch: "issue/17-fix-the-toggle-123",
+  author: "alice",
   summary: "Updated the toggle state.\nVerified the state transition with the targeted test.",
 };
 
@@ -35,8 +36,16 @@ test("buildPullRequestBody renders a structured PR body with related issue detai
   assert.match(body, /## Related Issue/);
   assert.match(body, /Closes #17/);
   assert.match(body, /\[#17 Fix the toggle\]\(https:\/\/github.com\/acme\/widgets\/issues\/17\)/);
+  assert.match(body, /## User/);
+  assert.match(body, /@alice/);
   assert.match(body, /## Repo/);
   assert.match(body, /## Branch/);
+});
+
+test("buildPullRequestBody normalizes an issue author into a GitHub mention", () => {
+  const body = buildPullRequestBody({ ...input, author: "@Alice" });
+
+  assert.match(body, /- @Alice/);
 });
 
 test("buildIssueWorkStatusComment renders the issue workflow milestones", () => {

--- a/server/issueFormatter.ts
+++ b/server/issueFormatter.ts
@@ -19,6 +19,11 @@ function bulletLines(lines: string[]): string[] {
   return lines.map((line) => `- ${line}`);
 }
 
+function formatGitHubMention(login: string | null | undefined): string {
+  const trimmed = login?.trim().replace(/^@/, "");
+  return trimmed ? `@${trimmed}` : "@unknown";
+}
+
 function redactLocalPaths(text: string): string {
   return text
     .replace(/(?:[A-Za-z]:\\(?:[^\\\s`'"]+\\)+[^\\\s`'"]+|\/(?:Users|home|Volumes|private|var|tmp|opt|usr|Applications|Library)(?:\/[^\s`'"]+)+)/g, "[path redacted]");
@@ -30,6 +35,7 @@ type IssueWorkBodyInput = {
   issueTitle: string;
   issueUrl: string;
   summary: string;
+  author?: string | null;
 };
 
 type IssueReplyBodyInput = IssueWorkBodyInput & {
@@ -105,6 +111,9 @@ export function buildPullRequestBody(input: PullRequestBodyInput): string {
     "## Related Issue",
     `- Closes #${input.issueNumber}`,
     `- [#${input.issueNumber} ${input.issueTitle}](${input.issueUrl})`,
+    "",
+    "## User",
+    `- ${formatGitHubMention(input.author)}`,
     "",
     "## Repo",
     `- \`${input.repoFullName}\``,


### PR DESCRIPTION
## Summary
- add a User section with @username to the pull request template
- include the issue author mention in generated issue-work PR bodies
- cover the generated PR body in formatter and background job tests

## Verification
- npm run check
- node --import tsx --test server/issueFormatter.test.ts server/backgroundJobHandlers.test.ts