### PR TITLE
feat: surface agent run status

### DIFF
--- a/client/src/components/CurrentRunStatusStrip.tsx
+++ b/client/src/components/CurrentRunStatusStrip.tsx
@@ -1,0 +1,55 @@
+import { Bot, CheckCircle2, CircleDashed, Loader2, XCircle } from "lucide-react";
+import type { CurrentRunStatus } from "@shared/schema";
+
+type CurrentRunStatusStripProps = {
+  run: CurrentRunStatus | null | undefined;
+  testId: string;
+};
+
+function formatRunTime(value: string | null): string | null {
+  if (!value) return null;
+  return new Date(value).toLocaleTimeString("en-US", { hour12: false });
+}
+
+function statusClass(status: CurrentRunStatus["status"]): string {
+  if (status === "failed") return "border-destructive/40 bg-destructive/10 text-destructive";
+  if (status === "completed") return "border-success/40 bg-success/10 text-success";
+  if (status === "queued") return "border-primary/30 bg-primary/10 text-primary";
+  return "border-primary/40 bg-primary/10 text-primary";
+}
+
+function StatusIcon({ status }: { status: CurrentRunStatus["status"] }) {
+  if (status === "failed") return <XCircle className="h-3.5 w-3.5" aria-hidden="true" />;
+  if (status === "completed") return <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />;
+  if (status === "queued") return <CircleDashed className="h-3.5 w-3.5" aria-hidden="true" />;
+  return <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />;
+}
+
+export function CurrentRunStatusStrip({ run, testId }: CurrentRunStatusStripProps) {
+  if (!run) return null;
+
+  const updatedAt = formatRunTime(run.updatedAt);
+  const detail = run.lastError ?? run.detail;
+
+  return (
+    <div
+      data-testid={testId}
+      className={`mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 border px-3 py-2 text-[11px] ${statusClass(run.status)}`}
+    >
+      <span className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider">
+        <StatusIcon status={run.status} />
+        {run.status}
+      </span>
+      <span className="font-medium text-foreground">{run.label}</span>
+      {run.phase && <span className="font-mono text-muted-foreground">{run.phase}</span>}
+      {run.agent && (
+        <span className="inline-flex items-center gap-1 font-mono text-muted-foreground">
+          <Bot className="h-3 w-3" aria-hidden="true" />
+          {run.agent}
+        </span>
+      )}
+      {updatedAt && <span className="font-mono text-muted-foreground">updated {updatedAt}</span>}
+      {detail && <span className="min-w-0 flex-1 truncate text-muted-foreground">{detail}</span>}
+    </div>
+  );
+}

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -281,6 +281,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["PR on issues badge", "pr-on-issues-badge"],
     ["run-now action", "button-apply"],
     ["pause-resume watch action", "button-toggle-watch"],
+    ["selected PR current run", "selected-pr-current-run"],
     ["CI healing panel", "panel-ci-healing"],
     ["ask agent tab", "tab-ask"],
     ["activity tab", "tab-activity"],
@@ -306,6 +307,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasExpression(sourceFile, "feedback manual decisions", /\[\s*["']accept["']\s*,\s*["']reject["']\s*,\s*["']flag["']\s*\]/);
   assertHasExpression(sourceFile, "dashboard error scroll action", /\bscrollToDashboardErrors\b/);
   assertHasExpression(sourceFile, "dashboard errors panel component", /\bDashboardErrorsPanel\b/);
