### PR TITLE
fix: expose issue pagination controls

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -363,6 +363,9 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   for (const [label, testId] of [
     ["sync button", "button-sync-issues"],
     ["start visible issue work button", "button-start-visible-issue-work"],
+    ["manual issue or PR number input", "input-manual-issue-pr-number"],
+    ["manual issue pull button", "button-pull-issue-number"],
+    ["manual PR pull button", "button-pull-pr-number"],
     ["issue number search", "issue-number-search"],
     ["work issue button", "button-work-issue"],
     ["evaluate issue button", "button-evaluate-issue"],
@@ -410,6 +413,8 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue work filter helper", /\bmatchesIssueWorkFilter\b/);
   assertHasExpression(sourceFile, "issue start work eligibility", /\bcanStartIssueWork\b/);
   assertHasExpression(sourceFile, "issue start work mutation", /\bstartVisibleWorkMutation\b/);
+  assertHasExpression(sourceFile, "manual issue pull mutation", /\bmanualPullIssueMutation\b/);
+  assertHasExpression(sourceFile, "manual PR pull mutation", /\bmanualPullPrMutation\b/);
   assertHasExpression(sourceFile, "stale issue helper", /\bisStaleIssue\b/);
   assertHasExpression(sourceFile, "issue detail refresh", /\bselectedIssueDetail\b/);
   assertHasExpression(sourceFile, "issue UI polling uses tuning interval", /\bgetUiPollIntervalMs\(config\)/);
@@ -421,6 +426,8 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue pagination load more", /\bloadMoreIssues\b/);
   assertHasExpression(sourceFile, "issue loaded count", /\bloadedIssueCount\b/);
   assertHasStringValue(sourceFile, "issue sync label", "sync");
+  assertHasStringValue(sourceFile, "manual issue pull label", "Pull issue");
+  assertHasStringValue(sourceFile, "manual PR pull label", "Pull PR");
   assertHasStringValue(sourceFile, "issue load more label", "Load more");
   assertHasStringValue(sourceFile, "issue number search placeholder", "Search #");
   assertHasStringValue(sourceFile, "issue body label", "Issue body");

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -389,6 +389,8 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
     ["issue ready to merge list", "issue-ready-to-merge-list"],
     ["issue work in progress list", "issue-work-in-progress-list"],
     ["issue list", "issue-list"],
+    ["load more issues button", "button-load-more-issues"],
+    ["loaded issue count", "issues-loaded-count"],
     ["issue detail logs", "issue-detail-logs"],
   ] satisfies SourceExpectation[]) {
     assertHasTestId(sourceFile, label, testId);
@@ -416,7 +418,10 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue queue helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "issue queue badge", /\bQueueStatusBadge\b/);
   assertHasExpression(sourceFile, "issue filtered list", /\bfilteredIssues\b/);
+  assertHasExpression(sourceFile, "issue pagination load more", /\bloadMoreIssues\b/);
+  assertHasExpression(sourceFile, "issue loaded count", /\bloadedIssueCount\b/);
   assertHasStringValue(sourceFile, "issue sync label", "sync");
