### PR TITLE
feat: show active GitHub auth status

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -437,6 +437,7 @@ test("settings keeps the QA-tested configuration, token, and runtime controls wi
   assertHasQueryKey(sourceFile, "settings config query", "/api/config");
   assertHasQueryKey(sourceFile, "runtime query", "/api/runtime");
   assertHasQueryKey(sourceFile, "repo settings query", "/api/repos/settings");
+  assertHasQueryKey(sourceFile, "GitHub auth status query", "/api/github-auth/status");
   assertHasApiRequest(sourceFile, "config mutation", "PATCH", "/api/config");
   assertHasApiRequest(sourceFile, "drain mutation", "POST", "/api/runtime/drain");
   assertHasApiRequest(sourceFile, "add PR mutation", "POST", "/api/prs");
@@ -484,6 +485,7 @@ test("settings keeps the QA-tested configuration, token, and runtime controls wi
     /testIdPrefix=\{`tracked-repo-issue-work-mode-\$\{repo\.repo\.replace\(\s*["']\/["']\s*,\s*["']-["']\s*\)\}`\}/,
   );
   assertHasExpression(sourceFile, "ordered GitHub tokens", /\bgithubTokens\b/);
+  assertHasTestId(sourceFile, "GitHub auth status", "github-auth-status");
   assertHasExpression(sourceFile, "repo sync drain guard", /disabled=\{syncReposMutation\.isPending \|\| globalDrainMode\}/);
   assertHasStringValue(sourceFile, "repo sync button label", "Sync");
 });

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -87,6 +87,13 @@ type GitHubRateLimitState = {
   lastLimitedAt: string | null;
 };
 
+type GitHubAuthStatus = {
+  connected: boolean;
+  login: string | null;
+  source: "saved_token" | "env_token" | "gh_auth" | "gh_auth_fallback" | "none";
+  error?: string;
+};
+
 type GitHubTokenTestResult = {
   index: number;
   token: string;
@@ -120,6 +127,14 @@ const TOKEN_TEST_STATUS_CLASS: Record<GitHubTokenTestResult["status"], string> =
   ok: "border-success-border bg-success-muted text-success-foreground",
   throttled: "border-warning-border bg-warning-muted text-warning-foreground",
   error: "border-destructive/40 bg-destructive/10 text-destructive",
+};
+
+const GITHUB_AUTH_SOURCE_LABEL: Record<GitHubAuthStatus["source"], string> = {
+  saved_token: "saved token",
+  env_token: "GITHUB_TOKEN",
+  gh_auth: "gh auth",
+  gh_auth_fallback: "gh auth fallback",
+  none: "not configured",
 };
 
 type WatchScope = (typeof WATCH_SCOPE_OPTIONS)[number]["value"];
@@ -421,6 +436,10 @@ export default function Settings() {
     queryKey: ["/api/github-rate-limit"],
     refetchInterval: uiPollIntervalMs,
   });
+  const { data: githubAuthStatus } = useQuery<GitHubAuthStatus>({
+    queryKey: ["/api/github-auth/status"],
+    refetchInterval: uiPollIntervalMs,
+  });
   const drainStatusView = getDrainStatusView(runtimeState, runtimeStateIsError);
   const globalDrainMode = runtimeState?.drainMode === true;
 