+  assertHasExpression(sourceFile, "PR current run strip", /\bCurrentRunStatusStrip\b/);
 
   for (const [label, endpoint] of [
     ["active PR API", "/api/prs"],
@@ -385,6 +387,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
     ["clear issue failures action", "button-clear-issue-failures"],
     ["issue work stage", "issue-work-stage"],
     ["issue work attempt", "issue-work-attempt"],
+    ["selected issue current run", "selected-issue-current-run"],
     ["issue auto work state", "issue-auto-work-state"],
     ["issue evaluation state", "issue-evaluation-state"],
     ["issue evaluation state list", "issue-evaluation-state-list"],
@@ -423,6 +426,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue PR mergeability", /\bworkPrMergeable\b/);
   assertHasExpression(sourceFile, "issue queue helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "issue queue badge", /\bQueueStatusBadge\b/);
+  assertHasExpression(sourceFile, "issue current run strip", /\bCurrentRunStatusStrip\b/);
   assertHasExpression(sourceFile, "issue filtered list", /\bfilteredIssues\b/);
   assertHasExpression(sourceFile, "issue pagination load more", /\bloadMoreIssues\b/);
   assertHasExpression(sourceFile, "issue loaded count", /\bloadedIssueCount\b/);

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -9,6 +9,7 @@ import { issueListPageSchema, issueSchema, type ActivityItem, type ActivitySnaps
 import { Skeleton } from "@/components/ui/skeleton";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import { CurrentRunStatusStrip } from "@/components/CurrentRunStatusStrip";
 import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 import { DashboardErrorsPanel } from "@/components/DashboardErrorsPanel";
 import { DetailHeader } from "@/components/detail/DetailHeader";
@@ -1873,6 +1874,7 @@ function IssuesPage() {
                     })()}
                   </>
                 )}
+                banner={<CurrentRunStatusStrip run={selectedIssue.currentRun} testId="selected-issue-current-run" />}
               />
                 );
               })()}

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/ciHealing";
 import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import { CurrentRunStatusStrip } from "@/components/CurrentRunStatusStrip";
 import { DashboardErrorsPanel } from "@/components/DashboardErrorsPanel";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DetailHeader } from "@/components/detail/DetailHeader";