+  assertHasStringValue(sourceFile, "issue load more label", "Load more");
   assertHasStringValue(sourceFile, "issue number search placeholder", "Search #");
   assertHasStringValue(sourceFile, "issue body label", "Issue body");
 });

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -1247,6 +1247,11 @@ function IssuesPage() {
   const staleIssueCount = issues.filter((issue) =>
     (selectedRepo === "all" || issue.repo === selectedRepo) && isStaleIssue(issue)
   ).length;
+  const loadedIssueCount = issues.length;
+  const loadedScopeCount = selectedRepo === "all"
+    ? loadedIssueCount
+    : issues.filter((issue) => issue.repo === selectedRepo).length;
+  const totalScopeCount = selectedRepo === "all" ? totalIssueCount : (repoTotals[selectedRepo] ?? loadedScopeCount);
 
   return (
     <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
@@ -1255,7 +1260,16 @@ function IssuesPage() {
         active="issues"
         status={(
           <>
-            <span><span className="font-mono text-foreground">{issues.length}</span> open</span>
+            <span>
+              <span className="font-mono text-foreground">{loadedIssueCount}</span>
+              {totalIssueCount > loadedIssueCount && (
+                <>
+                  <span className="mx-1 text-muted-foreground/70">/</span>
+                  <span className="font-mono text-foreground">{totalIssueCount}</span>
+                </>
+              )}
+              {" "}open
+            </span>
             <span><span className="font-mono text-foreground">{activeIssueCount}</span> active</span>
             {runtime?.drainMode && (
               <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
@@ -1552,7 +1566,31 @@ function IssuesPage() {
                       ))}
                     </div>
                   ))}
-                  {canLoadMore && <div ref={loadMoreSentinelRef} className="h-8 w-full" data-testid="issues-load-more-sentinel" />}
+                  {canLoadMore ? (
+                    <div ref={loadMoreSentinelRef} className="border-t border-border/60 px-4 py-3" data-testid="issues-load-more-sentinel">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                          Loaded <span className="font-mono text-foreground">{loadedScopeCount}</span>
+                          {" "}of <span className="font-mono text-foreground">{totalScopeCount}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => { void loadMoreIssues(); }}
+                          disabled={isLoadingMore || globalDrainMode}
+                          data-testid="button-load-more-issues"
+                          className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {isLoadingMore && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
+                          Load more
+                        </button>
+                      </div>
+                    </div>
+                  ) : totalIssueCount > loadedIssueCount ? (
+                    <div className="border-t border-border/60 px-4 py-3 text-[11px] uppercase tracking-wider text-muted-foreground" data-testid="issues-loaded-count">
+                      Loaded <span className="font-mono text-foreground">{loadedScopeCount}</span>
+                      {" "}of <span className="font-mono text-foreground">{totalScopeCount}</span>
+                    </div>
+                  ) : null}
                 </>
               )}
             </div>

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -769,6 +769,7 @@ function IssuesPage() {
   const { data: issuesPage, isLoading, isFetching } = issuesQuery;
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isSyncingRepos, setIsSyncingRepos] = useState(false);
+  const [manualPulledIssues, setManualPulledIssues] = useState<Issue[]>([]);
   useEffect(() => {
     if (issuesQuery.status === "success") {
       writeCachedIssues(issuesQuery.data);
@@ -779,11 +780,14 @@ function IssuesPage() {
   }, [issuesPage?.fetchedAt]);
 
   const issues = useMemo(() => {
-    const all = [issuesPage, ...extraPages].flatMap((page) => page?.items ?? []);
+    const all = [
+      ...manualPulledIssues,
+      ...[issuesPage, ...extraPages].flatMap((page) => page?.items ?? []),
+    ];
     const deduped = new Map<string, Issue>();
     for (const issue of all) deduped.set(issue.id, issue);
     return Array.from(deduped.values()).sort((a, b) => b.number - a.number);
-  }, [issuesPage, extraPages]);
+  }, [issuesPage, extraPages, manualPulledIssues]);
   const latestPage = extraPages[extraPages.length - 1] ?? issuesPage ?? null;
   const canLoadMore = Boolean(latestPage?.hasMore);
   const nextOffset = latestPage?.nextOffset ?? null;
@@ -860,9 +864,21 @@ function IssuesPage() {
   const [selectedRepo, setSelectedRepo] = useState<string>("all");
   const [selectedWorkFilter, setSelectedWorkFilter] = useState<IssueWorkFilter>("all");
   const [issueNumberSearch, setIssueNumberSearch] = useState("");
+  const [manualPullNumber, setManualPullNumber] = useState("");
   const [labelInput, setLabelInput] = useState("");
   const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
   const normalizedIssueNumberSearch = normalizeNumberSearch(issueNumberSearch);
+  const manualPullRepo = selectedRepo !== "all"
+    ? selectedRepo
+    : config?.watchedRepos.length === 1
+      ? config.watchedRepos[0]
+      : null;
+  const manualPullIssueNumber = Number(normalizeNumberSearch(manualPullNumber));
+  const canManualPull = Boolean(manualPullRepo)
+    && Number.isInteger(manualPullIssueNumber)
+    && manualPullIssueNumber > 0
+    && !globalDrainMode;
+  const manualPullRepoHint = manualPullRepo ?? "select a repo first";
   const filteredIssues = useMemo(
     () => issues
       .filter((issue) => selectedRepo === "all" || issue.repo === selectedRepo)
@@ -1198,6 +1214,54 @@ function IssuesPage() {
     },
   });
 
