### PR TITLE
fix: keep worked issues synced

### DIFF
--- a/client/src/lib/prReadiness.test.ts
+++ b/client/src/lib/prReadiness.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { FeedbackItem, PR, PRSummary } from "@shared/schema";
+import {
+  isGitHubReadyToMerge,
+  isPRDetailReadyToMerge,
+  isPRSummaryReadyToMerge,
+} from "./prReadiness";
+
+const resolvedFeedback = [{
+  id: "1",
+  prId: "pr-1",
+  author: "reviewer",
+  body: "done",
+  bodyHtml: "<p>done</p>",
+  replyKind: "general_comment",
+  sourceId: "comment-1",
+  sourceNodeId: null,
+  sourceUrl: null,
+  threadId: null,
+  threadResolved: null,
+  auditToken: "audit",
+  file: null,
+  line: null,
+  type: "comment",
+  createdAt: "2026-05-16T18:00:00.000Z",
+  decision: "accepted",
+  decisionReason: null,
+  action: null,
+  status: "resolved",
+  statusReason: null,
+}] satisfies FeedbackItem[];
+
+function makePr(overrides: Partial<PR> = {}): PR {
+  return {
+    id: "pr-1",
+    number: 42,
+    title: "PR",
+    body: null,
+    bodyHtml: null,
+    repo: "owner/repo",
+    branch: "feature",
+    author: "alice",
+    url: "https://github.com/owner/repo/pull/42",
+    status: "done",
+    feedbackItems: resolvedFeedback,
+    accepted: 1,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: true,
+    lintPassed: true,
+    mergeableState: "clean",
+    lastChecked: "2026-05-16T18:00:00.000Z",
+    lastSyncAttemptedAt: null,
+    lastSyncSucceededAt: null,
+    lastSyncError: null,
+    watchEnabled: true,
+    addedAt: "2026-05-16T18:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("isGitHubReadyToMerge only treats GitHub clean state as ready", () => {
+  assert.equal(isGitHubReadyToMerge({ mergeableState: "clean" }), true);
+  assert.equal(isGitHubReadyToMerge({ mergeableState: "blocked" }), false);
+  assert.equal(isGitHubReadyToMerge({ mergeableState: "dirty" }), false);
+  assert.equal(isGitHubReadyToMerge({ mergeableState: null }), false);
+});
+
+test("isPRDetailReadyToMerge requires comments, checks, lint, and GitHub ready state", () => {
+  assert.equal(isPRDetailReadyToMerge(makePr()), true);
+  assert.equal(isPRDetailReadyToMerge(makePr({ testsPassed: false })), false);
+  assert.equal(isPRDetailReadyToMerge(makePr({ lintPassed: false })), false);
+  assert.equal(isPRDetailReadyToMerge(makePr({ mergeableState: "blocked" })), false);
+  assert.equal(isPRDetailReadyToMerge(makePr({ feedbackItems: [] })), false);
+  assert.equal(isPRDetailReadyToMerge(makePr({ status: "processing" })), false);
+});
+
+test("isPRSummaryReadyToMerge uses stored checks and GitHub ready state", () => {
+  const summary = makePr();
+  const { feedbackItems: _feedbackItems, ...base } = summary;
+
+  assert.equal(isPRSummaryReadyToMerge(base satisfies PRSummary), true);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, testsPassed: null }), false);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, lintPassed: null }), false);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, mergeableState: "unstable" }), false);
+});

--- a/client/src/lib/prReadiness.ts
+++ b/client/src/lib/prReadiness.ts
@@ -1,0 +1,25 @@
+import type { PR, PRSummary } from "@shared/schema";
+import { isPRReadyToMerge } from "@/lib/feedbackStatus";
+
+export function isGitHubReadyToMerge(pr: Pick<PRSummary, "mergeableState">): boolean {
+  return pr.mergeableState === "clean";
+}
+
+export function isPRSummaryReadyToMerge(
+  pr: Pick<PRSummary, "status" | "testsPassed" | "lintPassed" | "mergeableState">,
+): boolean {
+  return pr.status === "done"
+    && pr.testsPassed === true
+    && pr.lintPassed === true
+    && isGitHubReadyToMerge(pr);
+}
+
+export function isPRDetailReadyToMerge(
+  pr: Pick<PR, "status" | "testsPassed" | "lintPassed" | "mergeableState" | "feedbackItems">,
+): boolean {
+  return pr.status !== "processing"
+    && pr.testsPassed === true
+    && pr.lintPassed === true
+    && isGitHubReadyToMerge(pr)
+    && isPRReadyToMerge(pr.feedbackItems);
+}

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -16,8 +16,11 @@ import {
   getFeedbackStatusBadgeClass,
   isFeedbackCollapsedByDefault,
   countActiveFeedbackStatuses,
-  isPRReadyToMerge,
 } from "@/lib/feedbackStatus";
