### PR TITLE
fix: limit concurrent PR work jobs

### DIFF
--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -219,6 +219,55 @@ test("BackgroundJobDispatcher waitForIdle reflects active queue handlers", async
   }
 });
 
+test("BackgroundJobDispatcher limits concurrent babysit jobs using config", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  await storage.updateConfig({ maxConcurrentBabysitRuns: 1 });
+
+  const firstRelease = deferred();
+  const started: string[] = [];
+
+  const firstJob = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", { prId: "pr-1" });
+  const secondJob = await queue.enqueue("babysit_pr", "pr-2", "babysit_pr:pr-2", { prId: "pr-2" });
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    handlers: {
+      babysit_pr: async (job) => {
+        started.push(job.targetId);
+        if (job.targetId === "pr-1") {
+          await firstRelease.promise;
+        }
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(() => started.length === 1);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    assert.deepEqual(started, ["pr-1"]);
+    assert.equal((await storage.getBackgroundJob(firstJob.id))?.status, "leased");
+    assert.equal((await storage.getBackgroundJob(secondJob.id))?.status, "queued");
+
+    firstRelease.resolve();
+    await waitForCondition(() => started.length === 2);
+    assert.equal(await dispatcher.waitForIdle(250), true);
+
+    assert.deepEqual(started, ["pr-1", "pr-2"]);
+    assert.equal((await storage.getBackgroundJob(firstJob.id))?.status, "completed");
+    assert.equal((await storage.getBackgroundJob(secondJob.id))?.status, "completed");
+  } finally {
+    firstRelease.resolve();
+    dispatcher.stop();
+  }
+});
+
 test("BackgroundJobDispatcher reclaims expired leases during operation, not just at startup", async () => {
   const storage = new MemStorage();
   const queue = new BackgroundJobQueue(storage);

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -151,7 +151,9 @@ export class BackgroundJobDispatcher {
       }
 
       const runtimeState = await this.storage.getRuntimeState();
-      const claimableKinds = runtimeState.drainMode ? this.drainClaimableKinds : this.handledKinds;
+      const claimableKinds = await this.resolveClaimableKinds(
+        runtimeState.drainMode ? this.drainClaimableKinds : this.handledKinds,
+      );
       if (claimableKinds.length === 0) {
         return;
       }
@@ -179,6 +181,24 @@ export class BackgroundJobDispatcher {
         this.schedulePoll(this.pollIntervalMs);
       }
     }
+  }
+
+  private async resolveClaimableKinds(kinds: BackgroundJobKind[]): Promise<BackgroundJobKind[]> {
+    if (!kinds.includes("babysit_pr")) {
+      return kinds;
+    }
+
+    const config = await this.storage.getConfig();
+    const maxConcurrentBabysitRuns = Math.max(1, config.maxConcurrentBabysitRuns);
+    const activeBabysitRuns = Array.from(this.activeJobs.keys())
+      .filter((jobId) => jobId.startsWith("babysit_pr:"))
+      .length;
+
+    if (activeBabysitRuns < maxConcurrentBabysitRuns) {
+      return kinds;
+    }
+
+    return kinds.filter((kind) => kind !== "babysit_pr");
   }
 
   private runJob(job: BackgroundJob): void {
@@ -220,7 +240,7 @@ export class BackgroundJobDispatcher {
         if (heartbeatTimer) {
           clearInterval(heartbeatTimer);
         }
-        this.activeJobs.delete(job.id);
+        this.activeJobs.delete(`${job.kind}:${job.id}`);
       }
     })().catch((error) => {
       this.onError(error);
@@ -230,7 +250,7 @@ export class BackgroundJobDispatcher {
       }
     });
 
-    this.activeJobs.set(job.id, jobPromise);
+    this.activeJobs.set(`${job.kind}:${job.id}`, jobPromise);
   }
 
   private async requeueExpiredAndNotify(): Promise<void> {


### PR DESCRIPTION
## Summary
- honor maxConcurrentBabysitRuns in the shared background dispatcher for babysit_pr jobs
- keep manually queued Work Now jobs queued until PR work capacity is available
- add regression coverage for burst-clicked PR work jobs

## Evidence
Logs showed eight babysitter failures in a few seconds after manual Work Now clicks, all failing on GitHub review-comments/metadata rate limits. The watcher already capped enqueues, but the dispatcher leased every queued babysit_pr job immediately.

## Tests
- npm test -- server/backgroundJobDispatcher.test.ts
- npm run check