### PR TITLE
fix: clarify completed run status tone

### DIFF
--- a/client/src/components/CurrentRunStatusStrip.tsx
+++ b/client/src/components/CurrentRunStatusStrip.tsx
@@ -13,7 +13,7 @@ function formatRunTime(value: string | null): string | null {
 
 function statusClass(status: CurrentRunStatus["status"]): string {
   if (status === "failed") return "border-destructive/40 bg-destructive/10 text-destructive";
-  if (status === "completed") return "border-success/40 bg-success/10 text-success";
+  if (status === "completed") return "border-warning-border bg-warning-muted text-warning-foreground";
   if (status === "queued") return "border-primary/30 bg-primary/10 text-primary";
   return "border-primary/40 bg-primary/10 text-primary";
 }

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -285,6 +285,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["CI healing panel", "panel-ci-healing"],
     ["ask agent tab", "tab-ask"],
     ["activity tab", "tab-activity"],
+    ["activity panel toggle", "button-toggle-activity-panel"],
     ["ask input", "input-question"],
     ["ask submit", "button-ask"],
     ["dashboard error pill", "dashboard-error-pill"],
@@ -334,7 +335,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasExpression(sourceFile, "PR number search helper", /\bmatchesNumberSearch\b/);
   assertHasStringValue(sourceFile, "PR number search placeholder", "Search #");
   assertHasExpression(sourceFile, "issue-linked PR index", /\bbuildIssueLinkedPRIndex\b/);
-  assertHasStringValue(sourceFile, "on issues tab label", /Issues \(/);
+  assertHasStringValue(sourceFile, "linked issues tab label", /Linked Issues \(/);
   assertHasStringValue(sourceFile, "dashboard sync label", "sync");
   assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
   assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type MouseEvent, type React
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, Pause, Play, PlayCircle, RefreshCw } from "lucide-react";
+import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, PanelRightClose, PanelRightOpen, Pause, Play, PlayCircle, RefreshCw } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, RuntimeState, WatchedRepo } from "@shared/schema";
 import { AppHeader } from "@/components/AppHeader";
@@ -859,16 +859,51 @@ function PRDescriptionPanel({ pr }: { pr: PR }) {
   );
 }
 
-function RightPanel({ prId }: { prId: string | null }) {
+function RightPanel({
+  prId,
+  isCollapsed,
+  onToggleCollapsed,
+}: {
+  prId: string | null;
+  isCollapsed: boolean;
+  onToggleCollapsed: () => void;
+}) {
+  if (isCollapsed) {
+    return (
+      <div className="flex h-10 w-full shrink-0 items-center justify-end border-t border-border px-2 lg:h-auto lg:w-10 lg:flex-col lg:justify-start lg:border-l lg:border-t-0 lg:px-0 lg:py-2" data-testid="activity-panel-collapsed">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          data-testid="button-toggle-activity-panel"
+          title="Expand activity"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <PanelRightOpen className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Expand activity</span>
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
-      <div className="flex shrink-0 border-b border-border">
+      <div className="flex shrink-0 items-center border-b border-border">
         <div
           className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
           data-testid="tab-activity"
         >
           Activity
         </div>
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          data-testid="button-toggle-activity-panel"
+          title="Collapse activity"
+          className="mr-2 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <PanelRightClose className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Collapse activity</span>
+        </button>
       </div>
       <div className="flex-1 overflow-hidden">
         <LogPanel prId={prId} />
@@ -1023,6 +1058,7 @@ export default function Dashboard() {
   const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isAskOpen, setIsAskOpen] = useState(false);
+  const [isActivityPanelCollapsed, setIsActivityPanelCollapsed] = useState(false);
 
   const handleSyncDashboard = async () => {
     setIsRefreshing(true);
@@ -1354,7 +1390,7 @@ export default function Dashboard() {
       <DashboardDrainBanner runtimeState={runtimeState} />
 
       <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
-        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[42rem] lg:border-b-0 lg:border-r">
+        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[32rem] xl:w-[34rem] lg:border-b-0 lg:border-r">
           <div className="sticky top-0 z-10 flex shrink-0 border-b border-border bg-background">
             <button
               type="button"
@@ -1378,7 +1414,7 @@ export default function Dashboard() {
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              Issues ({issueLinkedPRs.length})
+              Linked Issues ({issueLinkedPRs.length})
             </button>
             <button
               type="button"
@@ -1462,7 +1498,7 @@ export default function Dashboard() {
                   : isArchived
                     ? "No archived PRs. Closed PRs are archived automatically."
                     : viewMode === "issues"
-                      ? "No active PRs are linked from Issues yet."
+                      ? "No active PRs are linked from issues yet."
                   : "No PRs tracked yet. Add a repository or PR from Settings."}
               </div>
             ) : (
@@ -1659,6 +1695,8 @@ export default function Dashboard() {
 
         <RightPanel
           prId={selectedPRId}
+          isCollapsed={isActivityPanelCollapsed}
+          onToggleCollapsed={() => setIsActivityPanelCollapsed((current) => !current)}
         />
       </div>
       <div className="fixed bottom-4 right-4 z-50">

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -573,7 +573,7 @@ function formatRunPhaseLabel(phase: string | null | undefined): string {
   if (normalized.includes("agent-running") || normalized.includes("working")) return "Agent running";
   if (normalized.includes("verify") || normalized.includes("ci")) return "Verifying";
   if (normalized.includes("opening_pr")) return "Opening PR";
-  if (normalized.includes("completed") || normalized.includes("done")) return "Completed";
+  if (normalized.includes("completed") || normalized.includes("done")) return "Run finished";
   if (normalized.includes("failed")) return "Failed";
   return phase.replace(/^run\./, "").replace(/[-_.]/g, " ");
 }


### PR DESCRIPTION
## Summary
- render completed automation runs as warning/yellow instead of green
- label completed phases as "Run finished" so green remains reserved for actual ready-to-merge state

## Tests
- npm run check
- npm test -- server/appRuntime.test.ts
- npm test -- client/src/lib/fullAppQaSurface.test.ts
- git diff --check

Note: the first client QA attempt failed because this worktree was missing its local TypeScript package; `npm install` restored dependencies and the rerun passed.