### PR TITLE
fix: preserve PR watcher budget in PR-only mode

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -322,7 +322,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
 
   assertHasApiRequest(sourceFile, "failed activity clear mutation", "DELETE", "/api/activities/failed");
   assertHasApiRequest(sourceFile, "issue failure clear mutation", "DELETE", "/api/issues/work/failures");
-  assertHasApiRequest(sourceFile, "dashboard sync mutation", "POST", "/api/repos/sync");
+  assertHasApiRequest(sourceFile, "dashboard PR sync mutation", "POST", "/api/repos/sync?scope=prs");
   assertHasApiRequest(sourceFile, "ask agent mutation", "POST", /`\/api\/prs\/\$\{prId\}\/questions`/);
   assertHasTestId(sourceFile, "dashboard drain banner", "dashboard-drain-banner");
   assertHasTestId(sourceFile, "dashboard drain reason", "dashboard-drain-reason");
@@ -357,6 +357,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasApiRequest(sourceFile, "issue work mutation", "POST", "/api/issues/work");
   assertHasApiRequest(sourceFile, "issue evaluation mutation", "POST", "/api/issues/evaluate");
   assertHasApiRequest(sourceFile, "issue label mutation", "PATCH", "/api/issues/labels");
+  assertHasApiRequest(sourceFile, "issue scoped repo sync", "POST", /\/api\/repos\/sync\?scope=issues/);
   assertHasExpression(sourceFile, "issues drain guard", /enabled: runtime !== undefined && !globalDrainMode/);
   assertHasExpression(sourceFile, "issue detail drain guard", /enabled: Boolean\(selectedIssueFromList\) && !globalDrainMode/);
 

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -822,7 +822,7 @@ function IssuesPage() {
         }
         toast({ description: "Full sweep started." });
       }
-      await apiRequest("POST", fullSweep ? "/api/repos/sync?fullSweep=1" : "/api/repos/sync");
+      await apiRequest("POST", fullSweep ? "/api/repos/sync?scope=issues&fullSweep=1" : "/api/repos/sync?scope=issues");
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
         queryClient.invalidateQueries({ queryKey: ["/api/issues/coverage"] }),

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -1026,11 +1026,10 @@ export default function Dashboard() {
   const handleSyncDashboard = async () => {
     setIsRefreshing(true);
     try {
-      await apiRequest("POST", "/api/repos/sync");
+      await apiRequest("POST", "/api/repos/sync?scope=prs");
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["/api/prs"] }),
         queryClient.invalidateQueries({ queryKey: ["/api/prs/archived"] }),
-        queryClient.invalidateQueries({ queryKey: ["/api/issues"] }),
         queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
         queryClient.invalidateQueries({ queryKey: ["/api/healing-sessions"] }),
         queryClient.invalidateQueries({ queryKey: ["/api/runtime"] }),

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -257,6 +257,46 @@ test("manual sync runs immediately even when global manual mode is on", async ()
   assert.equal(jobs.length, 0);
 });
 