@@ -1592,6 +1593,7 @@ export default function Dashboard() {
                 ) : undefined}
                 banner={(
                   <>
+                    <CurrentRunStatusStrip run={selectedPR.currentRun} testId="selected-pr-current-run" />
                     {isPRDetailReadyToMerge(selectedPR) && (
                       <ReadyToMergeIndicator
                         href={selectedPR.url}

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -126,6 +126,42 @@ test("runtime queueBabysit uses repo agent override when configured", async () =
   assert.equal(jobs[0]?.payload.preferredAgent, "codex");
 });
 
+test("runtime exposes the latest PR agent run status", async () => {
+  const storage = new MemStorage();
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+  });
+  const pr = await seedPR(storage, { status: "processing" });
+
+  await storage.upsertAgentRun({
+    id: "run-1",
+    prId: pr.id,
+    preferredAgent: "claude",
+    resolvedAgent: "claude",
+    status: "running",
+    phase: "run.agent-running",
+    prompt: null,
+    initialHeadSha: null,
+    metadata: null,
+    lastError: null,
+    createdAt: "2026-05-17T10:00:00.000Z",
+    updatedAt: "2026-05-17T10:01:00.000Z",
+  });
+  await storage.addLog(pr.id, "info", "Applying approved feedback", {
+    runId: "run-1",
+    phase: "run.agent-running",
+  });
+
+  const selected = await runtime.getPR(pr.id);
+
+  assert.equal(selected?.currentRun?.status, "running");
+  assert.equal(selected?.currentRun?.phase, "run.agent-running");
+  assert.equal(selected?.currentRun?.agent, "claude");
+  assert.equal(selected?.currentRun?.detail, "Applying approved feedback");
+});
+
 test("runtime setWatchEnabled updates the PR and emits a change event", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({
@@ -969,6 +1005,53 @@ test("syncIssue refreshes worked issue metadata from GitHub", async () => {
   const stored = await storage.getSyncedIssue("owner/repo", 7);
   assert.equal(stored?.isWorked, true, "refresh must preserve the worked marker");
   assert.equal(stored?.payload.title, "Fresh title");
+});
+
+test("runtime exposes queued issue work as current run status", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.enqueueBackgroundJob({
+    kind: "work_issue",
+    targetId: "owner/repo#7",
+    dedupeKey: "work_issue:owner/repo#7",
+  });
+  await storage.addLog("owner/repo#7", "info", "Queued manual issue work", {
+    phase: "issue.queued",
+    metadata: { stage: "queued" },
+  });
+
+  const fakeOctokit = {
+    issues: {
+      get: async () => ({
+        data: {
+          number: 7,
+          title: "Fix issue work",
+          body: "body",
+          html_url: "https://github.com/owner/repo/issues/7",
+          user: { login: "alice" },
+          labels: [],
+          assignees: [],
+          comments: 0,
+          created_at: "2026-05-03T17:00:00.000Z",
+          updated_at: "2026-05-16T18:00:00.000Z",
+        },
+      }),
+    },
+    paginate: async () => [],
+  };
+
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    buildOctokitFn: async () => fakeOctokit as never,
+  });
+
+  const selected = await runtime.getIssue("owner/repo", 7);
+
+  assert.equal(selected.currentRun?.status, "queued");
+  assert.equal(selected.currentRun?.phase, "issue.queued");
+  assert.equal(selected.currentRun?.detail, "Queued manual issue work");
 });
 
 test("pickWatcherColdStartDelayMs stays within the 15-45s cold-start window", () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -4,6 +4,7 @@ import type {
   ActivitySnapshot,
   BackgroundJob,
   Config,
+  CurrentRunStatus,
   Issue,
   IssueListPage,
   IssueEvaluation,
@@ -564,15 +565,70 @@ function derivePrStageFromLogs(logs: LogEntry[]): PRStage {
   return stage;
 }
 
+function formatRunPhaseLabel(phase: string | null | undefined): string {
+  if (!phase) return "Run active";
+  const normalized = phase.toLowerCase();
+  if (normalized.includes("sync")) return "Syncing GitHub";
+  if (normalized.includes("prompt")) return "Preparing work";
+  if (normalized.includes("agent-running") || normalized.includes("working")) return "Agent running";
+  if (normalized.includes("verify") || normalized.includes("ci")) return "Verifying";
+  if (normalized.includes("opening_pr")) return "Opening PR";
+  if (normalized.includes("completed") || normalized.includes("done")) return "Completed";
+  if (normalized.includes("failed")) return "Failed";
+  return phase.replace(/^run\./, "").replace(/[-_.]/g, " ");
+}
+
+function latestRunLog(logs: LogEntry[], runId: string): LogEntry | undefined {
+  for (let index = logs.length - 1; index >= 0; index -= 1) {
+    const logEntry = logs[index];
+    if (logEntry?.runId === runId) {
+      return logEntry;
+    }
+  }
+  return undefined;
+}
+
+async function deriveCurrentPrRun(pr: PR | PRSummary, storage: IStorage, logs?: LogEntry[]): Promise<CurrentRunStatus | null> {
+  const runs = await storage.listAgentRuns({ prId: pr.id });
+  const latestRun = runs
+    .slice()
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+  if (!latestRun) return null;
+
+  const prLogs = logs ?? await storage.getLogs(pr.id);
+  const detailLog = latestRunLog(prLogs, latestRun.id);
+  return {
+    id: latestRun.id,
+    status: latestRun.status,
+    phase: latestRun.phase,
+    label: formatRunPhaseLabel(latestRun.phase),
+    detail: detailLog?.message ?? latestRun.lastError,
+    agent: latestRun.resolvedAgent ?? latestRun.preferredAgent,
+    startedAt: latestRun.createdAt,
+    updatedAt: latestRun.updatedAt,
+    lastError: latestRun.lastError,
+  };
+}
+
 async function attachDerivedPrStage<T extends PR | PRSummary>(pr: T, storage: IStorage): Promise<T> {
+  const withCurrentRun = async (updates: Pick<PR, "prStage">): Promise<T> => ({
+    ...pr,
+    ...updates,
+    currentRun: await deriveCurrentPrRun(pr, storage),
+  });
+
   if (pr.status === "watching") {
-    return { ...pr, prStage: "feedback_synced" };
+    return withCurrentRun({ prStage: "feedback_synced" });
   }
   if (pr.status === "done" || pr.status === "archived") {
-    return { ...pr, prStage: "done" };
+    return withCurrentRun({ prStage: "done" });
   }
   const logs = await storage.getLogs(pr.id);
-  return { ...pr, prStage: derivePrStageFromLogs(logs) };
+  return {
+    ...pr,
+    prStage: derivePrStageFromLogs(logs),
+    currentRun: await deriveCurrentPrRun(pr, storage, logs),
+  };
 }
 
 function issueWorkStageFromLogs(
@@ -598,6 +654,34 @@ function issueWorkStageFromLogs(
   if (fallback === "in_progress") return "working";
   if (fallback === "failed") return "failed";
   return "idle";
+}
+
+function currentRunStatusFromIssueJob(
+  job: BackgroundJob | undefined,
+  logs: LogEntry[],
+  workStage: NonNullable<Issue["workStage"]>,
+): CurrentRunStatus | null {
+  if (!job) return null;
+
+  const latestLog = logs[logs.length - 1];
+  const phase = latestLog?.phase ?? workStage;
+  return {
+    id: job.id,
+    status: job.status === "failed"
+      ? "failed"
+      : job.status === "completed"
+        ? "completed"
+        : job.status === "queued"
+          ? "queued"
+          : "running",
+    phase,
+    label: formatRunPhaseLabel(phase),
+    detail: latestLog?.message ?? job.lastError,
+    agent: null,
+    startedAt: job.createdAt,
+    updatedAt: job.completedAt ?? job.updatedAt,
+    lastError: job.lastError,
+  };
 }
 
 export function issueWorkPrFromLogs(
@@ -1279,6 +1363,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       evaluationRecommendedLabels: evaluation?.recommendedLabels ?? [],
       evaluationUpdatedAt: evaluation?.updatedAt ?? null,
       subtasks: subtaskSet?.subtasks ?? null,
+      currentRun: currentRunStatusFromIssueJob(latestJob, workLogs, workStage),
     };
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -57,6 +57,19 @@ export const docsAssessmentSchema = z.object({
 });
 export type DocsAssessment = z.infer<typeof docsAssessmentSchema>;
 
+export const currentRunStatusSchema = z.object({
+  id: z.string(),
+  status: z.enum(["queued", "running", "completed", "failed"]),
+  phase: z.string().nullable(),
+  label: z.string(),
+  detail: z.string().nullable(),
+  agent: z.enum(["codex", "claude"]).nullable(),
+  startedAt: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+  lastError: z.string().nullable(),
+});
+export type CurrentRunStatus = z.infer<typeof currentRunStatusSchema>;
+
 export const prSchema = z.object({
   id: z.string(),
   number: z.number(),
@@ -82,6 +95,7 @@ export const prSchema = z.object({
   lastSyncError: z.string().nullable().default(null),
   watchEnabled: z.boolean().default(true),
   docsAssessment: docsAssessmentSchema.nullable().optional(),
+  currentRun: currentRunStatusSchema.nullable().optional(),
   addedAt: z.string(),
 });
 export type PR = z.infer<typeof prSchema>;
@@ -273,6 +287,7 @@ export const issueSchema = z.object({
   evaluationRecommendedLabels: z.array(z.string()).optional(),
   evaluationUpdatedAt: z.string().nullable().optional(),
   subtasks: z.array(issueSubtaskSchema).nullable().optional(),
+  currentRun: currentRunStatusSchema.nullable().optional(),
 });
 export type Issue = z.infer<typeof issueSchema>;
 


### PR DESCRIPTION
## Summary
- expose compact current-run status on PR and issue API models
- derive PR status from the latest agent run journal and issue status from durable work jobs/stage logs
- show the current run strip in PR and issue detail headers

## Tests
- npm run check
- npm test -- server/appRuntime.test.ts
- npm test -- client/src/lib/fullAppQaSurface.test.ts
- npm run build
- git diff --check

Note: `npm test -- ...` expands through the repo test script and passed the broader server/client surface as well. `/simplify` was invoked for the changed files but produced no output and made no edits before being stopped.