+  const manualPullIssueMutation = useMutation({
+    mutationFn: async ({ repo, number }: { repo: string; number: number }) => {
+      const res = await apiRequest("POST", "/api/issues/sync", { repo, number });
+      return res.json() as Promise<Issue>;
+    },
+    onSuccess: async (issue) => {
+      setManualPullNumber("");
+      setManualPulledIssues((current) => {
+        const next = new Map(current.map((item) => [item.id, item]));
+        next.set(issue.id, issue);
+        return Array.from(next.values());
+      });
+      setSelectedRepo(issue.repo);
+      setSelectedIssueId(issue.id);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues/detail", issue.repo, issue.number] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/issues/coverage"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] }),
+      ]);
+      toast({ description: `Pulled issue ${issue.repo}#${issue.number}.` });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Could not pull issue: ${error.message}` });
+    },
+  });
+
+  const manualPullPrMutation = useMutation({
+    mutationFn: async ({ repo, number }: { repo: string; number: number }) => {
+      const res = await apiRequest("POST", "/api/prs", {
+        url: `https://github.com/${repo}/pull/${number}`,
+      });
+      return res.json() as Promise<{ id: string; repo: string; number: number }>;
+    },
+    onSuccess: async (pr) => {
+      setManualPullNumber("");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/prs"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/prs", pr.id] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
+      ]);
+      toast({ description: `Pulled PR ${pr.repo}#${pr.number}.` });
+    },
+    onError: (error) => {
+      toast({ variant: "destructive", description: `Could not pull PR: ${error.message}` });
+    },
+  });
+
   const labelMutation = useMutation({
     mutationFn: async ({ issue, add, remove }: { issue: Issue; add?: string[]; remove?: string[] }) => {
       const res = await apiRequest("PATCH", "/api/issues/labels", {
@@ -1379,6 +1443,53 @@ function IssuesPage() {
             </div>
           </div>
           <div data-testid="repo-filter-bar" className="flex flex-col gap-2 border-b border-border px-4 py-2.5">
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (canManualPull && manualPullRepo) {
+                  manualPullIssueMutation.mutate({ repo: manualPullRepo, number: manualPullIssueNumber });
+                }
+              }}
+              className="flex flex-wrap items-start gap-2"
+            >
+              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Pull
+              </span>
+              <div className="flex min-w-0 flex-1 flex-wrap gap-1">
+                <label htmlFor="manual-issue-pr-number" className="sr-only">Issue or pull request number</label>
+                <input
+                  id="manual-issue-pr-number"
+                  value={manualPullNumber}
+                  onChange={(event) => setManualPullNumber(event.target.value)}
+                  placeholder={`# for ${manualPullRepoHint}`}
+                  data-testid="input-manual-issue-pr-number"
+                  className="h-7 min-w-[11rem] flex-1 rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+                <button
+                  type="submit"
+                  disabled={!canManualPull || manualPullIssueMutation.isPending}
+                  data-testid="button-pull-issue-number"
+                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {manualPullIssueMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
+                  Pull issue
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (canManualPull && manualPullRepo) {
+                      manualPullPrMutation.mutate({ repo: manualPullRepo, number: manualPullIssueNumber });
+                    }
+                  }}
+                  disabled={!canManualPull || manualPullPrMutation.isPending}
+                  data-testid="button-pull-pr-number"
+                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {manualPullPrMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
+                  Pull PR
+                </button>
+              </div>
+            </form>
             <div className="flex flex-wrap items-start gap-2">
               <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                 Search

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -1107,6 +1107,33 @@ test("fetchIssueSummary normalizes direct issue metadata", async () => {
   assert.deepEqual(issue.assignees, []);
 });
 
+test("fetchIssueSummary rejects pull requests returned by the issues API", async () => {
+  const octokit = {
+    issues: {
+      get: async () => ({
+        data: {
+          number: 31,
+          title: "Fix via PR",
+          body: null,
+          html_url: "https://github.com/owner/repo/pull/31",
+          user: { login: "bob" },
+          labels: [],
+          assignees: [],
+          comments: 0,
+          created_at: "2026-05-03T17:00:00.000Z",
+          updated_at: "2026-05-03T18:00:00.000Z",
+          pull_request: { url: "https://api.github.com/repos/owner/repo/pulls/31" },
+        },
+      }),
+    },
+  };
+
+  await assert.rejects(
+    () => fetchIssueSummary(octokit as never, { owner: "owner", repo: "repo", number: 31 }),
+    /pull request/i,
+  );
+});
+
 test("addLabelsToIssue sends label names to GitHub issues", async () => {
   const calls: unknown[] = [];
   const octokit = {

--- a/server/github.ts
+++ b/server/github.ts
@@ -1462,6 +1462,12 @@ export async function fetchIssueSummary(
   );
 
   const issue = response.data;
+  if (issue.pull_request) {
+    throw new GitHubIntegrationError(
+      `${formatRepoSlug(parsed)}#${parsed.number} is a pull request; add it from the PR monitor instead`,
+      400,
+    );
+  }
   return {
     number: issue.number,
     title: issue.title || `Issue #${issue.number}`,


### PR DESCRIPTION
## Summary
- Show loaded issue count against the synced total in the issues header
- Add a visible Load more button at the bottom of the issue list
- Add a manual Pull control for issue or PR numbers in the selected watched repo
- Keep manually pulled issues visible even if they are outside the currently loaded 100-item page
- Reject PRs from the issue-sync path so PR numbers do not get imported as issues

## Tests
- npm run check
- node --import tsx --test client/src/lib/fullAppQaSurface.test.ts server/github.test.ts
- npm run test:all