+test("manual sync can target only PRs or only issues", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+
+  let prSyncCalls = 0;
+  let issueListCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        issueListCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: {
+      syncAndBabysitTrackedRepos: async () => {
+        prSyncCalls += 1;
+      },
+    } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.syncRepos({ scope: "prs" });
+  assert.equal(prSyncCalls, 1);
+  assert.equal(issueListCalls, 0);
+
+  await runtime.syncRepos({ scope: "issues" });
+  assert.equal(prSyncCalls, 1);
+  assert.ok(issueListCalls > 0);
+
+  const issueOnlyCalls = issueListCalls;
+  await runtime.syncRepos();
+  assert.equal(prSyncCalls, 2);
+  assert.ok(issueListCalls > issueOnlyCalls);
+});
+
 test("automatic watcher does not sync issues when issue automation is off", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({
@@ -291,6 +331,114 @@ test("automatic watcher does not sync issues when issue automation is off", asyn
   await new Promise((resolve) => setTimeout(resolve, 20));
 
   assert.equal(issueListCalls, 0, "PR-only auto mode must not spend budget on issue sync");
+});
+
+test("automatic watcher runs issue sync without PR sync when PR automation is off", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoPrs: false,
+    autoIssues: true,
+    watchedRepos: ["owner/repo"],
+  });
+  const pr = await seedPR(storage, { repo: "owner/repo", watchEnabled: false });
+
+  let issueListCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        issueListCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: {
+      syncAndBabysitTrackedRepos: async () => {
+        throw new Error("issue-only auto mode must not sync PRs");
+      },
+    } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.setPRWatchEnabled(pr.id, true);
+  await waitForCondition(() => issueListCalls > 0);
+
+  const jobs = await storage.listBackgroundJobs({ kind: "sync_watched_repos" });
+  assert.equal(jobs.length, 0, "issue-only auto mode must not queue PR sync");
+});
+
+test("automatic watcher does nothing when PR and issue automation are both off", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoPrs: false,
+    autoIssues: false,
+    watchedRepos: ["owner/repo"],
+  });
+  const pr = await seedPR(storage, { repo: "owner/repo", watchEnabled: false });
+
+  let issueListCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        issueListCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: {
+      syncAndBabysitTrackedRepos: async () => {
+        throw new Error("disabled auto mode must not sync PRs");
+      },
+    } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.setPRWatchEnabled(pr.id, true);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(issueListCalls, 0);
+  const jobs = await storage.listBackgroundJobs({ kind: "sync_watched_repos" });
+  assert.equal(jobs.length, 0);
+});
+
+test("automatic watcher can run PR and issue automation together", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoPrs: true,
+    autoIssues: true,
+    watchedRepos: ["owner/repo"],
+  });
+  const pr = await seedPR(storage, { repo: "owner/repo", watchEnabled: false });
+
+  let issueListCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        issueListCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.setPRWatchEnabled(pr.id, true);
+  await waitForCondition(async () => {
+    const jobs = await storage.listBackgroundJobs({ kind: "sync_watched_repos" });
+    return jobs.length === 1 && issueListCalls > 0;
+  });
 });
 
 test("runtime release adapter skips merged PRs without a merge commit SHA", () => {

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -36,6 +36,25 @@ async function seedPR(storage: MemStorage, overrides: Partial<NewPR> = {}) {
   });
 }
 
