### PR TITLE
feat: cache GitHub releases in storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vite.config.ts.*
 .gstack/qa-reports/screenshots/
 src-tauri/target/
 .claude/
+.agents/

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -1591,7 +1591,7 @@ export default function Dashboard() {
                 ) : undefined}
                 banner={(
                   <>
-                    {isPRReadyToMerge(selectedPR.feedbackItems) && selectedPR.status !== "processing" && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
+                    {isPRReadyToMerge(selectedPR.feedbackItems) && (selectedPR.status === "watching" || selectedPR.status === "done") && countActiveFeedbackStatuses(selectedPR.feedbackItems).inProgress === 0 && (
                       <ReadyToMergeIndicator
                         href={selectedPR.url}
                         testId="detail-ready-to-merge"

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -11,6 +11,7 @@ import type {
   HealingSession,
   LogEntry,
   OperatorWarning,
+  GitHubRelease,
   PR,
   PRStage,
   PRSummary,
@@ -64,6 +65,7 @@ import {
   listOpenIssuesForRepo,
   listOpenLinkedPullRequestsForIssue,
   listReleasesForRepo,
+  listReleasesForRepoConditional,
   listUnreleasedMergedPulls,
   type MergedPRSummary,
   parsePRUrl,
@@ -252,6 +254,9 @@ const MAX_AUTO_ISSUE_SWEEP_PAGES = 50;
 // so quiet repos yield watcher slots and rate-limit budget to active ones. Any
 // observed change clears the cooldown and the repo returns to every-tick.
 const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
+// How long a cached GitHub releases entry is served before a background
+// refresh is triggered on the next Releases-page read.
+const RELEASE_CACHE_TTL_MS = 10 * 60_000;
 const AUTO_WORK_BLOCKED_LABELS = new Set([
   "blocked",
   "question",
@@ -1886,6 +1891,57 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     throw new AppRuntimeError(409, message);
   };
 
+  // GitHub releases are served from a DB cache; this refreshes one repo's
+  // entry via a conditional request. A 304 just bumps fetchedAt so the TTL
+  // resets without re-storing unchanged data.
+  const releaseCacheRefreshInFlight = new Set<string>();
+  const refreshReleaseCache = async (repoSlug: string): Promise<void> => {
+    if (releaseCacheRefreshInFlight.has(repoSlug)) {
+      return;
+    }
+    releaseCacheRefreshInFlight.add(repoSlug);
+    try {
+      const parsed = parseRepoSlug(repoSlug);
+      if (!parsed) {
+        return;
+      }
+      const config = await storage.getConfig();
+      const octokit = await buildOctokit(config);
+      const existing = await storage.getGithubReleaseCache(repoSlug);
+      const result = await listReleasesForRepoConditional(octokit, parsed, existing?.etag ?? null);
+      if (result.notModified) {
+        if (existing) {
+          await storage.upsertGithubReleaseCache({ ...existing, fetchedAt: new Date().toISOString() });
+        }
+        return;
+      }
+      const releases: GitHubRelease[] = result.releases.map((release) => ({
+        id: release.id,
+        tagName: release.tagName,
+        name: release.name,
+        body: release.body,
+        bodyHtml: release.body ? renderGitHubMarkdown(release.body) : null,
+        htmlUrl: release.htmlUrl,
+        draft: release.draft,
+        prerelease: release.prerelease,
+        publishedAt: release.publishedAt,
+      }));
+      await storage.upsertGithubReleaseCache({
+        repo: repoSlug,
+        releases,
+        etag: result.etag,
+        fetchedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      log.warn(
+        { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
+        "Failed to refresh GitHub releases cache",
+      );
+    } finally {
+      releaseCacheRefreshInFlight.delete(repoSlug);
+    }
+  };
+
   const runtime: AppRuntime = {
     async start() {
       if (started) {
@@ -2611,37 +2667,26 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         return [];
       }
 
-      const octokit = await buildOctokit(config);
+      const now = Date.now();
       const perRepo = await Promise.all(
         config.watchedRepos.map(async (repoSlug): Promise<RepoGitHubReleases | null> => {
-          const parsed = parseRepoSlug(repoSlug);
-          if (!parsed) {
+          if (!parseRepoSlug(repoSlug)) {
             return null;
           }
 
-          try {
-            const summaries = await listReleasesForRepo(octokit, parsed);
-            return {
-              repo: repoSlug,
-              releases: summaries.map((release) => ({
-                id: release.id,
-                tagName: release.tagName,
-                name: release.name,
-                body: release.body,
-                bodyHtml: release.body ? renderGitHubMarkdown(release.body) : null,
-                htmlUrl: release.htmlUrl,
-                draft: release.draft,
-                prerelease: release.prerelease,
-                publishedAt: release.publishedAt,
-              })),
-            };
-          } catch (error) {
-            log.warn(
-              { err: error instanceof Error ? error.message : String(error), repo: repoSlug },
-              "Failed to fetch GitHub releases for repo",
-            );
-            return { repo: repoSlug, releases: [] };
+          const cached = await storage.getGithubReleaseCache(repoSlug);
+          if (!cached) {
+            // Cold cache: block on the first fetch so the page gets real data.
+            await refreshReleaseCache(repoSlug);
+            const fresh = await storage.getGithubReleaseCache(repoSlug);
+            return { repo: repoSlug, releases: fresh?.releases ?? [] };
           }
+
+          if (now - new Date(cached.fetchedAt).getTime() > RELEASE_CACHE_TTL_MS) {
+            // Warm but stale: refresh in the background, serve cached now.
+            void refreshReleaseCache(repoSlug);
+          }
+          return { repo: repoSlug, releases: cached.releases };
         }),
       );
 

--- a/server/github.ts
+++ b/server/github.ts
@@ -1580,6 +1580,23 @@ export async function getDefaultBranchForRepo(
   return defaultBranch;
 }
 
+type RawGitHubRelease = Awaited<ReturnType<Octokit["repos"]["listReleases"]>>["data"][number];
+
+function mapReleaseToSummary(release: RawGitHubRelease): GitHubReleaseSummary {
+  return {
+    id: release.id,
+    tagName: release.tag_name || "",
+    name: release.name || release.tag_name || `Release ${release.id}`,
+    body: release.body || null,
+    htmlUrl: release.html_url || "",
+    apiUrl: release.url || "",
+    draft: Boolean(release.draft),
+    prerelease: Boolean(release.prerelease),
+    targetCommitish: release.target_commitish || null,
+    publishedAt: release.published_at || null,
+  };
+}
+
 export async function listReleasesForRepo(
   octokit: Octokit,
   repo: ParsedRepoSlug,
@@ -1592,18 +1609,55 @@ export async function listReleasesForRepo(
     }),
   );
 
-  return releases.map((release) => ({
-    id: release.id,
-    tagName: release.tag_name || "",
-    name: release.name || release.tag_name || `Release ${release.id}`,
-    body: release.body || null,
-    htmlUrl: release.html_url || "",
-    apiUrl: release.url || "",
-    draft: Boolean(release.draft),
-    prerelease: Boolean(release.prerelease),
-    targetCommitish: release.target_commitish || null,
-    publishedAt: release.published_at || null,
-  }));
+  return releases.map(mapReleaseToSummary);
+}
+
+export type ConditionalReleaseList =
+  | { notModified: true }
+  | { notModified: false; etag: string | null; releases: GitHubReleaseSummary[] };
+
+/**
+ * Conditional GET of a repo's releases. Page 1 carries an `If-None-Match`; a
+ * 304 means the release list is unchanged since `cachedEtag` and costs no
+ * primary rate-limit budget.
+ */
+export async function listReleasesForRepoConditional(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  cachedEtag: string | null,
+): Promise<ConditionalReleaseList> {
+  return withGitHubErrorHandling("repository releases", repo, async () => {
+    const perPage = 100;
+    const collected: GitHubReleaseSummary[] = [];
+    let firstPageEtag: string | null = null;
+
+    for (let page = 1; ; page += 1) {
+      let response;
+      try {
+        response = await octokit.repos.listReleases({
+          owner: repo.owner,
+          repo: repo.repo,
+          per_page: perPage,
+          page,
+          ...(page === 1 && cachedEtag ? { headers: { "if-none-match": cachedEtag } } : {}),
+        });
+      } catch (error) {
+        if (page === 1 && (error as { status?: number } | undefined)?.status === 304) {
+          return { notModified: true };
+        }
+        throw error;
+      }
+
+      if (page === 1) {
+        const etag = response.headers?.etag;
+        firstPageEtag = typeof etag === "string" ? etag : null;
+      }
+      collected.push(...response.data.map(mapReleaseToSummary));
+      if (response.data.length < perPage) break;
+    }
+
+    return { notModified: false, etag: firstPageEtag, releases: collected };
+  });
 }
 
 export async function listTagsForRepo(

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -54,7 +54,7 @@ import {
   createSocialChangelog,
   touchAgentRun,
 } from "@shared/models";
-import type { IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
+import type { GithubReleaseCacheEntry, IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 
 export class MemStorage implements IStorage {
@@ -82,6 +82,7 @@ export class MemStorage implements IStorage {
   private syncedIssues: Map<string, StoredIssueRecord> = new Map();
   private githubEtags: Map<string, string> = new Map();
   private repoSyncStates: Map<string, RepoSyncState> = new Map();
+  private githubReleaseCache: Map<string, GithubReleaseCacheEntry> = new Map();
 
   private cloneConfig(config: Config): Config {
     return structuredClone(config);
@@ -436,6 +437,18 @@ export class MemStorage implements IStorage {
       nextEligibleAt: "nextEligibleAt" in updates
         ? updates.nextEligibleAt ?? null
         : existing?.nextEligibleAt ?? null,
+    });
+  }
+
+  async getGithubReleaseCache(repo: string): Promise<GithubReleaseCacheEntry | undefined> {
+    const entry = this.githubReleaseCache.get(repo);
+    return entry ? { ...entry, releases: entry.releases.map((release) => ({ ...release })) } : undefined;
+  }
+
+  async upsertGithubReleaseCache(entry: GithubReleaseCacheEntry): Promise<void> {
+    this.githubReleaseCache.set(entry.repo, {
+      ...entry,
+      releases: entry.releases.map((release) => ({ ...release })),
     });
   }
 

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -60,7 +60,7 @@ import {
   createReleaseRun,
   createSocialChangelog,
 } from "@shared/models";
-import type { IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
+import type { GithubReleaseCacheEntry, IStorage, RepoSyncKind, RepoSyncState, StoredIssueRecord } from "./storage";
 import { getCodeFactoryPaths } from "./paths";
 import { DEFAULT_CONFIG } from "./defaultConfig";
 import { appendLogFile } from "./logFiles";
@@ -895,6 +895,13 @@ export class SqliteStorage implements IStorage {
         last_synced_at TEXT,
         next_eligible_at TEXT,
         PRIMARY KEY(repo, kind)
+      );
+
+      CREATE TABLE IF NOT EXISTS github_release_cache (
+        repo TEXT PRIMARY KEY,
+        releases_json TEXT NOT NULL,
+        etag TEXT,
+        fetched_at TEXT NOT NULL
       );
 
       CREATE INDEX IF NOT EXISTS idx_feedback_items_pr_id ON feedback_items(pr_id);
@@ -2359,6 +2366,38 @@ export class SqliteStorage implements IStorage {
         kind,
         lastSyncedAt,
         nextEligibleAt,
+      );
+    });
+  }
+
+  async getGithubReleaseCache(repo: string): Promise<GithubReleaseCacheEntry | undefined> {
+    const row = this.get<{ releases_json: string; etag: string | null; fetched_at: string }>(
+      "SELECT releases_json, etag, fetched_at FROM github_release_cache WHERE repo = ?",
+      repo,
+    );
+    if (!row) {
+      return undefined;
+    }
+    return {
+      repo,
+      releases: JSON.parse(row.releases_json) as GithubReleaseCacheEntry["releases"],
+      etag: row.etag,
+      fetchedAt: row.fetched_at,
+    };
+  }
+
+  async upsertGithubReleaseCache(entry: GithubReleaseCacheEntry): Promise<void> {
+    this.withWriteTransaction(() => {
+      this.run(
+        `INSERT INTO github_release_cache (repo, releases_json, etag, fetched_at) VALUES (?, ?, ?, ?)
+         ON CONFLICT(repo) DO UPDATE SET
+           releases_json = excluded.releases_json,
+           etag = excluded.etag,
+           fetched_at = excluded.fetched_at`,
+        entry.repo,
+        JSON.stringify(entry.releases),
+        entry.etag,
+        entry.fetchedAt,
       );
     });
   }

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1250,3 +1250,68 @@ test("MemStorage repo sync state matches the SqliteStorage contract", async () =
     { repo: "o/r", kind: "prs", lastSyncedAt: "t1", nextEligibleAt: null },
   ]);
 });
+
+test("SqliteStorage persists the GitHub releases cache and overwrites per repo across reopen", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const entry = {
+    repo: "o/r",
+    releases: [{
+      id: 1,
+      tagName: "v1.0.0",
+      name: "v1.0.0",
+      body: "notes",
+      bodyHtml: "<p>notes</p>",
+      htmlUrl: "https://example.com/releases/1",
+      draft: false,
+      prerelease: false,
+      publishedAt: "2026-05-15T10:00:00.000Z",
+    }],
+    etag: 'W/"rel-abc"',
+    fetchedAt: "2026-05-15T10:00:00.000Z",
+  };
+  const first = new SqliteStorage(root);
+  try {
+    assert.equal(await first.getGithubReleaseCache("o/r"), undefined);
+    await first.upsertGithubReleaseCache(entry);
+    assert.deepEqual(await first.getGithubReleaseCache("o/r"), entry);
+
+    // Upsert keeps a single row per repo.
+    const updated = { ...entry, releases: [], etag: 'W/"rel-def"', fetchedAt: "2026-05-15T12:00:00.000Z" };
+    await first.upsertGithubReleaseCache(updated);
+    assert.deepEqual(await first.getGithubReleaseCache("o/r"), updated);
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    const reloaded = await second.getGithubReleaseCache("o/r");
+    assert.equal(reloaded?.etag, 'W/"rel-def"');
+    assert.deepEqual(reloaded?.releases, []);
+  } finally {
+    second.close();
+  }
+});
+
+test("MemStorage GitHub releases cache matches the SqliteStorage contract", async () => {
+  const storage = new MemStorage();
+  assert.equal(await storage.getGithubReleaseCache("o/r"), undefined);
+  const entry = {
+    repo: "o/r",
+    releases: [{
+      id: 9,
+      tagName: "v9",
+      name: "v9",
+      body: null,
+      bodyHtml: null,
+      htmlUrl: "https://example.com/releases/9",
+      draft: false,
+      prerelease: true,
+      publishedAt: null,
+    }],
+    etag: null,
+    fetchedAt: "t1",
+  };
+  await storage.upsertGithubReleaseCache(entry);
+  assert.deepEqual(await storage.getGithubReleaseCache("o/r"), entry);
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12,6 +12,7 @@ import type {
   IssueSubtaskSet,
   LogEntry,
   FailureFingerprint,
+  GitHubRelease,
   HealingAttempt,
   HealingAttemptStatus,
   HealingSession,
@@ -60,6 +61,16 @@ export type RepoSyncState = {
   kind: RepoSyncKind;
   lastSyncedAt: string | null;
   nextEligibleAt: string | null;
+};
+
+// DB-backed cache of a repo's GitHub releases so the Releases page reads from
+// storage instead of hitting the GitHub API on every load. `etag` drives a
+// conditional refresh; `fetchedAt` drives the staleness TTL.
+export type GithubReleaseCacheEntry = {
+  repo: string;
+  releases: GitHubRelease[];
+  etag: string | null;
+  fetchedAt: string;
 };
 
 export interface IStorage {
@@ -134,6 +145,10 @@ export interface IStorage {
     kind: RepoSyncKind,
     updates: { lastSyncedAt?: string | null; nextEligibleAt?: string | null },
   ): Promise<void>;
+
+  // DB-backed GitHub releases cache (one row per repo).
+  getGithubReleaseCache(repo: string): Promise<GithubReleaseCacheEntry | undefined>;
+  upsertGithubReleaseCache(entry: GithubReleaseCacheEntry): Promise<void>;
 
   // CI healing
   getHealingSession(id: string): Promise<HealingSession | undefined>;


### PR DESCRIPTION
## Summary
- Add a DB-backed GitHub releases cache so the Releases page reads from storage instead of calling the GitHub API on every load.
- Cold cache blocks on the first fetch; a warm-but-stale entry (>10m) is served immediately while a background refresh runs.
- Refreshes use a conditional request — a 304 costs no primary rate-limit budget and just bumps the TTL.
- Gate the PR detail ready-to-merge banner on explicit `watching`/`done` status rather than `!== "processing"`.
- Add `.agents/` to `.gitignore`.

## Changes
- `server/storage.ts` — new `GithubReleaseCacheEntry` type + `get/upsertGithubReleaseCache` interface methods.
- `server/memoryStorage.ts` / `server/sqliteStorage.ts` — implement the cache (new `github_release_cache` table for SQLite).
- `server/github.ts` — `listReleasesForRepoConditional` with `If-None-Match` handling; extract shared `mapReleaseToSummary`.
- `server/appRuntime.ts` — `refreshReleaseCache` with in-flight dedupe; releases read path now serves from cache.
- `client/src/pages/prs.tsx` — ready-to-merge banner status gating.

## Test plan
- [x] `npm test` — 617 pass
- [x] `npm run check` — typecheck clean
- [ ] Verify Releases page loads from cache and refreshes after TTL