+import {
+  isPRDetailReadyToMerge,
+  isPRSummaryReadyToMerge,
+} from "@/lib/prReadiness";
 import {
   getHealingSessionView,
   selectRelevantHealingSession,
@@ -70,8 +73,7 @@ type PrStatusFilter = "all" | "ready" | "ci_failing" | "attention" | "processing
 function matchesPrStatusFilter(pr: PRSummary, filter: PrStatusFilter): boolean {
   switch (filter) {
     case "ready":
-      // No mergeable_state on the stored PR — "done with green CI" is the proxy.
-      return pr.status === "done" && pr.testsPassed === true && pr.lintPassed === true;
+      return isPRSummaryReadyToMerge(pr);
     case "ci_failing":
       return pr.testsPassed === false || pr.lintPassed === false;
     case "attention":
@@ -1591,7 +1593,7 @@ export default function Dashboard() {
                 ) : undefined}
                 banner={(
                   <>
-                    {isPRReadyToMerge(selectedPR.feedbackItems) && selectedPR.status !== "processing" && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
+                    {isPRDetailReadyToMerge(selectedPR) && (
                       <ReadyToMergeIndicator
                         href={selectedPR.url}
                         testId="detail-ready-to-merge"

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -4,6 +4,7 @@ import type { NewPR } from "@shared/schema";
 import {
   createAppRuntime,
   deriveWorkPrMergeable,
+  getCurrentIssueEvaluationForLabels,
   getIssueAutoWorkEligibility,
   issueWorkAttemptCountFromJobs,
   issueWorkPrFromLogs,
@@ -335,6 +336,34 @@ test("getIssueAutoWorkEligibility requires a ready label, app approval, and no b
   });
 });
 
+test("getCurrentIssueEvaluationForLabels ignores stale blocked-label evaluations", () => {
+  assert.equal(getCurrentIssueEvaluationForLabels({ labels: ["needs-triage"] }, {
+    status: "blocked",
+    summary: "Blocked from automatic work by label: needs-maintainer-review.",
+    safetyFlags: ["blocked-label:needs-maintainer-review"],
+  }), null);
+
+  assert.deepEqual(getCurrentIssueEvaluationForLabels({ labels: ["needs-maintainer-review"] }, {
+    status: "blocked",
+    summary: "Blocked from automatic work by label: needs-maintainer-review.",
+    safetyFlags: ["blocked-label:needs-maintainer-review"],
+  }), {
+    status: "blocked",
+    summary: "Blocked from automatic work by label: needs-maintainer-review.",
+    safetyFlags: ["blocked-label:needs-maintainer-review"],
+  });
+
+  assert.deepEqual(getCurrentIssueEvaluationForLabels({ labels: ["needs-triage"] }, {
+    status: "blocked",
+    summary: "Blocked from automatic work because the issue asks for risky secret, network, or destructive behavior.",
+    safetyFlags: ["blocked-label:needs-maintainer-review", "secret-access"],
+  }), {
+    status: "blocked",
+    summary: "Blocked from automatic work because the issue asks for risky secret, network, or destructive behavior.",
+    safetyFlags: ["blocked-label:needs-maintainer-review", "secret-access"],
+  });
+});
+
 test("deriveWorkPrMergeable only treats a clean PR as ready to merge", () => {
   // "clean" is the only state where conflicts, required checks, and required
   // reviews are all satisfied — so it is the only one that counts as ready.
@@ -660,6 +689,83 @@ test("syncRepos syncs issues and persists the new etag when the issue list chang
     'W/"issues-v1"',
     "a successful sweep should persist the fresh etag for next tick",
   );
+});
+
+test("syncIssue refreshes worked issue metadata from GitHub", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.upsertSyncedIssues("owner/repo", [{
+    number: 7,
+    title: "Old title",
+    body: "old body",
+    bodyHtml: null,
+    url: "https://github.com/owner/repo/issues/7",
+    repoFullName: "owner/repo",
+    repoCloneUrl: "https://github.com/owner/repo.git",
+    author: "alice",
+    labels: ["needs-maintainer-review"],
+    assignees: [],
+    comments: 0,
+    createdAt: "2026-05-03T17:00:00.000Z",
+    updatedAt: "2026-05-03T18:00:00.000Z",
+  }], "2026-05-03T18:00:00.000Z");
+  await storage.markSyncedIssueWorked("owner/repo", 7);
+  await storage.upsertIssueEvaluation({
+    targetId: "owner/repo#7",
+    repo: "owner/repo",
+    issueNumber: 7,
+    status: "blocked",
+    confidence: 0.95,
+    summary: "Blocked from automatic work by label: needs-maintainer-review.",
+    safetyFlags: ["blocked-label:needs-maintainer-review"],
+    recommendedLabels: ["needs-maintainer-review", "blocked"],
+    markerCommentId: null,
+  });
+
+  let issueFetches = 0;
+  const fakeOctokit = {
+    issues: {
+      get: async () => {
+        issueFetches += 1;
+        return {
+          data: {
+            number: 7,
+            title: "Fresh title",
+            body: "fresh body",
+            html_url: "https://github.com/owner/repo/issues/7",
+            user: { login: "alice" },
+            labels: [{ name: "needs-triage" }],
+            assignees: [],
+            comments: 2,
+            created_at: "2026-05-03T17:00:00.000Z",
+            updated_at: "2026-05-16T18:00:00.000Z",
+          },
+        };
+      },
+    },
+    paginate: async () => [],
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  const synced = await runtime.syncIssue("owner/repo", 7);
+
+  assert.equal(issueFetches, 1, "manual issue sync must fetch GitHub even when the issue is already worked");
+  assert.equal(synced.isWorked, true);
+  assert.equal(synced.title, "Fresh title");
+  assert.deepEqual(synced.labels, ["needs-triage"]);
+  assert.equal(synced.evaluationStatus, null, "stale blocked-label evaluation should not survive label refresh");
+  assert.equal(synced.autoWorkBlockedReason, "missing ready-for-agent label");
+
+  const stored = await storage.getSyncedIssue("owner/repo", 7);
+  assert.equal(stored?.isWorked, true, "refresh must preserve the worked marker");
+  assert.equal(stored?.payload.title, "Fresh title");
 });
 
 test("pickWatcherColdStartDelayMs stays within the 15-45s cold-start window", () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -440,6 +440,31 @@ export function getIssueAutoWorkEligibility(
   };
 }
 
+export function getCurrentIssueEvaluationForLabels<T extends Pick<IssueEvaluation, "status" | "summary" | "safetyFlags">>(
+  issue: Pick<Issue, "labels">,
+  evaluation?: T | null,
+): T | null {
+  if (!evaluation) {
+    return null;
+  }
+
+  const currentLabels = new Set(issue.labels.map(normalizeIssueLabel).filter(Boolean));
+  const blockedLabelFlags = evaluation.safetyFlags
+    .map((flag) => flag.trim().toLowerCase())
+    .filter((flag) => flag.startsWith("blocked-label:"));
+
+  if (
+    evaluation.status === "blocked"
+    && blockedLabelFlags.length > 0
+    && evaluation.safetyFlags.length === blockedLabelFlags.length
+    && blockedLabelFlags.some((flag) => !currentLabels.has(flag.slice("blocked-label:".length)))
+  ) {
+    return null;
+  }
+
+  return evaluation;
+}
+
 /**
  * Maps a GitHub pull request `mergeable_state` to the "ready to merge" flag.
  * GitHub's `mergeable` boolean only reflects merge conflicts — it stays true
@@ -964,7 +989,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       });
     }
 
-    const octokit = await buildOctokit(config);
+    const octokit = await buildOctokitImpl(config);
     const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });
     const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
     const priority = isPriorityIssueAuthor(issue.author, config.priorityIssueAuthors)
@@ -1024,7 +1049,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       });
     }
 
-    const octokit = await buildOctokit(config);
+    const octokit = await buildOctokitImpl(config);
     const issueSummary = await fetchIssueSummary(octokit, { ...parsedRepo, number });
     const enriched = await applyIssueWorkState(issueSummary);
     const targetId = formatIssueTargetId(issueSummary.repoFullName, issueSummary.number);
@@ -1176,7 +1201,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     const latestJob = getLatestBackgroundJob(issueJobs);
     const workState = issueWorkStatusFromJobs(issueJobs);
     const workLogs = latestJob ? await storage.getLogs(targetId) : [];
-    const evaluation = await storage.getIssueEvaluation(targetId);
+    const storedEvaluation = await storage.getIssueEvaluation(targetId);
+    const evaluation = getCurrentIssueEvaluationForLabels({
+      labels: issue.labels,
+    }, storedEvaluation);
     const subtaskSet = await storage.getIssueSubtasks(targetId);
     const readyPr = latestJob?.status === "completed"
       ? issueWorkPrFromLogs(workLogs, issue.repoFullName)
@@ -1200,8 +1228,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const parsedPr = parsePRUrl(readyPr.workPrUrl);
       if (parsedPr) {
         try {
-          const config = await storage.getConfig();
-          const octokit = await buildOctokit(config);
+          const octokit = options.octokit ?? await buildOctokitImpl(await storage.getConfig());
           const pull = await fetchPullSummary(octokit, parsedPr);
           workPrMergeable = deriveWorkPrMergeable(pull.mergeableState);
         } catch (error) {
@@ -1373,7 +1400,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const targetId = formatIssueTargetId(issue.repoFullName, issue.number);
       const attemptedAt = markIssueSyncAttempt(targetId);
       markIssueSyncSuccess(targetId, attemptedAt);
-      return applyIssueWorkState(issue, { issueJobs: workJobsByTarget.get(targetId) ?? [], octokit, isWorked: record.isWorked });
+      return applyIssueWorkState(issue, {
+        issueJobs: workJobsByTarget.get(targetId) ?? [],
+        includePrMergeability: record.isWorked,
+        octokit,
+        isWorked: record.isWorked,
+      });
     }));
 
     const sortedItems = issuesWithWorkLinks
@@ -1406,7 +1438,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
     }
 
-    const octokit = await buildOctokit(config);
+    const octokit = await buildOctokitImpl(config);
     const targetId = formatIssueTargetId(canonical, number);
     const attemptedAt = markIssueSyncAttempt(targetId);
     try {
@@ -1431,19 +1463,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
     }
 
-    const existing = await storage.getSyncedIssue(canonical, number);
     const targetId = formatIssueTargetId(canonical, number);
     const attemptedAt = markIssueSyncAttempt(targetId);
-    if (existing?.isWorked) {
-      markIssueSyncSuccess(targetId, attemptedAt);
-      return applyIssueWorkState(existing.payload, { includePrMergeability: true, isWorked: true });
-    }
-
-    const octokit = await buildOctokit(config);
+    const octokit = await buildOctokitImpl(config);
+    const existing = await storage.getSyncedIssue(canonical, number);
     const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });
     await storage.upsertSyncedIssues(canonical, [issue], new Date().toISOString());
     markIssueSyncSuccess(targetId, attemptedAt);
-    return applyIssueWorkState(issue, { includePrMergeability: true, octokit });
+    return applyIssueWorkState(issue, { includePrMergeability: true, octokit, isWorked: existing?.isWorked ?? false });
   }
 
   async function updateIssueLabelsInternal(
@@ -2249,6 +2276,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         flagged: 0,
         testsPassed: null,
         lintPassed: null,
+        mergeableState: summary.mergeableState,
         lastChecked: null,
       });
 

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -368,6 +368,71 @@ test("syncFeedbackForPR logs completion even when no new feedback items arrive",
   assert.equal(logs.at(-1)?.message, "GitHub sync complete: 1 feedback item (0 new)");
 });
 
+test("syncFeedbackForPR refreshes PR metadata from GitHub", async () => {
+  const storage = new MemStorage();
+  const existingItem = makeFeedbackItem();
+
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Old PR title",
+    repo: "octo/example",
+    branch: "feature/old",
+    author: "old-author",
+    url: "https://github.com/octo/example/pull/42",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(storage, {
+    buildOctokit: async () => ({}) as never,
+    fetchFeedbackItemsForPR: async () => [existingItem],
+    fetchPullSummary: async () => makePullSummary(pr, {
+      title: "Fresh PR title",
+      body: "fresh body",
+      bodyHtml: "<p>fresh body</p>",
+      branch: "feature/fresh",
+      author: "fresh-author",
+      url: "https://github.com/octo/example/pull/42",
+      repoFullName: "octo/example",
+      mergeableState: "clean",
+    }),
+    listFailingStatuses: async () => {
+      throw new Error("unused in this test");
+    },
+    checkCISettled: async () => {
+      throw new Error("unused in this test");
+    },
+    listOpenPullsForRepo: async () => {
+      throw new Error("unused in this test");
+    },
+    postFollowUpForFeedbackItem: async () => {
+      throw new Error("unused in this test");
+    },
+    resolveReviewThread: async () => {
+      throw new Error("unused in this test");
+    },
+    resolveGitHubAuthToken: async () => undefined,
+    addReactionToComment: async () => {},
+    postStatusReplyForFeedbackItem: async () => null,
+    updateStatusReply: async () => {},
+  });
+
+  const updated = await babysitter.syncFeedbackForPR(pr.id);
+
+  assert.equal(updated.title, "Fresh PR title");
+  assert.equal(updated.body, "fresh body");
+  assert.equal(updated.bodyHtml, "<p>fresh body</p>");
+  assert.equal(updated.branch, "feature/fresh");
+  assert.equal(updated.author, "fresh-author");
+  assert.equal(updated.mergeableState, "clean");
+});
+
 test("syncAndBabysitTrackedRepos deprioritizes a repo whose PR list is unchanged", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ watchedRepos: ["octo/example"] });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1809,11 +1809,21 @@ export class PRBabysitter {
     let refreshedTitle = pr.title;
     let refreshedBody: string | null = pr.body;
     let refreshedBodyHtml: string | null = pr.bodyHtml;
+    let refreshedRepo = pr.repo;
+    let refreshedBranch = pr.branch;
+    let refreshedAuthor = pr.author;
+    let refreshedUrl = pr.url;
+    let refreshedMergeableState = pr.mergeableState;
     try {
       const pullSummary = await this.github.fetchPullSummary(octokit, parsed);
       refreshedTitle = pullSummary.title;
       refreshedBody = pullSummary.body;
       refreshedBodyHtml = pullSummary.bodyHtml;
+      refreshedRepo = pullSummary.repoFullName;
+      refreshedBranch = pullSummary.branch;
+      refreshedAuthor = pullSummary.author;
+      refreshedUrl = pullSummary.url;
+      refreshedMergeableState = pullSummary.mergeableState;
     } catch {
       // Non-fatal: keep existing PR metadata if the summary fetch fails.
     }
@@ -1827,6 +1837,11 @@ export class PRBabysitter {
       title: refreshedTitle,
       body: refreshedBody,
       bodyHtml: refreshedBodyHtml,
+      repo: refreshedRepo,
+      branch: refreshedBranch,
+      author: refreshedAuthor,
+      url: refreshedUrl,
+      mergeableState: refreshedMergeableState,
       prStage: nextPrStage,
       status: pr.status,
       lastChecked: new Date().toISOString(),

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -350,9 +350,6 @@ export class MemStorage implements IStorage {
     for (const issue of issues) {
       const key = `${repo}#${issue.number}`;
       const existing = this.syncedIssues.get(key);
-      if (existing?.isWorked) {
-        continue;
-      }
       this.syncedIssues.set(key, {
         repo,
         number: issue.number,

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -160,6 +160,7 @@ type PRRow = {
   flagged: number;
   tests_passed: number | null;
   lint_passed: number | null;
+  mergeable_state: string | null;
   last_checked: string | null;
   last_sync_attempted_at: string | null;
   last_sync_succeeded_at: string | null;
@@ -619,6 +620,7 @@ export class SqliteStorage implements IStorage {
         flagged INTEGER NOT NULL,
         tests_passed INTEGER,
         lint_passed INTEGER,
+        mergeable_state TEXT,
         last_checked TEXT,
         last_sync_attempted_at TEXT,
         last_sync_succeeded_at TEXT,
@@ -980,6 +982,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("prs", "body", "TEXT");
     this.ensureColumn("prs", "body_html", "TEXT");
     this.ensureColumn("prs", "pr_stage", "TEXT");
+    this.ensureColumn("prs", "mergeable_state", "TEXT");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
     if (!configExists) {
@@ -1295,6 +1298,7 @@ export class SqliteStorage implements IStorage {
       flagged: row.flagged,
       testsPassed: row.tests_passed === null ? null : Boolean(row.tests_passed),
       lintPassed: row.lint_passed === null ? null : Boolean(row.lint_passed),
+      mergeableState: row.mergeable_state ?? null,
       lastChecked: row.last_checked,
       lastSyncAttemptedAt: row.last_sync_attempted_at ?? null,
       lastSyncSucceededAt: row.last_sync_succeeded_at ?? null,
@@ -1323,6 +1327,7 @@ export class SqliteStorage implements IStorage {
       flagged: row.flagged,
       testsPassed: row.tests_passed === null ? null : Boolean(row.tests_passed),
       lintPassed: row.lint_passed === null ? null : Boolean(row.lint_passed),
+      mergeableState: row.mergeable_state ?? null,
       lastChecked: row.last_checked,
       lastSyncAttemptedAt: row.last_sync_attempted_at ?? null,
       lastSyncSucceededAt: row.last_sync_succeeded_at ?? null,
@@ -1656,7 +1661,7 @@ export class SqliteStorage implements IStorage {
   async getPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
       ORDER BY number DESC
@@ -1670,7 +1675,7 @@ export class SqliteStorage implements IStorage {
   async getArchivedPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
       ORDER BY number DESC
@@ -1684,7 +1689,7 @@ export class SqliteStorage implements IStorage {
   async getPRSummaries(): Promise<PRSummary[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status != 'archived'
       ORDER BY number DESC
@@ -1696,7 +1701,7 @@ export class SqliteStorage implements IStorage {
   async getArchivedPRSummaries(): Promise<PRSummary[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE status = 'archived'
       ORDER BY number DESC
@@ -1708,7 +1713,7 @@ export class SqliteStorage implements IStorage {
   async getPR(id: string): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE id = ?
     `, id);
@@ -1724,7 +1729,7 @@ export class SqliteStorage implements IStorage {
   async getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
       FROM prs
       WHERE repo = ? AND number = ?
     `, repo, number);
@@ -1744,8 +1749,8 @@ export class SqliteStorage implements IStorage {
       this.run(`
         INSERT INTO prs (
           id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-          tests_passed, lint_passed, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         full.id,
         full.number,
@@ -1763,6 +1768,7 @@ export class SqliteStorage implements IStorage {
         full.flagged,
         full.testsPassed === null ? null : Number(full.testsPassed),
         full.lintPassed === null ? null : Number(full.lintPassed),
+        full.mergeableState ?? null,
         full.lastChecked,
         full.lastSyncAttemptedAt ?? null,
         full.lastSyncSucceededAt ?? null,
@@ -1789,7 +1795,7 @@ export class SqliteStorage implements IStorage {
       this.run(`
         UPDATE prs
         SET number = ?, title = ?, body = ?, body_html = ?, pr_stage = ?, repo = ?, branch = ?, author = ?, url = ?, status = ?,
-            accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, last_checked = ?,
+            accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, mergeable_state = ?, last_checked = ?,
             last_sync_attempted_at = ?, last_sync_succeeded_at = ?, last_sync_error = ?, watch_enabled = ?, docs_assessment_json = ?
         WHERE id = ?
       `,
@@ -1808,6 +1814,7 @@ export class SqliteStorage implements IStorage {
         updated.flagged,
         updated.testsPassed === null ? null : Number(updated.testsPassed),
         updated.lintPassed === null ? null : Number(updated.lintPassed),
+        updated.mergeableState ?? null,
         updated.lastChecked,
         updated.lastSyncAttemptedAt ?? null,
         updated.lastSyncSucceededAt ?? null,
@@ -2212,7 +2219,6 @@ export class SqliteStorage implements IStorage {
               payload_json = excluded.payload_json,
               is_open = 1,
               last_seen_at = excluded.last_seen_at
-            WHERE synced_issues.is_worked = 0
           `,
           repo,
           issue.number,

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -128,6 +128,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
     flagged: 0,
     testsPassed: null,
     lintPassed: null,
+    mergeableState: "clean",
     lastChecked: null,
     watchEnabled: false,
   });
@@ -263,6 +264,7 @@ test("SqliteStorage reloads config and PR state from the same root", async () =>
   assert.equal(reloadedPr?.feedbackItems[0]?.threadId, "PRRT_kwDO_thread");
   assert.equal(reloadedPr?.feedbackItems[0]?.auditToken, "codefactory-feedback:feedback-1");
   assert.equal(reloadedPr?.accepted, 1);
+  assert.equal(reloadedPr?.mergeableState, "clean");
   assert.equal(reloadedPr?.watchEnabled, false);
   assert.equal(reloadedPr?.docsAssessment?.headSha, "abc123");
   assert.equal(reloadedPr?.docsAssessment?.status, "needed");
@@ -1188,6 +1190,57 @@ test("SqliteStorage stores, overwrites, and clears GitHub etags across reopen", 
     assert.equal(await second.getGithubEtag("issues:open:owner/repo"), undefined);
   } finally {
     second.close();
+  }
+});
+
+test("synced issue upsert refreshes worked issue payloads without clearing worked state", async () => {
+  async function assertRefreshesWorkedIssue(storage: Pick<MemStorage, "upsertSyncedIssues" | "markSyncedIssueWorked" | "getSyncedIssue">) {
+    await storage.upsertSyncedIssues("owner/repo", [{
+      number: 7,
+      title: "Old title",
+      body: null,
+      bodyHtml: null,
+      url: "https://github.com/owner/repo/issues/7",
+      repoFullName: "owner/repo",
+      repoCloneUrl: "https://github.com/owner/repo.git",
+      author: "alice",
+      labels: ["needs-maintainer-review"],
+      assignees: [],
+      comments: 0,
+      createdAt: "2026-05-03T17:00:00.000Z",
+      updatedAt: "2026-05-03T18:00:00.000Z",
+    }], "2026-05-03T18:00:00.000Z");
+    await storage.markSyncedIssueWorked("owner/repo", 7);
+    await storage.upsertSyncedIssues("owner/repo", [{
+      number: 7,
+      title: "Fresh title",
+      body: null,
+      bodyHtml: null,
+      url: "https://github.com/owner/repo/issues/7",
+      repoFullName: "owner/repo",
+      repoCloneUrl: "https://github.com/owner/repo.git",
+      author: "alice",
+      labels: ["needs-triage"],
+      assignees: [],
+      comments: 1,
+      createdAt: "2026-05-03T17:00:00.000Z",
+      updatedAt: "2026-05-16T18:00:00.000Z",
+    }], "2026-05-16T18:00:00.000Z");
+
+    const record = await storage.getSyncedIssue("owner/repo", 7);
+    assert.equal(record?.isWorked, true);
+    assert.equal(record?.payload.title, "Fresh title");
+    assert.deepEqual(record?.payload.labels, ["needs-triage"]);
+  }
+
+  await assertRefreshesWorkedIssue(new MemStorage());
+
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const sqlite = new SqliteStorage(root);
+  try {
+    await assertRefreshesWorkedIssue(sqlite);
+  } finally {
+    sqlite.close();
   }
 });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -75,6 +75,7 @@ export const prSchema = z.object({
   flagged: z.number(),
   testsPassed: z.boolean().nullable(),
   lintPassed: z.boolean().nullable(),
+  mergeableState: z.string().nullable().default(null),
   lastChecked: z.string().nullable(),
   lastSyncAttemptedAt: z.string().nullable().default(null),
   lastSyncSucceededAt: z.string().nullable().default(null),


### PR DESCRIPTION
## Summary
- Refresh worked issue records from GitHub during manual issue sync instead of returning cached payloads
- Keep worked issues in the list tied to live linked-PR mergeability so ready-to-merge is not treated as done
- Ignore stale label-only blocked evaluations after the blocking label is removed
- Refresh PR metadata during individual PR sync, including GitHub mergeable state
- Gate the PR ready-to-merge banner on terminal feedback, passing checks/lint, and GitHub `mergeable_state === clean`

## Tests
- npm run check
- npm run test:all