### PR TITLE
fix: clear stale drain state and improve log views

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -8,7 +8,7 @@ import { Switch } from "@/components/ui/switch";
 import { ToastAction } from "@/components/ui/toast";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { toast } from "@/hooks/use-toast";
-import { getUiPollIntervalMs } from "@/lib/polling";
+import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
 
 type AppHeaderSection = "dashboard" | "prs" | "issues" | "releases" | "logs" | "settings";
 type GitHubRateLimitState = {
@@ -297,7 +297,7 @@ function GitHubRateLimitNotice() {
   const recentlyLimited = githubRateLimit?.recentlyLimited === true;
   const { data: activities } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
-    refetchInterval: uiPollIntervalMs,
+    refetchInterval: ACTIVITY_POLL_INTERVAL_MS,
     enabled: !explicitlyLimited,
   });
 

--- a/client/src/components/GlobalActivityPanel.tsx
+++ b/client/src/components/GlobalActivityPanel.tsx
@@ -1,0 +1,96 @@
+import type { ActivityItem, ActivitySnapshot } from "@shared/schema";
+import { QueueStatusBadge } from "@/components/QueueStatusBadge";
+import type { QueueStatusView } from "@/lib/activityQueue";
+
+function formatClock(timestamp: string | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
+}
+
+export function GlobalActivityPanel({
+  activities,
+  queueStatusById,
+}: {
+  activities: ActivitySnapshot;
+  queueStatusById: Map<string, QueueStatusView>;
+}) {
+  const visibleActivities = [...activities.inProgress, ...activities.queued, ...activities.failed].slice(0, 5);
+
+  return (
+    <div className="shrink-0 border-b border-border px-3 py-2" data-testid="global-activity-panel">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Automation</div>
+        <div className="flex shrink-0 items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span><span className="font-mono text-foreground/80">{activities.inProgress.length}</span> running</span>
+          <span><span className="font-mono text-foreground/80">{activities.queued.length}</span> queued</span>
+        </div>
+      </div>
+      {visibleActivities.length === 0 ? (
+        <div className="mt-2 text-[11px] text-muted-foreground">No automation running or queued.</div>
+      ) : (
+        <div className="mt-2 space-y-1">
+          {visibleActivities.map((activity) => (
+            <GlobalActivityRow
+              key={activity.id}
+              activity={activity}
+              queueStatus={queueStatusById.get(activity.targetId) ?? null}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GlobalActivityRow({
+  activity,
+  queueStatus,
+}: {
+  activity: ActivityItem;
+  queueStatus: QueueStatusView | null;
+}) {
+  const statusClass = activity.status === "failed"
+    ? "border-destructive/50 text-destructive"
+    : activity.status === "in_progress"
+      ? "border-primary/50 text-primary"
+      : "border-border text-muted-foreground";
+  const timeLabel = activity.status === "in_progress"
+    ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
+    : formatClock(activity.availableAt) ?? formatClock(activity.updatedAt);
+  const content = (
+    <div
+      className="min-w-0 rounded-md border border-border/70 bg-background px-2 py-1.5"
+      data-testid="global-activity-row"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${statusClass}`}>
+          {activity.status === "in_progress" ? "running" : activity.status}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{activity.label}</span>
+        {timeLabel && <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{timeLabel}</span>}
+      </div>
+      {activity.detail && (
+        <div className="mt-1 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
+      )}
+      <div className="mt-1">
+        <QueueStatusBadge status={queueStatus} />
+      </div>
+      {activity.lastError && (
+        <div className="mt-1 line-clamp-2 text-[11px] text-destructive">{activity.lastError}</div>
+      )}
+    </div>
+  );
+
+  if (activity.targetUrl) {
+    return (
+      <a href={activity.targetUrl} target="_blank" rel="noopener noreferrer" className="block outline-none focus-visible:ring-1 focus-visible:ring-ring">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+}

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -408,7 +408,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue work logs", /\bissueLogs\b/);
   assertHasExpression(sourceFile, "issue body html rendering", /\bbodyHtml\b/);
   assertHasExpression(sourceFile, "issue markdown class", /issue-markdown/);
-  assertHasExpression(sourceFile, "issue author line", /by\s+\{issue\.author\s*\|\|\s*["']unknown["']\}/);
+  assertHasExpression(sourceFile, "issue author line", /by\s+\{formatGitHubUsername\(issue\.author\)\}/);
   assertHasExpression(sourceFile, "issue log metadata chips", /\bgetLogMetadataEntries\b/);
   assertHasExpression(sourceFile, "issue work pr field", /\bworkPrUrl\b/);
   assertHasExpression(sourceFile, "issue work stage field", /\bworkStage\b/);
@@ -517,6 +517,7 @@ test("logs route keeps the QA-tested filtering, streaming, copy, and download su
   assertHasJsxAttribute(sourceFile, "id", "source filter", "logs-source");
   assertHasJsxAttribute(sourceFile, "type", "search input", "search");
   assertHasStringValue(sourceFile, "follow tail toggle", "follow tail");
+  assertHasStringValue(sourceFile, "clear view action", "clear view");
   assertHasExpression(sourceFile, "copy action", /navigator\.clipboard\.writeText/);
   assertHasExpression(sourceFile, "download action", /patchdeck-logs-/);
 });

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -271,6 +271,7 @@ test("full app QA route matrix is wired through the hash router", async () => {
 
 test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows wired", async () => {
   const { sourceFile } = await parseProjectFile("client/src/pages/prs.tsx");
+  const { sourceFile: globalActivitySourceFile } = await parseProjectFile("client/src/components/GlobalActivityPanel.tsx");
   const { sourceFile: dashboardErrorsSourceFile } = await parseProjectFile("client/src/components/DashboardErrorsPanel.tsx");
 
   for (const [label, testId] of [
@@ -286,8 +287,6 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["ask agent tab", "tab-ask"],
     ["activity tab", "tab-activity"],
     ["activity panel toggle", "button-toggle-activity-panel"],
-    ["global activity panel", "global-activity-panel"],
-    ["global activity row", "global-activity-row"],
     ["ask input", "input-question"],
     ["ask submit", "button-ask"],
     ["dashboard error pill", "dashboard-error-pill"],
@@ -338,8 +337,10 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasStringValue(sourceFile, "PR number search placeholder", "Search #");
   assertHasExpression(sourceFile, "issue-linked PR index", /\bbuildIssueLinkedPRIndex\b/);
   assertHasStringValue(sourceFile, "linked issues tab label", /Linked Issues \(/);
-  assertHasStringValue(sourceFile, "global activity heading", "Automation");
-  assertHasStringValue(sourceFile, "global activity empty state", "No automation running or queued.");
+  assertHasTestId(globalActivitySourceFile, "global activity panel", "global-activity-panel");
+  assertHasTestId(globalActivitySourceFile, "global activity row", "global-activity-row");
+  assertHasStringValue(globalActivitySourceFile, "global activity heading", "Automation");
+  assertHasStringValue(globalActivitySourceFile, "global activity empty state", "No automation running or queued.");
   assertHasStringValue(sourceFile, "dashboard sync label", "sync");
   assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
   assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");
@@ -352,6 +353,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasExpression(sourceFile, "dashboard issues drain guard", /enabled: runtimeState !== undefined && !globalDrainMode/);
   assertHasExpression(sourceFile, "dashboard active error count", /\bactiveErrorCount\b/);
   assertHasExpression(sourceFile, "dashboard errors roll-up state", /\bareErrorsRolledUp\b/);
+  assertHasExpression(sourceFile, "global automation panel", /\bGlobalActivityPanel\b/);
 });
 
 test("issues page keeps the QA-tested issue monitor and work surface wired", async () => {
@@ -431,6 +433,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue PR mergeability", /\bworkPrMergeable\b/);
   assertHasExpression(sourceFile, "issue queue helper", /\bbuildQueueStatusIndex\b/);
   assertHasExpression(sourceFile, "issue queue badge", /\bQueueStatusBadge\b/);
+  assertHasExpression(sourceFile, "issue activity automation panel", /\bGlobalActivityPanel\b/);
   assertHasExpression(sourceFile, "issue current run strip", /\bCurrentRunStatusStrip\b/);
   assertHasExpression(sourceFile, "issue filtered list", /\bfilteredIssues\b/);
   assertHasExpression(sourceFile, "issue pagination load more", /\bloadMoreIssues\b/);

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -286,6 +286,8 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["ask agent tab", "tab-ask"],
     ["activity tab", "tab-activity"],
     ["activity panel toggle", "button-toggle-activity-panel"],
+    ["global activity panel", "global-activity-panel"],
+    ["global activity row", "global-activity-row"],
     ["ask input", "input-question"],
     ["ask submit", "button-ask"],
     ["dashboard error pill", "dashboard-error-pill"],
@@ -336,6 +338,8 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasStringValue(sourceFile, "PR number search placeholder", "Search #");
   assertHasExpression(sourceFile, "issue-linked PR index", /\bbuildIssueLinkedPRIndex\b/);
   assertHasStringValue(sourceFile, "linked issues tab label", /Linked Issues \(/);
+  assertHasStringValue(sourceFile, "global activity heading", "Automation");
+  assertHasStringValue(sourceFile, "global activity empty state", "No automation running or queued.");
   assertHasStringValue(sourceFile, "dashboard sync label", "sync");
   assertHasStringValue(sourceFile, "drain mode action label", "Paused by drain mode");
   assertHasStringValue(sourceFile, "blocked manual copy", "Manual runs are blocked while global automation is paused.");

--- a/client/src/lib/polling.test.ts
+++ b/client/src/lib/polling.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getUiPollIntervalMs } from "./polling";
+import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "./polling";
 
 test("getUiPollIntervalMs follows configured watcher interval", () => {
   assert.equal(getUiPollIntervalMs({ pollIntervalMs: 600_000 }), 600_000);
@@ -10,4 +10,8 @@ test("getUiPollIntervalMs follows configured watcher interval", () => {
 test("getUiPollIntervalMs clamps short or missing intervals", () => {
   assert.equal(getUiPollIntervalMs({ pollIntervalMs: 1_000 }), 10_000);
   assert.equal(getUiPollIntervalMs(null), 600_000);
+});
+
+test("activity polling stays fast independent of GitHub tuning interval", () => {
+  assert.equal(ACTIVITY_POLL_INTERVAL_MS, 3_000);
 });

--- a/client/src/lib/polling.ts
+++ b/client/src/lib/polling.ts
@@ -2,6 +2,7 @@ import type { Config } from "@shared/schema";
 
 const DEFAULT_UI_POLL_INTERVAL_MS = 600_000;
 const MIN_UI_POLL_INTERVAL_MS = 10_000;
+export const ACTIVITY_POLL_INTERVAL_MS = 3_000;
 
 export function getUiPollIntervalMs(config?: Pick<Config, "pollIntervalMs"> | null): number {
   const configured = config?.pollIntervalMs ?? DEFAULT_UI_POLL_INTERVAL_MS;

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -10,6 +10,7 @@ import { DetailPanel } from "@/components/detail/DetailPanel";
 import { StatusChip } from "@/components/detail/StatusChip";
 import { EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ACTIVITY_POLL_INTERVAL_MS } from "@/lib/polling";
 
 type PRBreakdown = {
   total: number;
@@ -360,6 +361,7 @@ export default function Dashboard() {
   });
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
+    refetchInterval: ACTIVITY_POLL_INTERVAL_MS,
   });
 
   const watchedRepos = config?.watchedRepos ?? [];

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -12,6 +12,7 @@ import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import { CurrentRunStatusStrip } from "@/components/CurrentRunStatusStrip";
 import { ActivityMenu, EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 import { DashboardErrorsPanel } from "@/components/DashboardErrorsPanel";
+import { GlobalActivityPanel } from "@/components/GlobalActivityPanel";
 import { DetailHeader } from "@/components/detail/DetailHeader";
 import { DetailPanel } from "@/components/detail/DetailPanel";
 import { MetaBreadcrumb, type MetaItem } from "@/components/detail/MetaBreadcrumb";
@@ -643,7 +644,19 @@ function IssueLogRow({ entry }: { entry: LogEntry }) {
   );
 }
 
-function IssueLogPanel({ logs, selected, selectedKey }: { logs: LogEntry[]; selected: boolean; selectedKey: string | null }) {
+function IssueLogPanel({
+  logs,
+  selected,
+  selectedKey,
+  activities,
+  queueStatusById,
+}: {
+  logs: LogEntry[];
+  selected: boolean;
+  selectedKey: string | null;
+  activities: ActivitySnapshot;
+  queueStatusById: Map<string, QueueStatusView>;
+}) {
   const [clearedLogIds, setClearedLogIds] = useState<Set<string>>(() => new Set());
   const viewLogs = useMemo(
     () => logs.filter((log) => !clearedLogIds.has(log.id)),
@@ -664,6 +677,7 @@ function IssueLogPanel({ logs, selected, selectedKey }: { logs: LogEntry[]; sele
           Activity
         </div>
       </div>
+      <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} />
       <div className="flex-1 overflow-y-auto" data-testid="issue-detail-logs">
         {!selected ? (
           <div className="p-4 text-[12px] text-muted-foreground">
@@ -2109,7 +2123,13 @@ function IssuesPage() {
           )}
         </div>
 
-        <IssueLogPanel logs={issueLogs} selected={Boolean(selectedIssue)} selectedKey={selectedIssue?.id ?? null} />
+        <IssueLogPanel
+          logs={issueLogs}
+          selected={Boolean(selectedIssue)}
+          selectedKey={selectedIssue?.id ?? null}
+          activities={activities}
+          queueStatusById={queueStatusById}
+        />
       </div>
     </div>
   );

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -94,6 +94,11 @@ function formatDateTime(value: string | null | undefined): string {
   });
 }
 
+function formatGitHubUsername(username?: string | null): string {
+  const normalized = username?.trim().replace(/^@/, "");
+  return normalized ? `@${normalized}` : "@unknown";
+}
+
 function formatBodyPreview(body: string | null | undefined): string {
   if (!body) return "No body provided.";
   const text = body.trim().replace(/\s+/g, " ");
@@ -440,7 +445,7 @@ function IssueRow({
             {issue.repo} <span className="font-mono text-foreground/70">#{issue.number}</span>
           </div>
           <div className="mt-0.5 text-[11px] text-muted-foreground">
-            by {issue.author || "unknown"}
+            by {formatGitHubUsername(issue.author)}
           </div>
           <div className="mt-1 line-clamp-2 text-[12px] leading-5 text-muted-foreground">
             {formatBodyPreview(issue.body)}
@@ -638,7 +643,17 @@ function IssueLogRow({ entry }: { entry: LogEntry }) {
   );
 }
 
-function IssueLogPanel({ logs, selected }: { logs: LogEntry[]; selected: boolean }) {
+function IssueLogPanel({ logs, selected, selectedKey }: { logs: LogEntry[]; selected: boolean; selectedKey: string | null }) {
+  const [clearedLogIds, setClearedLogIds] = useState<Set<string>>(() => new Set());
+  const viewLogs = useMemo(
+    () => logs.filter((log) => !clearedLogIds.has(log.id)),
+    [clearedLogIds, logs],
+  );
+
+  useEffect(() => {
+    setClearedLogIds(new Set());
+  }, [selectedKey]);
+
   return (
     <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
       <div className="flex shrink-0 border-b border-border">
@@ -658,8 +673,26 @@ function IssueLogPanel({ logs, selected }: { logs: LogEntry[]; selected: boolean
           <div className="p-4 text-[12px] text-muted-foreground">
             No workflow logs yet.
           </div>
+        ) : viewLogs.length === 0 ? (
+          <div className="p-4 text-[12px] text-muted-foreground">
+            View cleared. New log entries will appear here.
+          </div>
         ) : (
-          logs.map((entry) => <IssueLogRow key={entry.id} entry={entry} />)
+          <>
+            <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                {viewLogs.length} visible
+              </span>
+              <button
+                type="button"
+                onClick={() => setClearedLogIds(new Set(logs.map((log) => log.id)))}
+                className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                Clear view
+              </button>
+            </div>
+            {viewLogs.map((entry) => <IssueLogRow key={entry.id} entry={entry} />)}
+          </>
         )}
       </div>
     </div>
@@ -1715,7 +1748,7 @@ function IssuesPage() {
               {(() => {
                 const metaItems: MetaItem[] = [
                   { key: "repo", content: <span>{selectedIssue.repo} <span className="font-mono text-foreground/80">#{selectedIssue.number}</span></span> },
-                  { key: "author", content: <span>author: <span className="text-foreground/80">{selectedIssue.author || "unknown"}</span></span> },
+                  { key: "author", content: <span>author: <span className="text-foreground/80">{formatGitHubUsername(selectedIssue.author)}</span></span> },
                   { key: "comments", content: <span>comments: <span className="font-mono text-foreground/80">{selectedIssue.comments}</span></span> },
                   { key: "updated", content: <span>updated <span className="font-mono">{formatDateTime(selectedIssue.updatedAt)}</span></span> },
                 ];
@@ -2076,7 +2109,7 @@ function IssuesPage() {
           )}
         </div>
 
-        <IssueLogPanel logs={issueLogs} selected={Boolean(selectedIssue)} />
+        <IssueLogPanel logs={issueLogs} selected={Boolean(selectedIssue)} selectedKey={selectedIssue?.id ?? null} />
       </div>
     </div>
   );

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -19,7 +19,7 @@ import { StageProgressBar } from "@/components/detail/StageProgressBar";
 import { StatusChip } from "@/components/detail/StatusChip";
 import { buildIssueStages } from "@/lib/stages";
 import { autoWorkTone, issueEvaluationTone, issueRowTone, issueWorkStatusTone, toneRailClass } from "@/lib/statusTones";
-import { getUiPollIntervalMs } from "@/lib/polling";
+import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
 
 const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v2";
 const ISSUES_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
@@ -741,7 +741,7 @@ function IssuesPage() {
   const globalDrainMode = runtime?.drainMode === true;
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
-    refetchInterval: LIVE_POLL_INTERVAL_MS,
+    refetchInterval: ACTIVITY_POLL_INTERVAL_MS,
   });
   const { data: config } = useQuery<Config>({ queryKey: ["/api/config"] });
   const uiPollIntervalMs = getUiPollIntervalMs(config);
@@ -1410,7 +1410,7 @@ function IssuesPage() {
               isClearingFailed={clearFailedActivitiesMutation.isPending}
               globalDrainMode={Boolean(runtime?.drainMode)}
               queueStatusById={queueStatusById}
-              pollIntervalMs={config?.pollIntervalMs}
+              pollIntervalMs={ACTIVITY_POLL_INTERVAL_MS}
             />
           </>
         )}

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -6,6 +6,7 @@ import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import type { ActivitySnapshot } from "@shared/schema";
 import { EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
+import { ACTIVITY_POLL_INTERVAL_MS } from "@/lib/polling";
 
 const LEVELS = ["trace", "debug", "info", "warn", "error", "fatal"] as const;
 type Level = (typeof LEVELS)[number];
@@ -114,7 +115,7 @@ export default function Logs() {
   const [clearedRecordSeqs, setClearedRecordSeqs] = useState<Set<number>>(() => new Set());
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
-    refetchInterval: 3000,
+    refetchInterval: ACTIVITY_POLL_INTERVAL_MS,
   });
 
   const recordsRef = useRef<LogRecord[]>([]);

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -111,6 +111,7 @@ export default function Logs() {
   const [records, setRecords] = useState<LogRecord[]>([]);
   const [sources, setSources] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [clearedRecordSeqs, setClearedRecordSeqs] = useState<Set<number>>(() => new Set());
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
     refetchInterval: 3000,
@@ -187,7 +188,7 @@ export default function Logs() {
   useEffect(() => { setUrlParams({ follow }); }, [follow]);
 
   const filteredRecords = useMemo(() => {
-    let out = records;
+    let out = records.filter((record) => !clearedRecordSeqs.has(record.seq));
     if (level) {
       const minRank = LEVEL_RANK[level];
       out = out.filter((r) => LEVEL_RANK[r.level] >= minRank);
@@ -201,7 +202,7 @@ export default function Logs() {
       );
     }
     return out;
-  }, [records, level, source, searchTerm]);
+  }, [clearedRecordSeqs, records, level, source, searchTerm]);
 
   const activityItems = useMemo(
     () => [...activities.failed, ...activities.inProgress, ...activities.queued]
@@ -216,6 +217,16 @@ export default function Logs() {
     } catch {
       /* ignore */
     }
+  };
+
+  const onClearView = () => {
+    setClearedRecordSeqs((current) => {
+      const next = new Set(current);
+      for (const record of filteredRecords) {
+        next.add(record.seq);
+      }
+      return next;
+    });
   };
 
   const onDownload = () => {
@@ -288,6 +299,14 @@ export default function Logs() {
           className="cursor-pointer rounded-md border border-border bg-transparent px-2.5 py-0.5 font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
           copy
+        </button>
+        <button
+          type="button"
+          onClick={onClearView}
+          disabled={filteredRecords.length === 0}
+          className="cursor-pointer rounded-md border border-border bg-transparent px-2.5 py-0.5 font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          clear view
         </button>
         <button
           type="button"

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -29,6 +29,7 @@ import { buildQueueStatusIndex, type QueueStatusView } from "@/lib/activityQueue
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import { CurrentRunStatusStrip } from "@/components/CurrentRunStatusStrip";
 import { DashboardErrorsPanel } from "@/components/DashboardErrorsPanel";
+import { GlobalActivityPanel } from "@/components/GlobalActivityPanel";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DetailHeader } from "@/components/detail/DetailHeader";
 import { MetaBreadcrumb, type MetaItem } from "@/components/detail/MetaBreadcrumb";
@@ -753,94 +754,6 @@ function LogPanel({ prId }: { prId: string | null }) {
       </div>
     </div>
   );
-}
-
-function GlobalActivityPanel({
-  activities,
-  queueStatusById,
-}: {
-  activities: ActivitySnapshot;
-  queueStatusById: Map<string, QueueStatusView>;
-}) {
-  const visibleActivities = useMemo(
-    () => [...activities.inProgress, ...activities.queued, ...activities.failed].slice(0, 5),
-    [activities.failed, activities.inProgress, activities.queued],
-  );
-
-  return (
-    <div className="shrink-0 border-b border-border px-3 py-2" data-testid="global-activity-panel">
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Automation</div>
-        <div className="flex shrink-0 items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-          <span><span className="font-mono text-foreground/80">{activities.inProgress.length}</span> running</span>
-          <span><span className="font-mono text-foreground/80">{activities.queued.length}</span> queued</span>
-        </div>
-      </div>
-      {visibleActivities.length === 0 ? (
-        <div className="mt-2 text-[11px] text-muted-foreground">No automation running or queued.</div>
-      ) : (
-        <div className="mt-2 space-y-1">
-          {visibleActivities.map((activity) => (
-            <GlobalActivityRow
-              key={activity.id}
-              activity={activity}
-              queueStatus={queueStatusById.get(activity.targetId) ?? null}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function GlobalActivityRow({
-  activity,
-  queueStatus,
-}: {
-  activity: ActivityItem;
-  queueStatus: QueueStatusView | null;
-}) {
-  const statusClass = activity.status === "failed"
-    ? "border-destructive/50 text-destructive"
-    : activity.status === "in_progress"
-      ? "border-primary/50 text-primary"
-      : "border-border text-muted-foreground";
-  const timeLabel = activity.status === "in_progress"
-    ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
-    : formatClock(activity.availableAt) ?? formatClock(activity.updatedAt);
-  const content = (
-    <div
-      className="min-w-0 rounded-md border border-border/70 bg-background px-2 py-1.5"
-      data-testid="global-activity-row"
-    >
-      <div className="flex min-w-0 items-center gap-2">
-        <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${statusClass}`}>
-          {activity.status === "in_progress" ? "running" : activity.status}
-        </span>
-        <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{activity.label}</span>
-        {timeLabel && <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{timeLabel}</span>}
-      </div>
-      {activity.detail && (
-        <div className="mt-1 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
-      )}
-      <div className="mt-1">
-        <QueueStatusBadge status={queueStatus} />
-      </div>
-      {activity.lastError && (
-        <div className="mt-1 line-clamp-2 text-[11px] text-destructive">{activity.lastError}</div>
-      )}
-    </div>
-  );
-
-  if (activity.targetUrl) {
-    return (
-      <a href={activity.targetUrl} target="_blank" rel="noopener noreferrer" className="block outline-none focus-visible:ring-1 focus-visible:ring-ring">
-        {content}
-      </a>
-    );
-  }
-
-  return content;
 }
 
 function HealingPanel({

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -755,6 +755,94 @@ function LogPanel({ prId }: { prId: string | null }) {
   );
 }
 
+function GlobalActivityPanel({
+  activities,
+  queueStatusById,
+}: {
+  activities: ActivitySnapshot;
+  queueStatusById: Map<string, QueueStatusView>;
+}) {
+  const visibleActivities = useMemo(
+    () => [...activities.inProgress, ...activities.queued, ...activities.failed].slice(0, 5),
+    [activities.failed, activities.inProgress, activities.queued],
+  );
+
+  return (
+    <div className="shrink-0 border-b border-border px-3 py-2" data-testid="global-activity-panel">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Automation</div>
+        <div className="flex shrink-0 items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span><span className="font-mono text-foreground/80">{activities.inProgress.length}</span> running</span>
+          <span><span className="font-mono text-foreground/80">{activities.queued.length}</span> queued</span>
+        </div>
+      </div>
+      {visibleActivities.length === 0 ? (
+        <div className="mt-2 text-[11px] text-muted-foreground">No automation running or queued.</div>
+      ) : (
+        <div className="mt-2 space-y-1">
+          {visibleActivities.map((activity) => (
+            <GlobalActivityRow
+              key={activity.id}
+              activity={activity}
+              queueStatus={queueStatusById.get(activity.targetId) ?? null}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GlobalActivityRow({
+  activity,
+  queueStatus,
+}: {
+  activity: ActivityItem;
+  queueStatus: QueueStatusView | null;
+}) {
+  const statusClass = activity.status === "failed"
+    ? "border-destructive/50 text-destructive"
+    : activity.status === "in_progress"
+      ? "border-primary/50 text-primary"
+      : "border-border text-muted-foreground";
+  const timeLabel = activity.status === "in_progress"
+    ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
+    : formatClock(activity.availableAt) ?? formatClock(activity.updatedAt);
+  const content = (
+    <div
+      className="min-w-0 rounded-md border border-border/70 bg-background px-2 py-1.5"
+      data-testid="global-activity-row"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${statusClass}`}>
+          {activity.status === "in_progress" ? "running" : activity.status}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{activity.label}</span>
+        {timeLabel && <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{timeLabel}</span>}
+      </div>
+      {activity.detail && (
+        <div className="mt-1 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
+      )}
+      <div className="mt-1">
+        <QueueStatusBadge status={queueStatus} />
+      </div>
+      {activity.lastError && (
+        <div className="mt-1 line-clamp-2 text-[11px] text-destructive">{activity.lastError}</div>
+      )}
+    </div>
+  );
+
+  if (activity.targetUrl) {
+    return (
+      <a href={activity.targetUrl} target="_blank" rel="noopener noreferrer" className="block outline-none focus-visible:ring-1 focus-visible:ring-ring">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
+}
+
 function HealingPanel({
   pr,
   config,
@@ -891,10 +979,14 @@ function PRDescriptionPanel({ pr }: { pr: PR }) {
 
 function RightPanel({
   prId,
+  activities,
+  queueStatusById,
   isCollapsed,
   onToggleCollapsed,
 }: {
   prId: string | null;
+  activities: ActivitySnapshot;
+  queueStatusById: Map<string, QueueStatusView>;
   isCollapsed: boolean;
   onToggleCollapsed: () => void;
 }) {
@@ -935,6 +1027,7 @@ function RightPanel({
           <span className="sr-only">Collapse activity</span>
         </button>
       </div>
+      <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} />
       <div className="flex-1 overflow-hidden">
         <LogPanel prId={prId} />
       </div>
@@ -1726,6 +1819,8 @@ export default function Dashboard() {
 
         <RightPanel
           prId={selectedPRId}
+          activities={activities}
+          queueStatusById={queueStatusById}
           isCollapsed={isActivityPanelCollapsed}
           onToggleCollapsed={() => setIsActivityPanelCollapsed((current) => !current)}
         />

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -36,7 +36,7 @@ import { StageProgressBar } from "@/components/detail/StageProgressBar";
 import { StatusChip } from "@/components/detail/StatusChip";
 import { buildPRStages } from "@/lib/stages";
 import { prStatusTone, toneRailClass } from "@/lib/statusTones";
-import { getUiPollIntervalMs } from "@/lib/polling";
+import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
 
 type GitHubRateLimitState = {
   limited: boolean;
@@ -1152,7 +1152,7 @@ export default function Dashboard() {
 
   const { data: activities = EMPTY_ACTIVITY_SNAPSHOT } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
-    refetchInterval: 3000,
+    refetchInterval: ACTIVITY_POLL_INTERVAL_MS,
   });
   const queueStatusById = useMemo(() => buildQueueStatusIndex(activities), [activities]);
 
@@ -1400,7 +1400,7 @@ export default function Dashboard() {
               isClearingFailed={clearFailedActivitiesMutation.isPending}
               globalDrainMode={globalDrainMode}
               queueStatusById={queueStatusById}
-              pollIntervalMs={config?.pollIntervalMs}
+              pollIntervalMs={ACTIVITY_POLL_INTERVAL_MS}
             />
           </>
         )}

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -52,6 +52,11 @@ function formatClock(timestamp: string | null): string | null {
   return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
 }
 
+function formatGitHubUsername(username?: string | null): string {
+  const normalized = username?.trim().replace(/^@/, "");
+  return normalized ? `@${normalized}` : "@unknown";
+}
+
 function isPRWatchEnabled(pr: Pick<PRSummary, "watchEnabled">): boolean {
   return pr.watchEnabled;
 }
@@ -465,6 +470,7 @@ const PRRow = memo(function PRRow({
             >
               {pr.repo}
             </a>
+            <span>{formatGitHubUsername(pr.author)}</span>
             <span>{formatStatusLabel(pr.status, pr.prStage)}</span>
             <QueueStatusBadge status={queueStatus} />
             {!watchEnabled && <WatchPausedIndicator />}
@@ -646,6 +652,7 @@ function FeedbackRow({
 
 function LogPanel({ prId }: { prId: string | null }) {
   const scrollerRef = useRef<HTMLDivElement>(null);
+  const [clearedLogIds, setClearedLogIds] = useState<Set<string>>(() => new Set());
   const { data: logs = [] } = useQuery<LogEntry[]>({
     queryKey: ["/api/logs", prId ?? "all"],
     queryFn: async () => {
@@ -659,11 +666,18 @@ function LogPanel({ prId }: { prId: string | null }) {
     enabled: Boolean(prId),
     refetchInterval: 1500,
   });
-  const visibleLogs = useMemo(
-    () => logs.length > MAX_VISIBLE_LOGS ? logs.slice(-MAX_VISIBLE_LOGS) : logs,
-    [logs],
+  const viewLogs = useMemo(
+    () => logs.filter((log) => !clearedLogIds.has(log.id)),
+    [clearedLogIds, logs],
   );
-  const hiddenLogCount = logs.length - visibleLogs.length;
+  const visibleLogs = useMemo(
+    () => viewLogs.length > MAX_VISIBLE_LOGS ? viewLogs.slice(-MAX_VISIBLE_LOGS) : viewLogs,
+    [viewLogs],
+  );
+  const hiddenLogCount = viewLogs.length - visibleLogs.length;
+  useEffect(() => {
+    setClearedLogIds(new Set());
+  }, [prId]);
   useEffect(() => {
     const scroller = scrollerRef.current;
     if (!scroller) {
@@ -671,7 +685,7 @@ function LogPanel({ prId }: { prId: string | null }) {
     }
 
     scroller.scrollTop = scroller.scrollHeight;
-  }, [logs.length, prId]);
+  }, [visibleLogs.length, prId]);
 
   return (
     <div className="flex h-full flex-col">
@@ -680,11 +694,27 @@ function LogPanel({ prId }: { prId: string | null }) {
           <div className="p-4 text-[12px] text-muted-foreground">Select a PR to see logs.</div>
         ) : logs.length === 0 ? (
           <div className="p-4 text-[12px] text-muted-foreground">No workflow logs yet.</div>
+        ) : viewLogs.length === 0 ? (
+          <div className="p-4 text-[12px] text-muted-foreground">
+            View cleared. New log entries will appear here.
+          </div>
         ) : (
           <>
+            <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                {viewLogs.length} visible
+              </span>
+              <button
+                type="button"
+                onClick={() => setClearedLogIds(new Set(logs.map((log) => log.id)))}
+                className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                Clear view
+              </button>
+            </div>
             {hiddenLogCount > 0 && (
               <div className="border-b border-border/60 px-3 py-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-                Showing latest {MAX_VISIBLE_LOGS} of {logs.length} entries.
+                Showing latest {MAX_VISIBLE_LOGS} entries.
               </div>
             )}
             {visibleLogs.map((log) => {
@@ -1527,6 +1557,7 @@ export default function Dashboard() {
               {(() => {
                 const metaItems: MetaItem[] = [
                   { key: "status", content: <span>status: <span className="text-foreground">{formatStatusLabel(selectedPR.status, selectedPR.prStage)}</span></span> },
+                  { key: "author", content: <span>author: <span className="text-foreground/80">{formatGitHubUsername(selectedPR.author)}</span></span> },
                   { key: "items", content: <span><span className="font-mono text-foreground">{selectedPR.feedbackItems.length}</span> items</span> },
                 ];
                 if (selectedPRQueueStatus) {

--- a/server/agentRunner.test.ts
+++ b/server/agentRunner.test.ts
@@ -244,8 +244,10 @@ test("buildAgentCommandArgs applies model and thinking flags for each agent", ()
 test("resolveAgent does not fall back when fallback is disabled", async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-agent-bin-"));
   const originalPath = process.env.PATH;
+  const originalDisableExtraPaths = process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS;
 
   try {
+    process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS = "1";
     process.env.PATH = tempRoot;
 
     await assert.rejects(
@@ -254,6 +256,11 @@ test("resolveAgent does not fall back when fallback is disabled", async () => {
     );
   } finally {
     process.env.PATH = originalPath;
+    if (originalDisableExtraPaths === undefined) {
+      delete process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS;
+    } else {
+      process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS = originalDisableExtraPaths;
+    }
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
@@ -269,8 +276,10 @@ test("resolveAgent uses the next coding agent when fallback is enabled", async (
     process.platform === "win32" ? "which.cmd" : "which",
   );
   const originalPath = process.env.PATH;
+  const originalDisableExtraPaths = process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS;
 
   try {
+    process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS = "1";
     await copyFile(process.execPath, fakeCodexPath);
     await chmod(fakeCodexPath, 0o755);
     await writeFile(
@@ -284,6 +293,11 @@ test("resolveAgent uses the next coding agent when fallback is enabled", async (
     assert.equal(await resolveAgent("claude", { allowFallback: true }), "codex");
   } finally {
     process.env.PATH = originalPath;
+    if (originalDisableExtraPaths === undefined) {
+      delete process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS;
+    } else {
+      process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS = originalDisableExtraPaths;
+    }
     await rm(tempRoot, { recursive: true, force: true });
   }
 });

--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -1,5 +1,6 @@
-import { mkdtemp, readFile, rm } from "fs/promises";
-import { tmpdir } from "os";
+import { access, mkdtemp, readFile, rm } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import { homedir, tmpdir } from "os";
 import path from "path";
 import { spawn } from "child_process";
 
@@ -62,6 +63,14 @@ const AGENT_CLI_MISSING_PATTERNS = [
   "enoent",
 ];
 
+const EXTRA_AGENT_COMMAND_DIRS = [
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  path.join(homedir(), ".local", "bin"),
+  path.join(homedir(), ".bun", "bin"),
+  path.join(homedir(), ".cargo", "bin"),
+];
+
 export function detectAgentUnavailability(message: string): AgentUnavailabilityKind | null {
   const lower = message.toLowerCase();
   if (lower.includes("unknown coding agent")) {
@@ -106,6 +115,15 @@ export async function resolveCommandPath(command: string): Promise<string | null
   const pathFromLoginShell = firstOutputLine(shellResult.stdout);
   if (shellResult.code === 0 && pathFromLoginShell) {
     return pathFromLoginShell;
+  }
+
+  if (process.env.PATCHDECK_DISABLE_AGENT_EXTRA_PATHS !== "1") {
+    for (const directory of EXTRA_AGENT_COMMAND_DIRS) {
+      const candidate = path.join(directory, command);
+      if (await canExecute(candidate)) {
+        return candidate;
+      }
+    }
   }
 
   return null;
@@ -432,6 +450,15 @@ function firstOutputLine(output: string): string | null {
     .map((candidate) => candidate.trim())
     .find(Boolean);
   return line ?? null;
+}
+
+async function canExecute(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate, process.platform === "win32" ? undefined : fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function summarizeHealthFailure(result: CommandResult): string {

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import type { NewPR } from "@shared/schema";
 import {
@@ -212,6 +215,46 @@ test("runtime setDrainMode logs enable and disable transitions", async () => {
   assert.match(ring, /Drain mode enabled/);
   assert.match(ring, /Agent health check failed for codex/);
   assert.match(ring, /Drain mode disabled/);
+});
+
+test("runtime clears stale CLI-missing drain mode once the agent command is available", async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-runtime-agent-bin-"));
+  const fakeCodexPath = path.join(
+    tempRoot,
+    process.platform === "win32" ? "codex.cmd" : "codex",
+  );
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeCodexPath,
+      process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n",
+      "utf8",
+    );
+    await chmod(fakeCodexPath, 0o755);
+    process.env.PATH = [tempRoot, "/usr/bin", "/bin"].join(path.delimiter);
+
+    const storage = new MemStorage();
+    const runtime = createAppRuntime({
+      storage,
+      startBackgroundServices: false,
+      startWatcher: false,
+    });
+    await storage.updateRuntimeState({
+      drainMode: true,
+      drainRequestedAt: "2026-05-17T13:57:29.224Z",
+      drainReason: "Agent health check failed for codex: codex CLI is not installed",
+    });
+
+    const snapshot = await runtime.getRuntimeSnapshot();
+
+    assert.equal(snapshot.drainMode, false);
+    assert.equal(snapshot.drainReason, null);
+    assert.equal(snapshot.drainRequestedAt, null);
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("runtime askQuestion persists the question and enqueues a durable job", async () => {

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -30,7 +30,7 @@ import type { IStorage } from "./storage";
 import { getDefaultStorage } from "./storage";
 import { PRBabysitter } from "./babysitter";
 import { resolveRepoAgentRuntimeSettings, resolveRepoCodingAgent } from "./agentSettings";
-import { detectAgentUnavailability, type AgentUnavailabilityKind } from "./agentRunner";
+import { commandExists, detectAgentUnavailability, type AgentUnavailabilityKind, type CodingAgent } from "./agentRunner";
 import { applyEvaluationDecision, applyFlagDecision } from "./feedbackLifecycle";
 import { applyManualFeedbackDecision } from "./manualFeedback";
 import { childLogger } from "./logger";
@@ -735,6 +735,11 @@ type AgentAvailabilityFailure = {
   kind: AgentUnavailabilityKind;
   fixSteps: string[];
 };
+
+function parseAgentCliMissingDrainReason(reason: string | null): CodingAgent | null {
+  const match = reason?.match(/^Agent health check failed for (codex|claude): \1 CLI is not installed$/i);
+  return match ? match[1].toLowerCase() as CodingAgent : null;
+}
 
 function buildCliMissingFixSteps(agentLabel: AgentLabel, command: "claude" | "codex"): string[] {
   return [
@@ -1730,11 +1735,27 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   }
 
   const getRuntimeSnapshot = async (): Promise<RuntimeSnapshot> => {
-    const state = await storage.getRuntimeState();
+    const state = await maybeClearStaleAgentCliDrain(await storage.getRuntimeState());
     return {
       ...state,
       activeRuns: backgroundJobDispatcher.getActiveRunCount(),
     };
+  };
+
+  const maybeClearStaleAgentCliDrain = async (state: RuntimeState): Promise<RuntimeState> => {
+    const agent = parseAgentCliMissingDrainReason(state.drainReason);
+    if (!state.drainMode || !agent || !(await commandExists(agent))) {
+      return state;
+    }
+
+    const updated = await storage.updateRuntimeState({
+      drainMode: false,
+      drainRequestedAt: null,
+      drainReason: null,
+    });
+    log.info({ agent }, "Cleared stale agent CLI drain mode after CLI became available");
+    notifyChange();
+    return updated;
   };
 
   const buildActivityDescriptionContext = async (jobs: BackgroundJob[]): Promise<ActivityDescriptionContext> => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -2651,14 +2651,15 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.deepEqual(postedFollowUps, [
     {
       id: "gh-review-comment-1",
-      body: `Addressed in commit \`def456\` by the latest babysitter run.\n\nRenamed the variable from \`foo\` to \`bar\` as requested.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->\n\n${APP_COMMENT_FOOTER}`,
+      body: `Addressed in commit \`def456\`.\n\nRenamed the variable from \`foo\` to \`bar\` as requested.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->\n\n${APP_COMMENT_FOOTER}`,
     },
   ]);
   assert.equal(postedAgentComments.length, 1);
   assert.match(
     postedAgentComments[0] || "",
-    /\*\*\[patchdeck\]\(https:\/\/github.com\/jeremymcs\/patchdeck\)\*\* dispatched `codex`/,
+    /\*\*\[patchdeck\]\(https:\/\/github.com\/jeremymcs\/patchdeck\)\*\* started an automated PR update\./,
   );
+  assert.doesNotMatch(postedAgentComments[0] || "", /Agent prompt|auditToken=codefactory-feedback/);
   assert.doesNotMatch(postedAgentComments[0] || "", /\*\*CodeFactory\*\*/);
   assert.equal(postedAgentComments[0]?.endsWith(APP_COMMENT_FOOTER), true);
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
@@ -3146,11 +3147,12 @@ test("babysitPR omits repository links in GitHub comments when disabled", async 
     assert.deepEqual(postedFollowUps, [
       {
         id: "gh-review-comment-1",
-        body: "Addressed in commit `def456` by the latest babysitter run.\n\nRenamed the variable from `foo` to `bar` as requested.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->",
+        body: "Addressed in commit `def456`.\n\nRenamed the variable from `foo` to `bar` as requested.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->",
       },
     ]);
     assert.equal(postedAgentComments.length, 1);
-    assert.match(postedAgentComments[0] || "", /\*\*patchdeck\*\* dispatched `codex`/);
+    assert.match(postedAgentComments[0] || "", /\*\*patchdeck\*\* started an automated PR update\./);
+    assert.doesNotMatch(postedAgentComments[0] || "", /Agent prompt|auditToken=codefactory-feedback/);
     assert.doesNotMatch(postedAgentComments[0] || "", /\[patchdeck\]\(https:\/\/github.com\/jeremymcs\/patchdeck\)/);
     assert.equal(postedAgentComments[0]?.includes(APP_COMMENT_FOOTER), false);
   } finally {
@@ -3206,8 +3208,8 @@ test("babysitPR keeps acceptance local and logs best-effort reaction failures", 
       makeFeedbackItem({
         id: "gh-review-comment-3",
         author: "code-factory",
-        body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${firstItem.auditToken}`,
-        bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${firstItem.auditToken}</p>`,
+        body: `Addressed in commit \`def456\`.\n\n${firstItem.auditToken}`,
+        bodyHtml: `<p>Addressed in commit <code>def456</code>.</p><p>${firstItem.auditToken}</p>`,
         sourceId: "3",
         sourceNodeId: "PRRC_kwDO_followup_1",
         sourceUrl: "https://github.com/octo/example/pull/42#discussion_r3",
@@ -3221,8 +3223,8 @@ test("babysitPR keeps acceptance local and logs best-effort reaction failures", 
       makeFeedbackItem({
         id: "gh-review-comment-4",
         author: "code-factory",
-        body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${secondItem.auditToken}`,
-        bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${secondItem.auditToken}</p>`,
+        body: `Addressed in commit \`def456\`.\n\n${secondItem.auditToken}`,
+        bodyHtml: `<p>Addressed in commit <code>def456</code>.</p><p>${secondItem.auditToken}</p>`,
         sourceId: "4",
         sourceNodeId: "PRRC_kwDO_followup_2",
         sourceUrl: "https://github.com/octo/example/pull/42#discussion_r4",
@@ -3353,8 +3355,8 @@ test("babysitPR posts progress replies when GitHub progress replies are enabled"
     const followUp = makeFeedbackItem({
       id: "gh-review-comment-2",
       author: "code-factory",
-      body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-      bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+      body: `Addressed in commit \`def456\`.\n\n${existingItem.auditToken}`,
+      bodyHtml: `<p>Addressed in commit <code>def456</code>.</p><p>${existingItem.auditToken}</p>`,
       sourceId: "2",
       sourceNodeId: "PRRC_kwDO_followup",
       sourceUrl: "https://github.com/octo/example/pull/42#discussion_r2",
@@ -3420,12 +3422,12 @@ test("babysitPR posts progress replies when GitHub progress replies are enabled"
 
     await babysitter.babysitPR(pr.id, "codex");
 
-    const expectedAcceptedLine = "\u23f3 **Accepted** \u2014 this comment requires code changes. Queuing fix...";
+    const expectedAcceptedLine = "\u23f3 **Accepted** \u2014 queued for a code change.";
     const expectedAcceptedStatus = `${expectedAcceptedLine}\n\n${APP_COMMENT_FOOTER}`;
     const expectedFinalStatusBody = [
       expectedAcceptedLine,
-      "\ud83e\uddf0 **Agent running** \u2014 `codex` is working on the fix...",
-      "\u2705 **Agent completed** \u2014 verifying changes...",
+      "\ud83e\uddf0 **In progress** \u2014 applying the accepted fix.",
+      "\u2705 **Verifying** \u2014 checking the applied changes.",
       "\ud83c\udf89 **Resolved** \u2014 addressed in commit `def456`.",
       "",
       APP_COMMENT_FOOTER,
@@ -3457,7 +3459,7 @@ test("runQueuedBabysitPR recovers an existing status reply after restart", async
   const staleStatusReply = makeFeedbackItem({
     id: "gh-review-comment-77",
     author: "alex-morgan-o",
-    body: "\u23f3 **Accepted** \u2014 this comment requires code changes. Queuing fix...",
+    body: "\u23f3 **Accepted** \u2014 queued for a code change.",
     sourceId: "77",
     sourceNodeId: "PRRC_kwDO_status",
     sourceUrl: "https://github.com/octo/example/pull/42#discussion_r77",
@@ -3579,7 +3581,7 @@ test("runQueuedBabysitPR recovers an existing status reply after restart", async
 
     await babysitter.runQueuedBabysitPR(pr.id, "codex");
 
-    assert.ok(updatedStatusBodies.some((body) => body.includes("**Agent running**")));
+    assert.ok(updatedStatusBodies.some((body) => body.includes("**In progress**")));
     assert.ok(updatedStatusBodies.at(-1)?.includes("**Resolved**"));
     const [run] = await storage.listAgentRuns({ prId: pr.id });
     assert.equal(run?.status, "completed");
@@ -3668,7 +3670,7 @@ test("babysitPR marks feedback failed without posting GitHub status when the age
   }
 });
 
-test("babysitPR includes the agent name in failed GitHub progress replies", async () => {
+test("babysitPR keeps failed GitHub progress replies concise", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({
     autoUpdateDocs: false,
@@ -3749,7 +3751,7 @@ test("babysitPR includes the agent name in failed GitHub progress replies", asyn
     const body = statusReplyRefs.get(existingItem.id)?.body ?? "";
     assert.match(
       body,
-      /\u274c \*\*Agent failed\*\* \u2014 `codex` exited with an error: TypeScript check failed/,
+      /\u274c \*\*Needs attention\*\* \u2014 automatic fix failed: TypeScript check failed/,
     );
   } finally {
     delete process.env.CODEFACTORY_HOME;
@@ -3928,8 +3930,8 @@ test("babysitPR treats footerless status replies as non-actionable", async () =>
   await storage.updateConfig({ autoUpdateDocs: false });
   const statusReply = makeFeedbackItem({
     author: "octocat",
-    body: "\ud83e\uddf0 **Agent running** \u2014 `codex` is working on the fix...",
-    bodyHtml: "<p><strong>Agent running</strong> - <code>codex</code> is working on the fix...</p>",
+    body: "\ud83e\uddf0 **In progress** \u2014 applying the accepted fix.",
+    bodyHtml: "<p><strong>In progress</strong> - applying the accepted fix.</p>",
     decision: null,
     status: "pending",
   });
@@ -5124,8 +5126,8 @@ test("babysitPR continues comment remediation when docs assessment fails", async
   const followUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`def456\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>def456</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
@@ -5238,8 +5240,8 @@ test("babysitPR retries accepted in-progress feedback items that still need GitH
   const followUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>abc123</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`abc123\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>abc123</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
@@ -5318,7 +5320,7 @@ test("babysitPR retries accepted in-progress feedback items that still need GitH
   assert.deepEqual(postedFollowUps, [
     {
       id: "gh-review-comment-1",
-      body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->\n\n${APP_COMMENT_FOOTER}`,
+      body: `Addressed in commit \`abc123\`.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->\n\n${APP_COMMENT_FOOTER}`,
     },
   ]);
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
@@ -5372,8 +5374,8 @@ test("resumeInterruptedRuns replays the persisted prompt when the PR head has no
   const followUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`def456\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>def456</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`def456\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>def456</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
@@ -5480,8 +5482,8 @@ test("resumeInterruptedRuns skips prompt replay when the PR head already moved",
   const followUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`moved99\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>moved99</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`moved99\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>moved99</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
@@ -6056,8 +6058,8 @@ test("babysitPR resolves lingering review threads without reposting an existing 
   const priorFollowUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>abc123</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`abc123\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>abc123</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
@@ -6170,8 +6172,8 @@ test("babysitPR reposts GitHub follow-up when an earlier audit trail used the wr
   const priorFollowUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>abc123</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`abc123\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>abc123</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r2",
@@ -6188,8 +6190,8 @@ test("babysitPR reposts GitHub follow-up when an earlier audit trail used the wr
   const correctedFollowUp = makeFeedbackItem({
     id: "gh-review-comment-3",
     author: "code-factory",
-    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
-    bodyHtml: `<p>Addressed in commit <code>abc123</code> by the latest babysitter run.</p><p>${existingItem.auditToken}</p>`,
+    body: `Addressed in commit \`abc123\`.\n\n${existingItem.auditToken}`,
+    bodyHtml: `<p>Addressed in commit <code>abc123</code>.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "3",
     sourceNodeId: "PRRC_kwDO_followup_corrected",
     sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#discussion_r3",
@@ -6290,7 +6292,7 @@ test("babysitPR reposts GitHub follow-up when an earlier audit trail used the wr
   assert.deepEqual(postedFollowUps, [
     {
       id: "gh-review-comment-1",
-      body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->\n\n${APP_COMMENT_FOOTER}`,
+      body: `Addressed in commit \`abc123\`.\n\n<!-- codefactory-feedback:gh-review-comment-1 -->\n\n${APP_COMMENT_FOOTER}`,
     },
   ]);
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
@@ -6321,6 +6323,7 @@ test("babysitPR resolves merge conflicts when PR is not mergeable", async () => 
   let conflictAgentPrompt = "";
   let fixAgentCalled = false;
   let conflictResolved = false;
+  const postedAgentComments: string[] = [];
   const pullSummary = makePullSummary(pr, { mergeable: false });
   const mergeAttempted = { value: false };
 
@@ -6342,6 +6345,9 @@ test("babysitPR resolves merge conflicts when PR is not mergeable", async () => 
       resolveReviewThread: async () => undefined,
       resolveGitHubAuthToken: async () => "test-token",
       addReactionToComment: async () => {},
+      postPRComment: async (_octokit: unknown, _parsedPr: unknown, body: string) => {
+        postedAgentComments.push(body);
+      },
       postStatusReplyForFeedbackItem: async () => null,
       updateStatusReply: async () => {},
     },
@@ -6386,6 +6392,10 @@ test("babysitPR resolves merge conflicts when PR is not mergeable", async () => 
   assert.equal(fixAgentCalled, false, "Should not run the fix agent when there are no comment/status tasks");
   assert.match(conflictAgentPrompt, /merge conflicts/i);
   assert.match(conflictAgentPrompt, /src\/example\.ts/);
+  assert.equal(postedAgentComments.length, 1);
+  assert.match(postedAgentComments[0] || "", /Merge conflicts were detected/);
+  assert.match(postedAgentComments[0] || "", /- `src\/example\.ts`/);
+  assert.doesNotMatch(postedAgentComments[0] || "", /Resolve ALL merge conflicts|Your task:/);
   assert.ok(logs.some((log) => log.phase === "conflict" && log.message.includes("merge conflicts")));
   assert.ok(logs.some((log) => log.phase === "conflict.agent" && log.message.includes("merge conflict resolution")));
 
@@ -6624,7 +6634,7 @@ test("babysitPR skips conflict resolution when PR is mergeable", async () => {
   const followUp = makeFeedbackItem({
     id: "gh-review-comment-2",
     author: "code-factory",
-    body: `Addressed in commit \`abc123\` by the latest babysitter run.\n\n${existingItem.auditToken}`,
+    body: `Addressed in commit \`abc123\`.\n\n${existingItem.auditToken}`,
     bodyHtml: `<p>Addressed.</p><p>${existingItem.auditToken}</p>`,
     sourceId: "2",
     sourceNodeId: "PRRC_kwDO_followup",
@@ -7617,7 +7627,8 @@ test("babysitPR escalates a healing session when the repaired commit still has t
   assert.equal(attempts.length, 1);
   assert.equal(attempts[0]?.status, "verified");
   assert.ok((attempts[0]?.improvementScore ?? 1) <= 0);
-  assert.ok(postedComments.some((body) => body.includes("[patchdeck](https://github.com/jeremymcs/patchdeck) CI Alert")));
+  assert.ok(postedComments.some((body) => body.includes("[patchdeck](https://github.com/jeremymcs/patchdeck) CI needs attention")));
+  assert.ok(postedComments.some((body) => body.includes("Review the failing checks before merging.")));
   assert.ok(postedComments.every((body) => body.endsWith(APP_COMMENT_FOOTER)));
 
   const updated = await storage.getPR(pr.id);

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -964,6 +964,32 @@ test("syncAndBabysitTrackedRepos caps in-flight babysit_pr jobs at maxConcurrent
   await babysitter.syncAndBabysitTrackedRepos();
   const afterSecond = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
   assert.equal(afterSecond.length, 3, "already-queued babysit jobs count toward the cap");
+
+  const claimedDeferredSweep = await backgroundJobQueue.claimNext({
+    workerId: "worker-1",
+    leaseMs: 30_000,
+    now: deferredSweeps[0]?.availableAt,
+    kinds: ["sync_watched_repos"],
+  });
+  assert.equal(claimedDeferredSweep?.id, deferredSweeps[0]?.id);
+
+  await babysitter.syncAndBabysitTrackedRepos({ fullSweep: true });
+  const allDeferredJobs = await storage.listBackgroundJobs({ kind: "sync_watched_repos" });
+  const replacementDeferredSweeps = await storage.listBackgroundJobs({
+    kind: "sync_watched_repos",
+    status: "queued",
+  });
+  assert.equal(
+    replacementDeferredSweeps.length,
+    1,
+    `a running deferred sweep leaves the next refill queued when backlog remains: ${JSON.stringify(allDeferredJobs.map((job) => ({
+      id: job.id,
+      targetId: job.targetId,
+      dedupeKey: job.dedupeKey,
+      status: job.status,
+    })))}`,
+  );
+  assert.notEqual(replacementDeferredSweeps[0]?.id, deferredSweeps[0]?.id);
 });
 
 test("syncAndBabysitTrackedRepos enqueues no babysit_pr jobs while the core budget is in the reserve", async () => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -956,6 +956,9 @@ test("syncAndBabysitTrackedRepos caps in-flight babysit_pr jobs at maxConcurrent
   await babysitter.syncAndBabysitTrackedRepos();
   const afterFirst = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
   assert.equal(afterFirst.length, 3, "first sweep enqueues no more than maxConcurrentBabysitRuns");
+  const deferredSweeps = await storage.listBackgroundJobs({ kind: "sync_watched_repos", status: "queued" });
+  assert.equal(deferredSweeps.length, 1, "deferred babysit backlog schedules a follow-up sweep");
+  assert.equal(deferredSweeps[0]?.payload.activityLabel, "Backfilling deferred PR work");
 
   // A second sweep must count the still-queued jobs as in-flight and add none.
   await babysitter.syncAndBabysitTrackedRepos();

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -959,6 +959,7 @@ test("syncAndBabysitTrackedRepos caps in-flight babysit_pr jobs at maxConcurrent
   const deferredSweeps = await storage.listBackgroundJobs({ kind: "sync_watched_repos", status: "queued" });
   assert.equal(deferredSweeps.length, 1, "deferred babysit backlog schedules a follow-up sweep");
   assert.equal(deferredSweeps[0]?.payload.activityLabel, "Backfilling deferred PR work");
+  assert.equal(deferredSweeps[0]?.payload.deferredBabysitBackfill, true);
 
   // A second sweep must count the still-queued jobs as in-flight and add none.
   await babysitter.syncAndBabysitTrackedRepos();
@@ -990,6 +991,63 @@ test("syncAndBabysitTrackedRepos caps in-flight babysit_pr jobs at maxConcurrent
     })))}`,
   );
   assert.notEqual(replacementDeferredSweeps[0]?.id, deferredSweeps[0]?.id);
+});
+
+test("syncAndBabysitTrackedRepos rotates babysit_pr jobs toward least recently checked PRs", async () => {
+  clearRateLimitStateForTests();
+  const storage = new MemStorage();
+  await storage.updateConfig({ watchedRepos: ["octo/example"], maxConcurrentBabysitRuns: 3 });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const pulls = Array.from({ length: 5 }, (_, i) => makeOctocatPull(100 + i));
+  const prById = new Map<string, number>();
+
+  for (const { number, lastChecked } of [
+    { number: 100, lastChecked: "2026-05-17T15:00:00.000Z" },
+    { number: 101, lastChecked: "2026-05-17T14:00:00.000Z" },
+    { number: 102, lastChecked: "2026-05-17T13:00:00.000Z" },
+    { number: 103, lastChecked: null },
+    { number: 104, lastChecked: "2026-05-17T12:00:00.000Z" },
+  ]) {
+    const pr = await storage.addPR({
+      number,
+      title: `PR ${number}`,
+      repo: "octo/example",
+      branch: `feature/${number}`,
+      author: "octocat",
+      url: `https://github.com/octo/example/pull/${number}`,
+      status: "watching",
+      feedbackItems: [],
+      accepted: 0,
+      rejected: 0,
+      flagged: 0,
+      testsPassed: null,
+      lintPassed: null,
+      lastChecked,
+    });
+    prById.set(pr.id, pr.number);
+  }
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({ listOpenPullsForRepo: async () => pulls }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.deepEqual(
+    jobs.map((job) => prById.get(job.targetId)),
+    [103, 104, 102],
+  );
 });
 
 test("syncAndBabysitTrackedRepos enqueues no babysit_pr jobs while the core budget is in the reserve", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -224,17 +224,17 @@ const defaultBabysitterRuntime: BabysitterRuntime = {
 };
 
 const STATUS_MESSAGES = {
-  accepted: "\u23f3 **Accepted** — this comment requires code changes. Queuing fix...",
-  agentRunning: (agent: CodingAgent) => `\ud83e\uddf0 **Agent running** — \`${agent}\` is working on the fix...`,
-  agentFailed: (agent: CodingAgent, reason?: string) => reason
-    ? `\u274c **Agent failed** — \`${agent}\` exited with an error: ${reason}`
-    : `\u274c **Agent failed** — \`${agent}\` exited with an error.`,
-  agentCompleted: "\u2705 **Agent completed** — verifying changes...",
+  accepted: "\u23f3 **Accepted** — queued for a code change.",
+  agentRunning: (_agent: CodingAgent) => "\ud83e\uddf0 **In progress** — applying the accepted fix.",
+  agentFailed: (_agent: CodingAgent, reason?: string) => reason
+    ? `\u274c **Needs attention** — automatic fix failed: ${reason}`
+    : "\u274c **Needs attention** — automatic fix failed.",
+  agentCompleted: "\u2705 **Verifying** — checking the applied changes.",
   resolved: (headSha: string) => {
     const shortSha = headSha.trim().slice(0, 7);
     return shortSha
       ? `\ud83c\udf89 **Resolved** — addressed in commit \`${shortSha}\`.`
-      : "\ud83c\udf89 **Resolved** — addressed in the latest babysitter run.";
+      : "\ud83c\udf89 **Resolved** — addressed in the latest update.";
   },
 } as const;
 
@@ -1051,8 +1051,8 @@ function buildFeedbackFollowUpBody(
 ): string {
   const shortSha = headSha.trim() ? headSha.trim().slice(0, 7) : "";
   const headline = shortSha
-    ? `Addressed in commit \`${shortSha}\` by the latest babysitter run.`
-    : "Addressed in the latest babysitter run.";
+    ? `Addressed in commit \`${shortSha}\`.`
+    : "Addressed in the latest update.";
 
   const parts = [headline];
 
@@ -1087,29 +1087,57 @@ function buildFeedbackFollowUpBody(
 
 const CODEFACTORY_COMMENT_MARKER = "<!-- codefactory-agent-command -->";
 
-function buildCodeFence(content: string): { open: string; close: string } {
-  let maxRun = 0;
-  const backtickRuns = content.match(/`{3,}/g);
-  if (backtickRuns) {
-    for (const run of backtickRuns) {
-      if (run.length > maxRun) maxRun = run.length;
-    }
-  }
-  const fence = "`".repeat(Math.max(3, maxRun + 1));
-  return { open: `${fence}text`, close: fence };
-}
-
 function isCodeFactoryComment(body: string): boolean {
   return body.includes(CODEFACTORY_COMMENT_MARKER);
 }
 
+function extractConflictFilesFromPrompt(prompt: string): string[] {
+  const lines = prompt.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === "The following files have merge conflicts:");
+  if (start === -1) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (!line.startsWith("  - ")) {
+      break;
+    }
+
+    const file = line.slice(4).trim();
+    if (file) {
+      files.push(file);
+    }
+  }
+
+  return files;
+}
+
+function formatPublicAgentCommandDetails(prompt: string): string[] {
+  const conflictFiles = extractConflictFilesFromPrompt(prompt);
+  if (conflictFiles.length > 0) {
+    return [
+      "Merge conflicts were detected while updating this branch from the base branch.",
+      "",
+      "Conflicted files:",
+      ...conflictFiles.map((file) => `- \`${file}\``),
+      "",
+      "An automatic resolution attempt is running. If it cannot complete safely, this PR will be marked for manual follow-up.",
+    ];
+  }
+
+  return [
+    "Accepted review feedback is being applied.",
+    "Progress and final results will be posted in the related review thread(s).",
+  ];
+}
+
 export function formatAgentCommandGitHubComment(
-  agent: CodingAgent,
+  _agent: CodingAgent,
   prompt: string,
   includeRepositoryLinksInGitHubComments: boolean,
   githubCommentAppName: string,
 ): string {
-  const fence = buildCodeFence(prompt);
   const appName = formatAppName(githubCommentAppName, includeRepositoryLinksInGitHubComments);
   const footer = formatIncludedAppCommentFooter(
     includeRepositoryLinksInGitHubComments,
@@ -1118,17 +1146,10 @@ export function formatAgentCommandGitHubComment(
   return [
     CODEFACTORY_COMMENT_MARKER,
     appName
-      ? `\ud83e\udd16 **${appName}** dispatched \`${agent}\` with the following prompt:`
-      : `\ud83e\udd16 Dispatched \`${agent}\` with the following prompt:`,
+      ? `**${appName}** started an automated PR update.`
+      : "Started an automated PR update.",
     "",
-    "<details>",
-    "<summary>Agent prompt (click to expand)</summary>",
-    "",
-    fence.open,
-    prompt,
-    fence.close,
-    "",
-    "</details>",
+    ...formatPublicAgentCommandDetails(prompt),
     ...(footer ? ["", footer] : []),
   ].join("\n");
 }
@@ -4716,13 +4737,13 @@ export class PRBabysitter {
               githubCommentAppName,
             );
             const alertBody = [
-              appName ? `## \u26a0\ufe0f ${appName} CI Alert` : "## \u26a0\ufe0f CI Alert",
+              appName ? `## ${appName} CI needs attention` : "## CI needs attention",
               "",
-              `The babysitter pushed changes (commit \`${headShaForFollowUp.slice(0, 7)}\`), but CI/CD checks are still failing:`,
+              `Changes were pushed in commit \`${headShaForFollowUp.slice(0, 7)}\`, but CI/CD checks are still failing:`,
               "",
               ...ciResult.failures.map((f) => `- **${f.context}**: ${f.description}${f.targetUrl ? ` ([details](${f.targetUrl}))` : ""}`),
               "",
-              "Manual investigation may be required.",
+              "Review the failing checks before merging.",
               ...(footer ? ["", footer] : []),
             ].join("\n");
             await this.github.postPRComment(octokit, parsedPr, alertBody);

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1336,6 +1336,27 @@ function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function getBabysitCandidateRank(pr: PR | undefined): number {
+  if (!pr) {
+    return 2;
+  }
+  if (pr.feedbackItems.some((item) => item.decision === "accept" && (item.status === "queued" || item.status === "in_progress"))) {
+    return 0;
+  }
+  if (pr.feedbackItems.some((item) => item.status === "pending")) {
+    return 1;
+  }
+  return 3;
+}
+
+function getLastCheckedSortValue(pr: PR | undefined): number {
+  if (!pr?.lastChecked) {
+    return 0;
+  }
+  const parsed = Date.parse(pr.lastChecked);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export class PRBabysitter {
   private readonly storage: IStorage;
   private readonly inProgress = new Map<string, {
@@ -1401,11 +1422,14 @@ export class PRBabysitter {
       // Deferred babysit refills need their own dedupe key so a running refill
       // does not suppress the next queued refill while backlog remains.
       `sync_watched_repos:${targetId}`,
-      buildActivityPayload({
-        label: "Backfilling deferred PR work",
-        detail: "Refilling babysitter queue after the active batch drains",
-        targetUrl: null,
-      }),
+      {
+        ...buildActivityPayload({
+          label: "Backfilling deferred PR work",
+          detail: "Refilling babysitter queue after the active batch drains",
+          targetUrl: null,
+        }),
+        deferredBabysitBackfill: true,
+      },
       {
         availableAt,
         priority: 5,
@@ -2230,8 +2254,24 @@ export class PRBabysitter {
       const babysitBudgetTight = isResourceBudgetBelowReserve("core");
       let babysitEnqueues = 0;
       let babysitDeferred = 0;
-      for (const pull of openPulls) {
-        let local = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
+      const localByNumber = new Map(trackedForRepo.map((pr) => [pr.number, pr]));
+      const orderedPulls = [...openPulls].sort((a, b) => {
+        const localA = localByNumber.get(a.number);
+        const localB = localByNumber.get(b.number);
+        const rankDiff = getBabysitCandidateRank(localA) - getBabysitCandidateRank(localB);
+        if (rankDiff !== 0) {
+          return rankDiff;
+        }
+
+        const checkedDiff = getLastCheckedSortValue(localA) - getLastCheckedSortValue(localB);
+        if (checkedDiff !== 0) {
+          return checkedDiff;
+        }
+
+        return b.number - a.number;
+      });
+      for (const pull of orderedPulls) {
+        let local = localByNumber.get(pull.number);
         if (!local) {
           // Register only PRs in automation scope — automationScopeNumbers
           // already honors the repo's ownPrsOnly setting, so a manual sync
@@ -2258,6 +2298,7 @@ export class PRBabysitter {
           });
 
           await this.storage.addLog(local.id, "info", `Auto-registered open PR #${pull.number} from ${repoSlug}`);
+          localByNumber.set(pull.number, local);
         }
 
         if (!automationScopeNumbers.has(pull.number)) {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -92,6 +92,7 @@ const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 // later sweeps (babysit_pr jobs are dedupe-keyed, so nothing is lost).
 const MAX_BABYSIT_ENQUEUES_PER_SWEEP = 10;
 const DEFERRED_BABYSIT_SWEEP_DELAY_MS = 15_000;
+const DEFERRED_BABYSIT_TARGET_PREFIX = "runtime:deferred-babysit:";
 // Repos visited per non-full sweep. The PR-list fetch is a conditional GET, so
 // a quiet repo costs no rate-limit budget; visiting several per tick keeps the
 // round-robin rotation short instead of one-repo-per-tick. Actual babysit work
@@ -1352,6 +1353,7 @@ export class PRBabysitter {
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
   private repoSyncCursor = 0;
+  private deferredBabysitSweepSequence = 0;
   // Per-repo open-PR list snapshot + its etag, kept together so a conditional
   // 304 always has a list to reuse. In-memory only — a restart simply
   // re-fetches once.
@@ -1383,12 +1385,22 @@ export class PRBabysitter {
       return;
     }
 
+    const queuedSweeps = await this.storage.listBackgroundJobs({
+      kind: "sync_watched_repos",
+      status: "queued",
+    });
+    if (queuedSweeps.some((job) => job.targetId.startsWith(DEFERRED_BABYSIT_TARGET_PREFIX))) {
+      return;
+    }
+
     const availableAt = new Date(this.now().getTime() + DEFERRED_BABYSIT_SWEEP_DELAY_MS);
-    const bucket = Math.floor(availableAt.getTime() / DEFERRED_BABYSIT_SWEEP_DELAY_MS);
+    const targetId = `${DEFERRED_BABYSIT_TARGET_PREFIX}${availableAt.getTime()}-${this.deferredBabysitSweepSequence++}`;
     await this.scheduleBackgroundJob(
       "sync_watched_repos",
-      `runtime:deferred-babysit:${bucket}`,
-      buildBackgroundJobDedupeKey("sync_watched_repos", `runtime:deferred-babysit:${bucket}`),
+      targetId,
+      // Deferred babysit refills need their own dedupe key so a running refill
+      // does not suppress the next queued refill while backlog remains.
+      `sync_watched_repos:${targetId}`,
       buildActivityPayload({
         label: "Backfilling deferred PR work",
         detail: "Refilling babysitter queue after the active batch drains",

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -91,6 +91,7 @@ const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 // cold-start burst on a repo with hundreds of open PRs; the rest backfill on
 // later sweeps (babysit_pr jobs are dedupe-keyed, so nothing is lost).
 const MAX_BABYSIT_ENQUEUES_PER_SWEEP = 10;
+const DEFERRED_BABYSIT_SWEEP_DELAY_MS = 15_000;
 // Repos visited per non-full sweep. The PR-list fetch is a conditional GET, so
 // a quiet repo costs no rate-limit budget; visiting several per tick keeps the
 // round-robin rotation short instead of one-repo-per-tick. Actual babysit work
@@ -1377,6 +1378,29 @@ export class PRBabysitter {
     return this.clock();
   }
 
+  private async scheduleDeferredBabysitSweep(): Promise<void> {
+    if (!this.scheduleBackgroundJob) {
+      return;
+    }
+
+    const availableAt = new Date(this.now().getTime() + DEFERRED_BABYSIT_SWEEP_DELAY_MS);
+    const bucket = Math.floor(availableAt.getTime() / DEFERRED_BABYSIT_SWEEP_DELAY_MS);
+    await this.scheduleBackgroundJob(
+      "sync_watched_repos",
+      `runtime:deferred-babysit:${bucket}`,
+      buildBackgroundJobDedupeKey("sync_watched_repos", `runtime:deferred-babysit:${bucket}`),
+      buildActivityPayload({
+        label: "Backfilling deferred PR work",
+        detail: "Refilling babysitter queue after the active batch drains",
+        targetUrl: null,
+      }),
+      {
+        availableAt,
+        priority: 5,
+      },
+    );
+  }
+
   private isFeedbackSyncCoolingDown(prId: string): boolean {
     const untilMs = this.feedbackSyncCooldownUntilMs.get(prId);
     if (!untilMs) {
@@ -2387,6 +2411,7 @@ export class PRBabysitter {
         }
       }
       if (babysitDeferred > 0) {
+        await this.scheduleDeferredBabysitSweep();
         log.info(
           {
             repo: repoSlug,

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -86,21 +86,47 @@ test("sync_watched_repos handler delegates to the babysitter", async () => {
   const storage = new MemStorage();
   const queue = new BackgroundJobQueue(storage);
   const job = await queue.enqueue("sync_watched_repos", "runtime:1", "sync_watched_repos", {});
-  let syncCalls = 0;
+  const syncOptions: unknown[] = [];
 
   const handlers = createBackgroundJobHandlers({
     storage,
     babysitter: {
       runQueuedBabysitPR: async () => undefined,
-      syncAndBabysitTrackedRepos: async () => {
-        syncCalls += 1;
+      syncAndBabysitTrackedRepos: async (options) => {
+        syncOptions.push(options);
       },
     },
   });
 
   await handlers.sync_watched_repos!(job);
 
-  assert.equal(syncCalls, 1);
+  assert.deepEqual(syncOptions, [undefined]);
+});
+
+test("sync_watched_repos handler runs deferred babysit backfills as full sweeps", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "sync_watched_repos",
+    "runtime:deferred-babysit:1",
+    "sync_watched_repos:runtime:deferred-babysit:1",
+    { deferredBabysitBackfill: true },
+  );
+  const syncOptions: unknown[] = [];
+
+  const handlers = createBackgroundJobHandlers({
+    storage,
+    babysitter: {
+      runQueuedBabysitPR: async () => undefined,
+      syncAndBabysitTrackedRepos: async (options) => {
+        syncOptions.push(options);
+      },
+    },
+  });
+
+  await handlers.sync_watched_repos!(job);
+
+  assert.deepEqual(syncOptions, [{ fullSweep: true }]);
 });
 
 test("babysit_pr handler delegates to the babysitter with the queued preferred agent", async () => {

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -124,10 +124,13 @@ export function createBackgroundJobHandlers(params: {
 
   return {
     sync_watched_repos: babysitter
-      ? async () => {
+      ? async (job) => {
         // The routine sweep runs at low priority so it yields core REST
         // budget to interactive routes and active babysitter sessions.
-        await runWithRequestPriority("low", () => babysitter.syncAndBabysitTrackedRepos());
+        const fullSweep = job.payload.deferredBabysitBackfill === true;
+        await runWithRequestPriority("low", () => babysitter.syncAndBabysitTrackedRepos(
+          fullSweep ? { fullSweep: true } : undefined,
+        ));
       }
       : undefined,
 

--- a/server/github.test.ts
+++ b/server/github.test.ts
@@ -1433,7 +1433,7 @@ test("fetchFeedbackItemsForPR marks patchdeck status and audit comments non-acti
           {
             id: 201,
             node_id: "IC_kwDO_status",
-            body: "**Accepted** - this comment requires code changes. Queuing fix...\n\nPosted by [patchdeck](https://github.com/jeremymcs/patchdeck)",
+            body: "**Accepted** - queued for a code change.\n\nPosted by [patchdeck](https://github.com/jeremymcs/patchdeck)",
             created_at: "2026-03-15T11:00:00Z",
             html_url: "https://github.com/jeremymcs/patchdeck/pull/1#issuecomment-201",
             user: { login: "octocat", type: "User" },
@@ -1449,7 +1449,7 @@ test("fetchFeedbackItemsForPR marks patchdeck status and audit comments non-acti
           {
             id: 204,
             node_id: "IC_kwDO_footerless_status",
-            body: "**Agent running** - patchdeck dispatched `codex` to apply the accepted fix.",
+            body: "**In progress** - applying the accepted fix.",
             created_at: "2026-03-15T11:01:30Z",
             html_url: "https://github.com/jeremymcs/patchdeck/pull/1#issuecomment-204",
             user: { login: "octocat", type: "User" },

--- a/server/github.ts
+++ b/server/github.ts
@@ -462,7 +462,7 @@ export function buildFeedbackAuditToken(feedbackId: string): string {
 const APP_COMMENT_FOOTER_PATTERN = /Posted by \[[^\]]+\]\(https:\/\/github\.com\/jeremymcs\/patchdeck\)/i;
 const AGENT_COMMAND_COMMENT_MARKER = "<!-- codefactory-agent-command -->";
 const AUDIT_TRAIL_COMMENT_PATTERN = /<!--\s*codefactory-feedback:[^>]+-->/i;
-export const APP_STATUS_COMMENT_PATTERN = /\*\*(?:Accepted|Agent running|Agent failed|Agent completed|Resolved)\*\*\s*(?:[—-]|$)/i;
+export const APP_STATUS_COMMENT_PATTERN = /\*\*(?:Accepted|Agent running|Agent failed|Agent completed|In progress|Needs attention|Verifying|Resolved)\*\*\s*(?:[—-]|$)/i;
 
 function classifyNonActionableAppFeedback(body: string): string | null {
   if (body.includes(AGENT_COMMAND_COMMENT_MARKER)) {

--- a/server/githubReplyBranding.test.ts
+++ b/server/githubReplyBranding.test.ts
@@ -21,8 +21,9 @@ test("GitHub reply branding can replace the visible app name", () => {
     "Review Bot",
   );
 
-  assert.match(comment, /\*\*Review Bot\*\* dispatched `codex`/);
-  assert.doesNotMatch(comment, /\*\*patchdeck\*\* dispatched/);
+  assert.match(comment, /\*\*Review Bot\*\* started an automated PR update\./);
+  assert.doesNotMatch(comment, /\*\*patchdeck\*\* started/);
+  assert.doesNotMatch(comment, /Fix the failing test\./);
   assert.doesNotMatch(comment, /Posted by/);
 });
 
@@ -34,9 +35,30 @@ test("GitHub reply branding can remove the visible app name", () => {
     "   ",
   );
 
-  assert.match(comment, /\ud83e\udd16 Dispatched `codex`/);
+  assert.match(comment, /^<!-- codefactory-agent-command -->\nStarted an automated PR update\./);
   assert.doesNotMatch(comment, /patchdeck/);
   assert.doesNotMatch(comment, /Posted by/);
+});
+
+test("GitHub agent command comments summarize merge conflicts without exposing the prompt", () => {
+  const comment = formatAgentCommandGitHubComment(
+    "codex",
+    [
+      "A merge from the base branch into the head branch has been started but has conflicts.",
+      "The following files have merge conflicts:",
+      "  - src/example.ts",
+      "",
+      "Your task:",
+      "1) Resolve ALL merge conflicts in the listed files.",
+    ].join("\n"),
+    false,
+    "Review Bot",
+  );
+
+  assert.match(comment, /Merge conflicts were detected/);
+  assert.match(comment, /- `src\/example\.ts`/);
+  assert.doesNotMatch(comment, /Your task:/);
+  assert.doesNotMatch(comment, /Resolve ALL merge conflicts/);
 });
 
 test("GitHub reply branding uses the custom name in linked footers", () => {


### PR DESCRIPTION
## Summary
- Clear stale CLI-missing drain mode once the configured agent command is available again.
- Add non-destructive Clear view controls to Logs, PR Activity logs, and issue Activity logs.
- Show PR and issue authors as @username for easier scanning.
- Keep deferred PR babysitter backlogs visible and refilled with a short-delay follow-up sweep instead of waiting for the full watcher interval.

Closes #109

## Verification
- [x] npm run check
- [x] node --import tsx --test server/agentRunner.test.ts server/appRuntime.test.ts
- [x] node --import tsx --test client/src/lib/fullAppQaSurface.test.ts client/src/lib/runtimeDisplay.test.ts
- [x] node --import tsx --test server/babysitter.test.ts

## Related Issue
- Closes #109
- [#109 Fix stale agent drain status and improve log visibility](https://github.com/jeremymcs/patchdeck/issues/109)

## User
- @jeremymcs

## Repo
- jeremymcs/patchdeck

## Branch
- fix/drain-cli-log-ui-status