@@ -455,6 +474,7 @@ export default function Settings() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/config"] });
       queryClient.invalidateQueries({ queryKey: ["/api/onboarding/status"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/github-auth/status"] });
       toast({ description: "Settings saved." });
     },
     onError: (error) => {
@@ -500,6 +520,7 @@ export default function Settings() {
       return res.json() as Promise<GitHubTokenTestResponse>;
     },
     onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/github-auth/status"] });
       const entries: GitHubTokenTestLogEntry[] = result.results.length === 0
         ? [{ kind: "info", message: "No configured GitHub tokens to test." }]
         : result.results.map((data) => ({ kind: "result", data }));
@@ -1396,6 +1417,25 @@ export default function Settings() {
 
                 <SettingsSubsection id="delivery-github" title="GitHub">
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
+              <div
+                className="flex flex-col gap-2 border border-border/80 bg-background/40 p-3 sm:flex-row sm:items-center sm:justify-between"
+                data-testid="github-auth-status"
+              >
+                <div className="min-w-0">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground">Active account</div>
+                  <div className="truncate font-mono text-sm">
+                    {githubAuthStatus?.connected && githubAuthStatus.login
+                      ? `@${githubAuthStatus.login}`
+                      : "not connected"}
+                  </div>
+                  {githubAuthStatus?.error ? (
+                    <div className="mt-1 text-[11px] text-destructive">{githubAuthStatus.error}</div>
+                  ) : null}
+                </div>
+                <div className="shrink-0 text-[11px] text-muted-foreground">
+                  source: <span className="font-mono text-foreground">{GITHUB_AUTH_SOURCE_LABEL[githubAuthStatus?.source ?? "none"]}</span>
+                </div>
+              </div>
               <div className="flex flex-col gap-3">
                 <div className="flex items-center justify-between gap-3">
                   <div>

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -58,6 +58,7 @@ import {
   fetchPullSummary,
   formatRepoSlug,
   getDefaultBranchForRepo,
+  getGitHubAuthStatus,
   getLatestSemverTagForRepo,
   GitHubIntegrationError,
   installCodeReviewWorkflow,
@@ -133,6 +134,7 @@ export type AppRuntime = {
   stop(): void;
   subscribe(listener: () => void): () => void;
   getRuntimeSnapshot(): Promise<RuntimeSnapshot>;
+  getGitHubAuthStatus(): ReturnType<typeof getGitHubAuthStatus>;
   setDrainMode(input: DrainModeParams): Promise<RuntimeSnapshot & { drained?: boolean }>;
   listActivities(): Promise<ActivitySnapshot>;
   clearFailedActivities(): Promise<{ cleared: number }>;
@@ -1961,6 +1963,11 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
 
     getRuntimeSnapshot,
+
+    async getGitHubAuthStatus() {
+      const config = await storage.getConfig();
+      return getGitHubAuthStatus(config);
+    },
 
     async listActivities() {
       const [failedJobs, leasedJobs, queuedJobs] = await Promise.all([

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -16,6 +16,7 @@ import {
   fetchPullCloseState,
   fetchPullSummary,
   formatRepoSlug,
+  getGitHubAuthStatus,
   getLatestSemverTagForRepo,
   listOpenLinkedPullRequestsForIssue,
   listOpenIssuesForRepo,
@@ -72,6 +73,29 @@ function restoreEnvValue(name: string, value: string | undefined): void {
   }
 
   process.env[name] = value;
+}
+
+function fetchAuthenticatedUserByToken(loginsByToken: Record<string, string>): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = input instanceof Request
+      ? input.headers
+      : new Headers(init?.headers);
+    const auth = headers.get("authorization") ?? "";
+    const token = auth.split(/\s+/).pop() ?? "";
+    const login = loginsByToken[token];
+
+    if (!login) {
+      return new Response(JSON.stringify({ message: "Bad credentials" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ login }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
 }
 
 function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
@@ -367,6 +391,68 @@ test("resolveGitHubAuthToken falls back to env token after configured tokens", a
   } finally {
     restoreEnvValue("GITHUB_TOKEN", original);
   }
+});
+
+test("getGitHubAuthStatus reports the active saved token account", async () => {
+  await withoutGithubTokenEnv(async () => {
+    const status = await getGitHubAuthStatus(
+      { ...config, githubTokens: ["ghp_saved_token"] },
+      {
+        ignoreCache: true,
+        requestFetch: fetchAuthenticatedUserByToken({
+          ghp_saved_token: "saved-user",
+        }),
+      },
+    );
+
+    assert.deepEqual(status, {
+      connected: true,
+      login: "saved-user",
+      source: "saved_token",
+    });
+  });
+});
+
+test("getGitHubAuthStatus reports gh auth when no configured or env token exists", async () => {
+  await withoutGithubTokenEnv(async () => {
+    const status = await getGitHubAuthStatus(
+      config,
+      {
+        ignoreCache: true,
+        runCommandFn: async () => ({ stdout: "gho_cli_token\n", stderr: "", code: 0 }),
+        requestFetch: fetchAuthenticatedUserByToken({
+          gho_cli_token: "cli-user",
+        }),
+      },
+    );
+
+    assert.deepEqual(status, {
+      connected: true,
+      login: "cli-user",
+      source: "gh_auth",
+    });
+  });
+});
+
+test("getGitHubAuthStatus reports gh auth fallback when the saved token is denied", async () => {
+  await withoutGithubTokenEnv(async () => {
+    const status = await getGitHubAuthStatus(
+      { ...config, githubTokens: ["ghp_stale_token"] },
+      {
+        ignoreCache: true,
+        runCommandFn: async () => ({ stdout: "gho_cli_token\n", stderr: "", code: 0 }),
+        requestFetch: fetchAuthenticatedUserByToken({
+          gho_cli_token: "cli-user",
+        }),
+      },
+    );
+
+    assert.deepEqual(status, {
+      connected: true,
+      login: "cli-user",
+      source: "gh_auth_fallback",
+    });
+  });
 });
 
 test("checkOnboardingStatus reads workflow files with authenticated API content calls", async () => {

--- a/server/github.ts
+++ b/server/github.ts
@@ -1151,10 +1151,103 @@ export type OnboardingStatus = {
   repos: RepoOnboardingStatus[];
 };
 
+export type GitHubAuthStatus = {
+  connected: boolean;
+  login: string | null;
+  source: "saved_token" | "env_token" | "gh_auth" | "gh_auth_fallback" | "none";
+  error?: string;
+};
+
 type OnboardingStatusDeps = {
   buildOctokitFn?: typeof buildOctokit;
   resolveGitHubAuthTokenFn?: typeof resolveGitHubAuthToken;
 };
+
+async function probeGitHubAuthToken(
+  token: string,
+  deps: BuildOctokitDeps = {},
+): Promise<{ ok: true; login: string } | { ok: false; error: unknown }> {
+  const client = new Octokit({
+    auth: token,
+    log: octokitLogger,
+    request: {
+      ...(deps.requestFetch ? { fetch: deps.requestFetch } : {}),
+      headers: {
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+      },
+    },
+  });
+
+  try {
+    const { data } = await client.rest.users.getAuthenticated();
+    return { ok: true, login: data.login };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+export async function getGitHubAuthStatus(
+  config: Config,
+  deps: BuildOctokitDeps = {},
+): Promise<GitHubAuthStatus> {
+  const configuredToken = resolveConfiguredGitHubToken(config);
+  if (configuredToken) {
+    const configured = await probeGitHubAuthToken(configuredToken, deps);
+    if (configured.ok) {
+      return { connected: true, login: configured.login, source: "saved_token" };
+    }
+
+    if (shouldFallbackToGhAuth(configured.error)) {
+      const ghToken = await resolveGhAuthToken(deps);
+      if (ghToken && ghToken !== configuredToken) {
+        const gh = await probeGitHubAuthToken(ghToken, deps);
+        if (gh.ok) {
+          return { connected: true, login: gh.login, source: "gh_auth_fallback" };
+        }
+      }
+    }
+
+    return {
+      connected: false,
+      login: null,
+      source: "saved_token",
+      error: configured.error instanceof Error ? configured.error.message : String(configured.error),
+    };
+  }
+
+  const envToken = process.env.GITHUB_TOKEN?.trim();
+  if (envToken) {
+    const env = await probeGitHubAuthToken(envToken, deps);
+    return env.ok
+      ? { connected: true, login: env.login, source: "env_token" }
+      : {
+        connected: false,
+        login: null,
+        source: "env_token",
+        error: env.error instanceof Error ? env.error.message : String(env.error),
+      };
+  }
+
+  const ghToken = await resolveGhAuthToken(deps);
+  if (!ghToken) {
+    return {
+      connected: false,
+      login: null,
+      source: "none",
+      error: "No GitHub token found. Run `gh auth login`, set GITHUB_TOKEN, or add a saved token in settings.",
+    };
+  }
+
+  const gh = await probeGitHubAuthToken(ghToken, deps);
+  return gh.ok
+    ? { connected: true, login: gh.login, source: "gh_auth" }
+    : {
+      connected: false,
+      login: null,
+      source: "gh_auth",
+      error: gh.error instanceof Error ? gh.error.message : String(gh.error),
+    };
+}
 
 export async function checkOnboardingStatus(
   config: Config,

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -252,6 +252,31 @@ test("GET /api/github-rate-limit reports the current reset time", async () => {
   }
 });
 
+test("GET /api/github-auth/status reports the runtime auth account", async () => {
+  const fakeRuntime = {
+    start: async () => {},
+    stop: () => {},
+    getGitHubAuthStatus: async () => ({
+      connected: true,
+      login: "octocat",
+      source: "gh_auth" as const,
+    }),
+  } as AppRuntime;
+  const harness = await createHarness(undefined, { runtime: fakeRuntime });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/github-auth/status`);
+    assert.equal(response.status, 200);
+
+    const body = await response.json() as { connected: boolean; login: string | null; source: string };
+    assert.equal(body.connected, true);
+    assert.equal(body.login, "octocat");
+    assert.equal(body.source, "gh_auth");
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/github-tokens/test returns per-token diagnostics", async () => {
   const harness = await createHarness(new MemStorage(), {
     testGitHubTokensFn: async () => ({
@@ -1654,6 +1679,7 @@ test("GET and POST /api/issues proxy the runtime issue monitor and work action",
     },
     listActivities: async () => ({ failed: [], inProgress: [], queued: [], warnings: [], generatedAt: "2026-05-03T00:00:00.000Z" }),
     getRuntimeSnapshot: async () => ({ drainMode: false, drainRequestedAt: null, drainReason: null, activeRuns: 0 }),
+    getGitHubAuthStatus: async () => ({ connected: true, login: "octocat", source: "gh_auth" }),
     setDrainMode: async () => ({ drainMode: false, drainRequestedAt: null, drainReason: null, activeRuns: 0 }),
     clearFailedActivities: async () => ({ cleared: 0 }),
     listRepos: async () => [],

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -798,6 +798,14 @@ export async function registerRoutes(
     res.json(maskConfig(await runtime.getConfig()));
   });
 
+  app.get("/api/github-auth/status", async (_req, res) => {
+    try {
+      res.json(await runtime.getGitHubAuthStatus());
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.get("/api/app-update", async (_req, res) => {
     try {
       const currentVersion = process.env.APP_VERSION || "dev";


### PR DESCRIPTION
## Summary
- add a GitHub auth status endpoint that reports the active account and auth source without exposing tokens
- show the active GitHub account in Settings > GitHub
- distinguish saved token, GITHUB_TOKEN, gh auth, gh auth fallback, and missing auth states

## Notes
Patchdeck auth priority is saved Settings tokens first, then GITHUB_TOKEN, then the logged-in `gh auth` token. Saved-token 401/403 auth failures can fall back to `gh auth`, and the new status reports that as `gh auth fallback`.

## Tests
- `npm test -- server/github.test.ts server/routes.test.ts`
- `npm test -- client/src/lib/fullAppQaSurface.test.ts`
- `npm run check`
- `git diff --check`