+async function waitForCondition(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 250,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (true) {
+    if (await condition()) {
+      return;
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      throw new Error(`Condition not met within ${timeoutMs}ms`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 test("runtime lists active and archived PRs separately", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({
@@ -236,6 +255,42 @@ test("manual sync runs immediately even when global manual mode is on", async ()
     kind: "sync_watched_repos",
   });
   assert.equal(jobs.length, 0);
+});
+
+test("automatic watcher does not sync issues when issue automation is off", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    autoPrs: true,
+    autoIssues: false,
+    watchedRepos: ["owner/repo"],
+  });
+  const pr = await seedPR(storage, { repo: "owner/repo", watchEnabled: false });
+
+  let issueListCalls = 0;
+  const fakeOctokit = {
+    issues: {
+      listForRepo: async () => {
+        issueListCalls += 1;
+        return { data: [], headers: {} };
+      },
+    },
+  };
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    babysitter: { syncAndBabysitTrackedRepos: async () => {} } as never,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  await runtime.setPRWatchEnabled(pr.id, true);
+  await waitForCondition(async () => {
+    const jobs = await storage.listBackgroundJobs({ kind: "sync_watched_repos" });
+    return jobs.length === 1;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(issueListCalls, 0, "PR-only auto mode must not spend budget on issue sync");
 });
 
 test("runtime release adapter skips merged PRs without a merge commit SHA", () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -899,16 +899,21 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         return;
       }
 
-      await scheduleBackgroundJob(
-        "sync_watched_repos",
-        "runtime:1",
-        buildBackgroundJobDedupeKey("sync_watched_repos", "runtime:1"),
-      );
-      // The routine issue sweep is low priority — it yields core REST budget
-      // to interactive routes and active babysitter sessions. A manual
-      // syncRepos() stays high priority.
-      await runWithRequestPriority("low", () => syncStoredIssuesStep());
-      await queueAutomaticIssueWorkInternal();
+      if (config.autoPrs !== false) {
+        await scheduleBackgroundJob(
+          "sync_watched_repos",
+          "runtime:1",
+          buildBackgroundJobDedupeKey("sync_watched_repos", "runtime:1"),
+        );
+      }
+
+      if (config.autoIssues !== false) {
+        // The routine issue sweep is low priority — it yields core REST budget
+        // to interactive routes and active babysitter sessions. A manual
+        // syncRepos() stays high priority.
+        await runWithRequestPriority("low", () => syncStoredIssuesStep());
+        await queueAutomaticIssueWorkInternal();
+      }
     },
     (error) => {
       log.warn(

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -128,6 +128,8 @@ export type DrainModeParams = {
   timeoutMs?: number;
 };
 
+export type RepoSyncScope = "all" | "prs" | "issues";
+
 export type AppRuntime = {
   start(): Promise<void>;
   stop(): void;
@@ -141,7 +143,7 @@ export type AppRuntime = {
   addRepo(repoInput: string): Promise<{ repo: string }>;
   removeRepo(repoInput: string, mode?: "soft" | "hard"): Promise<{ ok: true; repo: string; mode: "soft" | "hard"; removedPrs: number }>;
   updateRepoSettings(repoInput: string, updates: Partial<Omit<WatchedRepo, "repo">>): Promise<WatchedRepo>;
-  syncRepos(options?: { fullSweep?: boolean }): Promise<{ ok: true }>;
+  syncRepos(options?: { fullSweep?: boolean; scope?: RepoSyncScope }): Promise<{ ok: true }>;
   listIssueCoverage(): Promise<IssueCoverage[]>;
   createManualRelease(repoInput: string): Promise<ReleaseRun>;
   listPRs(view?: "active" | "archived"): Promise<PRSummary[]>;
@@ -2123,15 +2125,20 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       return updated;
     },
 
-    async syncRepos(options?: { fullSweep?: boolean }) {
+    async syncRepos(options?: { fullSweep?: boolean; scope?: RepoSyncScope }) {
       const runtimeState = await storage.getRuntimeState();
       if (runtimeState.drainMode) {
         return { ok: true as const };
       }
 
       const fullSweep = options?.fullSweep === true;
-      await babysitter.syncAndBabysitTrackedRepos({ fullSweep });
-      await syncStoredIssuesStep({ fullSweep });
+      const scope = options?.scope ?? "all";
+      if (scope === "all" || scope === "prs") {
+        await babysitter.syncAndBabysitTrackedRepos({ fullSweep });
+      }
+      if (scope === "all" || scope === "issues") {
+        await syncStoredIssuesStep({ fullSweep });
+      }
       notifyChange();
       return { ok: true as const };
     },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -453,7 +453,8 @@ export async function registerRoutes(
   app.post("/api/repos/sync", async (req, res) => {
     try {
       const fullSweep = req.query.fullSweep === "1" || req.query.fullSweep === "true";
-      const result = await runtime.syncRepos({ fullSweep });
+      const scope = z.enum(["all", "prs", "issues"]).default("all").parse(req.query.scope);
+      const result = await runtime.syncRepos({ fullSweep, scope });
       invalidatePrDetailCache();
       res.json(result);
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- split automatic watcher work by `autoPrs` and `autoIssues` so either side can run alone, both can run, or both can stay off
- add `scope=all|prs|issues` to `/api/repos/sync` with backward-compatible `all` default
- make the PR page sync PRs only and the Issues page sync issues only, including issue full sweeps
- keep QA coverage on the scoped manual sync routes and runtime watcher combinations

## Evidence
Live config had `autoPrs=true` and `autoIssues=false`, but server logs still showed the automatic watcher running issue sync every 10 minutes and hitting GitHub rate limits. That spent budget that should have been reserved for PR monitoring. The later changes fully separate the PR and issue sync paths so manual and automatic work do not piggyback unexpectedly.

## Tests
- `npm test -- server/appRuntime.test.ts`
- `npm test -- client/src/lib/fullAppQaSurface.test.ts`
- `npm run check`
- `git diff --check`
