### PR TITLE
fix: clarify automation work status

### DIFF
--- a/client/src/components/ActivityMenu.tsx
+++ b/client/src/components/ActivityMenu.tsx
@@ -3,6 +3,7 @@ import type { ActivityItem, ActivitySnapshot, BackgroundJobKind } from "@shared/
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import type { QueueStatusView } from "@/lib/activityQueue";
+import { formatActivityDetail, formatActivityLabel } from "@/lib/activityDisplay";
 
 export const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
   failed: [],
@@ -50,6 +51,8 @@ function ActivityKindBadge({ kind }: { kind: BackgroundJobKind }) {
 }
 
 function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueStatus: QueueStatusView | null }) {
+  const label = formatActivityLabel(activity.label);
+  const detail = formatActivityDetail(activity.detail);
   const timeLabel = activity.status === "failed"
     ? formatClock(activity.updatedAt)
     : activity.status === "in_progress"
@@ -70,10 +73,10 @@ function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueS
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-1.5">
           <ActivityKindBadge kind={activity.kind} />
-          <span className="min-w-0 truncate text-[12px] leading-4 text-foreground">{activity.label}</span>
+          <span className="min-w-0 truncate text-[12px] leading-4 text-foreground">{label}</span>
         </span>
-        {activity.detail && (
-          <span className="block truncate text-[11px] leading-4 text-muted-foreground">{activity.detail}</span>
+        {detail && (
+          <span className="block truncate text-[11px] leading-4 text-muted-foreground">{detail}</span>
         )}
         <div className="mt-1">
           <QueueStatusBadge status={queueStatus} />
@@ -143,6 +146,7 @@ export function ActivityMenu({
   globalDrainMode,
   queueStatusById,
   pollIntervalMs,
+  idleReason,
 }: {
   activities: ActivitySnapshot;
   onClearFailed: () => void;
@@ -150,6 +154,7 @@ export function ActivityMenu({
   globalDrainMode: boolean;
   queueStatusById: Map<string, QueueStatusView>;
   pollIntervalMs?: number;
+  idleReason?: string | null;
 }) {
   const failedCount = activities.failed.length;
   const inProgressCount = activities.inProgress.length;
@@ -197,16 +202,24 @@ export function ActivityMenu({
         <ActivitySection
           title="In progress"
           items={activities.inProgress}
-          emptyLabel="No activities running right now."
+          emptyLabel="No automation running right now."
           queueStatusById={queueStatusById}
         />
         <div className="border-t border-border" />
         <ActivitySection
           title="Queued"
           items={activities.queued}
-          emptyLabel="Queue is empty."
+          emptyLabel={idleReason ? "No work is queued." : "Queue is empty."}
           queueStatusById={queueStatusById}
         />
+        {idleReason && totalCount === 0 && (
+          <div
+            className="border-t border-border px-2 py-2 text-[11px] leading-4 text-warning-foreground"
+            data-testid="activity-idle-reason"
+          >
+            {idleReason}
+          </div>
+        )}
         {globalDrainMode && queuedCount > 0 && (
           <div
             className="border-t border-border px-2 py-2 text-[11px] text-muted-foreground"

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -223,7 +223,7 @@ function AutoModeButton() {
             <label htmlFor="auto-mode-prs" className="flex min-w-0 cursor-pointer flex-col">
               <span className="text-[12px] font-medium text-foreground">Pull requests</span>
               <span className="text-[10px] text-muted-foreground">
-                Watcher runs the babysitter on watched PRs. Per-repo overrides in Settings.
+                Watcher queues safe automation runs on watched PRs. Per-repo overrides live in Settings.
               </span>
             </label>
             <Switch

--- a/client/src/components/CurrentRunStatusStrip.tsx
+++ b/client/src/components/CurrentRunStatusStrip.tsx
@@ -1,5 +1,6 @@
 import { Bot, CheckCircle2, CircleDashed, Loader2, XCircle } from "lucide-react";
 import type { CurrentRunStatus } from "@shared/schema";
+import { formatCurrentRunStatus } from "@/lib/statusCopy";
 
 type CurrentRunStatusStripProps = {
   run: CurrentRunStatus | null | undefined;
@@ -38,7 +39,7 @@ export function CurrentRunStatusStrip({ run, testId }: CurrentRunStatusStripProp
     >
       <span className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider">
         <StatusIcon status={run.status} />
-        {run.status}
+        {formatCurrentRunStatus(run.status)}
       </span>
       <span className="font-medium text-foreground">{run.label}</span>
       {run.phase && <span className="font-mono text-muted-foreground">{run.phase}</span>}

--- a/client/src/components/GlobalActivityPanel.tsx
+++ b/client/src/components/GlobalActivityPanel.tsx
@@ -1,6 +1,7 @@
 import type { ActivityItem, ActivitySnapshot } from "@shared/schema";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import type { QueueStatusView } from "@/lib/activityQueue";
+import { formatActivityDetail, formatActivityLabel } from "@/lib/activityDisplay";
 
 function formatClock(timestamp: string | null): string | null {
   if (!timestamp) {
@@ -13,9 +14,11 @@ function formatClock(timestamp: string | null): string | null {
 export function GlobalActivityPanel({
   activities,
   queueStatusById,
+  idleReason,
 }: {
   activities: ActivitySnapshot;
   queueStatusById: Map<string, QueueStatusView>;
+  idleReason?: string | null;
 }) {
   const visibleActivities = [...activities.inProgress, ...activities.queued, ...activities.failed].slice(0, 5);
 
@@ -29,7 +32,9 @@ export function GlobalActivityPanel({
         </div>
       </div>
       {visibleActivities.length === 0 ? (
-        <div className="mt-2 text-[11px] text-muted-foreground">No automation running or queued.</div>
+        <div className="mt-2 text-[11px] leading-4 text-muted-foreground" data-testid="global-activity-idle-reason">
+          {idleReason ?? "No automation running or queued."}
+        </div>
       ) : (
         <div className="mt-2 space-y-1">
           {visibleActivities.map((activity) => (
@@ -52,6 +57,8 @@ function GlobalActivityRow({
   activity: ActivityItem;
   queueStatus: QueueStatusView | null;
 }) {
+  const label = formatActivityLabel(activity.label);
+  const detail = formatActivityDetail(activity.detail);
   const statusClass = activity.status === "failed"
     ? "border-destructive/50 text-destructive"
     : activity.status === "in_progress"
@@ -69,11 +76,11 @@ function GlobalActivityRow({
         <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${statusClass}`}>
           {activity.status === "in_progress" ? "running" : activity.status}
         </span>
-        <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{activity.label}</span>
+        <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{label}</span>
         {timeLabel && <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{timeLabel}</span>}
       </div>
-      {activity.detail && (
-        <div className="mt-1 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
+      {detail && (
+        <div className="mt-1 truncate text-[11px] text-muted-foreground">{detail}</div>
       )}
       <div className="mt-1">
         <QueueStatusBadge status={queueStatus} />

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -123,7 +123,7 @@ export function getOnboardingPanelState(status: OnboardingStatus) {
           ? "Reviewer setup preserved while GitHub checks are temporarily rate limited."
           : `Reviewer Action detected in ${reposWithReview.length} repo${reposWithReview.length === 1 ? "" : "s"}.`
         : accessibleRepos.length > 0
-          ? "Drop a Claude, Codex, or Gemini GitHub Action into a tracked repo so AI review comments appear on every new PR — PatchDeck then babysits the feedback."
+          ? "Drop a code-review GitHub Action into a tracked repo so review comments appear on every new PR. PatchDeck tracks the feedback and queues safe fixes."
           : "Track a repo first, then add a reviewer GitHub Action to it.",
       complete: workflowStepComplete,
     },
@@ -393,7 +393,7 @@ export function OnboardingPanel() {
                   <div className="space-y-2 pt-1">
                     <div className="space-y-2 border border-border bg-muted/40 px-3 py-2">
                       <p className="text-[12px] text-muted-foreground">
-                        These are GitHub Actions that run on every PR and post AI review comments. PatchDeck reads those comments, decides which need code changes, and dispatches its own agent to fix them. Different providers have different strengths — pick whichever fits your stack.
+                        These are GitHub Actions that run on every PR and post review comments. PatchDeck reads those comments, decides which need code changes, and queues safe fixes. Pick whichever review tool fits your stack.
                       </p>
                       <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
                         {REVIEW_PROVIDER_GUIDES.map((provider) => (
@@ -451,7 +451,7 @@ export function OnboardingPanel() {
                   <div className="space-y-2 pt-1">
                     <div className="space-y-2 border border-border bg-muted/40 px-3 py-2">
                       <p className="text-[12px] text-muted-foreground">
-                        These are GitHub Actions that run on every PR and post AI review comments. PatchDeck reads those comments, decides which need code changes, and dispatches its own agent to fix them. Different providers have different strengths — pick whichever fits your stack.
+                        These are GitHub Actions that run on every PR and post review comments. PatchDeck reads those comments, decides which need code changes, and queues safe fixes. Pick whichever review tool fits your stack.
                       </p>
                       <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
                         {REVIEW_PROVIDER_GUIDES.map((provider) => (

--- a/client/src/components/SocialPostGenerator.tsx
+++ b/client/src/components/SocialPostGenerator.tsx
@@ -131,7 +131,7 @@ export function SocialPostGenerator({
 
       {post?.status === "generating" && (
         <div className="mt-2 text-[11px] text-muted-foreground">
-          The agent is composing posts. This can take 30–120 seconds.
+          Automation is composing posts. This can take 30–120 seconds.
         </div>
       )}
 

--- a/client/src/components/detail/StageProgressBar.tsx
+++ b/client/src/components/detail/StageProgressBar.tsx
@@ -31,7 +31,7 @@ export function StageProgressBar({
           const segmentClass = (() => {
             switch (stage.state) {
               case "done":
-                return "bg-success";
+                return "bg-primary/70";
               case "active":
                 return "bg-primary animate-pulse";
               case "failed":

--- a/client/src/lib/activityDisplay.test.ts
+++ b/client/src/lib/activityDisplay.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatActivityDetail, formatActivityLabel } from "./activityDisplay";
+
+test("formatActivityLabel updates legacy PR work labels", () => {
+  assert.equal(formatActivityLabel("Babysitting PR #6097"), "Working PR #6097");
+  assert.equal(formatActivityLabel("Working PR #6097"), "Working PR #6097");
+});
+
+test("formatActivityDetail updates legacy deferred queue copy", () => {
+  assert.equal(
+    formatActivityDetail("Refilling babysitter queue after the active batch drains"),
+    "Refilling PR work queue after the active batch drains",
+  );
+  assert.equal(formatActivityDetail(null), null);
+});

--- a/client/src/lib/activityDisplay.ts
+++ b/client/src/lib/activityDisplay.ts
@@ -1,0 +1,7 @@
+export function formatActivityLabel(label: string): string {
+  return label.replace(/^Babysitting PR\b/, "Working PR");
+}
+
+export function formatActivityDetail(detail: string | null): string | null {
+  return detail?.replace("Refilling babysitter queue", "Refilling PR work queue") ?? null;
+}

--- a/client/src/lib/activityIdle.test.ts
+++ b/client/src/lib/activityIdle.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ActivitySnapshot } from "@shared/schema";
+import { getActivityIdleReason } from "./activityIdle";
+
+const emptyActivities: Pick<ActivitySnapshot, "inProgress" | "queued"> = {
+  inProgress: [],
+  queued: [],
+};
+
+test("getActivityIdleReason returns null while work is running", () => {
+  assert.equal(getActivityIdleReason({
+    activities: {
+      ...emptyActivities,
+      inProgress: [{} as ActivitySnapshot["inProgress"][number]],
+    },
+  }), null);
+});
+
+test("getActivityIdleReason explains drain mode before generic idleness", () => {
+  assert.equal(getActivityIdleReason({
+    activities: emptyActivities,
+    drainMode: true,
+    drainReason: "operator paused",
+    trackedCount: 12,
+    trackedLabel: "PR",
+  }), "Automation is paused by drain mode: operator paused");
+});
+
+test("getActivityIdleReason explains rate limits with reset time", () => {
+  const reason = getActivityIdleReason({
+    activities: emptyActivities,
+    githubRateLimited: true,
+    githubRateLimitResetAt: "2026-05-17T16:30:00.000Z",
+  });
+
+  assert.match(reason ?? "", /GitHub is rate-limited/);
+  assert.match(reason ?? "", /resume after/);
+});
+
+test("getActivityIdleReason explains eligible tracked work", () => {
+  assert.equal(getActivityIdleReason({
+    activities: emptyActivities,
+    trackedCount: 20,
+    eligibleCount: 3,
+    trackedLabel: "PR",
+  }), "No jobs are running. 3 PRs can be queued when the next safe work slot opens.");
+});
+
+test("getActivityIdleReason explains tracked work with no known eligible items", () => {
+  assert.equal(getActivityIdleReason({
+    activities: emptyActivities,
+    trackedCount: 20,
+    eligibleCount: 0,
+    trackedLabel: "issue",
+  }), "No jobs are running. 20 issues are tracked, but none are eligible right now or the watcher is waiting for the next sync pass.");
+});

--- a/client/src/lib/activityIdle.ts
+++ b/client/src/lib/activityIdle.ts
@@ -1,0 +1,61 @@
+import type { ActivitySnapshot } from "@shared/schema";
+
+export type ActivityIdleReasonInput = {
+  activities: Pick<ActivitySnapshot, "inProgress" | "queued">;
+  drainMode?: boolean;
+  drainReason?: string | null;
+  githubRateLimited?: boolean;
+  githubRateLimitResetAt?: string | null;
+  autoEnabled?: boolean;
+  trackedLabel?: string;
+  trackedCount?: number;
+  eligibleCount?: number;
+};
+
+function formatResetTime(resetAt: string | null | undefined): string | null {
+  if (!resetAt) return null;
+  const date = new Date(resetAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString("en-US");
+}
+
+function pluralize(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? "" : "s"}`;
+}
+
+export function getActivityIdleReason(input: ActivityIdleReasonInput): string | null {
+  if (input.activities.inProgress.length > 0 || input.activities.queued.length > 0) {
+    return null;
+  }
+
+  if (input.drainMode) {
+    return input.drainReason
+      ? `Automation is paused by drain mode: ${input.drainReason}`
+      : "Automation is paused by drain mode.";
+  }
+
+  if (input.githubRateLimited) {
+    const resetTime = formatResetTime(input.githubRateLimitResetAt);
+    return resetTime
+      ? `GitHub is rate-limited. Work will resume after ${resetTime}.`
+      : "GitHub is rate-limited. Work will resume when the limit resets.";
+  }
+
+  if (input.autoEnabled === false) {
+    return "Automation is set to manual mode.";
+  }
+
+  const trackedCount = input.trackedCount ?? 0;
+  const trackedLabel = input.trackedLabel ?? "item";
+  const eligibleCount = input.eligibleCount ?? 0;
+
+  if (eligibleCount > 0) {
+    return `No jobs are running. ${pluralize(eligibleCount, trackedLabel)} can be queued when the next safe work slot opens.`;
+  }
+
+  if (trackedCount > 0) {
+    return `No jobs are running. ${pluralize(trackedCount, trackedLabel)} are tracked, but none are eligible right now or the watcher is waiting for the next sync pass.`;
+  }
+
+  return "No tracked work yet.";
+}

--- a/client/src/lib/activityQueue.test.ts
+++ b/client/src/lib/activityQueue.test.ts
@@ -10,7 +10,7 @@ const snapshot: ActivitySnapshot = {
       id: "run-1",
       kind: "babysit_pr",
       status: "in_progress",
-      label: "Babysitting PR #1",
+      label: "Working PR #1",
       detail: null,
       targetId: "pr-1",
       targetUrl: null,

--- a/client/src/lib/feedbackStatus.test.ts
+++ b/client/src/lib/feedbackStatus.test.ts
@@ -5,6 +5,7 @@ import {
   formatFeedbackStatusLabel,
   isFeedbackCollapsedByDefault,
   countActiveFeedbackStatuses,
+  arePRFeedbackItemsResolved,
   isPRReadyToMerge,
 } from "./feedbackStatus";
 
@@ -35,6 +36,10 @@ test('isFeedbackCollapsedByDefault("pending") === false', () => {
 });
 
 // isPRReadyToMerge
+test("arePRFeedbackItemsResolved returns true for empty items", () => {
+  assert.equal(arePRFeedbackItemsResolved([]), true);
+});
+
 test("isPRReadyToMerge returns false for empty items", () => {
   assert.equal(isPRReadyToMerge([]), false);
 });

--- a/client/src/lib/feedbackStatus.ts
+++ b/client/src/lib/feedbackStatus.ts
@@ -23,13 +23,16 @@ export function isFeedbackCollapsedByDefault(status: FeedbackStatus): boolean {
   return isTerminalFeedbackStatus(status) || status === "warning";
 }
 
+export function arePRFeedbackItemsResolved(items: FeedbackItem[]): boolean {
+  return items.every((item) => isTerminalFeedbackStatus(item.status));
+}
+
 /**
- * A PR is ready to merge when it has feedback items and every item
- * has reached a terminal state (resolved or rejected).
+ * Legacy feedback-only helper. Full PR readiness also requires GitHub checks,
+ * mergeability, and a non-running work state.
  */
 export function isPRReadyToMerge(items: FeedbackItem[]): boolean {
-  if (items.length === 0) return false;
-  return items.every((item) => isTerminalFeedbackStatus(item.status));
+  return items.length > 0 && arePRFeedbackItemsResolved(items);
 }
 
 export function countActiveFeedbackStatuses(items: FeedbackItem[]): {

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -283,6 +283,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
     ["run-now action", "button-apply"],
     ["pause-resume watch action", "button-toggle-watch"],
     ["selected PR current run", "selected-pr-current-run"],
+    ["PR merge readiness checklist", "pr-merge-readiness-checklist"],
     ["CI healing panel", "panel-ci-healing"],
     ["ask agent tab", "tab-ask"],
     ["activity tab", "tab-activity"],
@@ -406,6 +407,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
     ["load more issues button", "button-load-more-issues"],
     ["loaded issue count", "issues-loaded-count"],
     ["issue detail logs", "issue-detail-logs"],
+    ["issue activity panel toggle", "button-toggle-issue-activity-panel"],
   ] satisfies SourceExpectation[]) {
     assertHasTestId(sourceFile, label, testId);
   }
@@ -439,6 +441,7 @@ test("issues page keeps the QA-tested issue monitor and work surface wired", asy
   assertHasExpression(sourceFile, "issue pagination load more", /\bloadMoreIssues\b/);
   assertHasExpression(sourceFile, "issue loaded count", /\bloadedIssueCount\b/);
   assertHasStringValue(sourceFile, "issue sync label", "sync");
+  assertHasStringValue(sourceFile, "issue queue work label", "Queue work");
   assertHasStringValue(sourceFile, "manual issue pull label", "Pull issue");
   assertHasStringValue(sourceFile, "manual PR pull label", "Pull PR");
   assertHasStringValue(sourceFile, "issue load more label", "Load more");
@@ -565,6 +568,7 @@ test("activity menu keeps the QA-tested trigger, drain note, and poll footer wir
   assertHasTestId(sourceFile, "activity menu trigger", "activity-menu-trigger");
   assertHasTestId(sourceFile, "clear failed activities", "clear-failed-activities");
   assertHasTestId(sourceFile, "activity drain note", "activity-drain-note");
+  assertHasTestId(sourceFile, "activity idle reason", "activity-idle-reason");
   assertHasTestId(sourceFile, "activity poll footer", "activity-poll-footer");
   assertHasStringValue(sourceFile, "queued drain copy", "Queued automation is paused until drain mode is disabled.");
 });

--- a/client/src/lib/prReadiness.test.ts
+++ b/client/src/lib/prReadiness.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { FeedbackItem, PR, PRSummary } from "@shared/schema";
 import {
+  buildPRReadinessChecks,
   isGitHubReadyToMerge,
   isPRDetailReadyToMerge,
   isPRSummaryReadyToMerge,
@@ -67,13 +68,14 @@ test("isGitHubReadyToMerge only treats GitHub clean state as ready", () => {
   assert.equal(isGitHubReadyToMerge({ mergeableState: null }), false);
 });
 
-test("isPRDetailReadyToMerge requires comments, checks, lint, and GitHub ready state", () => {
+test("isPRDetailReadyToMerge requires idle work, checks, lint, resolved comments, and GitHub ready state", () => {
   assert.equal(isPRDetailReadyToMerge(makePr()), true);
   assert.equal(isPRDetailReadyToMerge(makePr({ testsPassed: false })), false);
   assert.equal(isPRDetailReadyToMerge(makePr({ lintPassed: false })), false);
   assert.equal(isPRDetailReadyToMerge(makePr({ mergeableState: "blocked" })), false);
-  assert.equal(isPRDetailReadyToMerge(makePr({ feedbackItems: [] })), false);
+  assert.equal(isPRDetailReadyToMerge(makePr({ feedbackItems: [] })), true);
   assert.equal(isPRDetailReadyToMerge(makePr({ status: "processing" })), false);
+  assert.equal(isPRDetailReadyToMerge(makePr({ status: "error" })), false);
 });
 
 test("isPRSummaryReadyToMerge uses stored checks and GitHub ready state", () => {
@@ -81,7 +83,31 @@ test("isPRSummaryReadyToMerge uses stored checks and GitHub ready state", () => 
   const { feedbackItems: _feedbackItems, ...base } = summary;
 
   assert.equal(isPRSummaryReadyToMerge(base satisfies PRSummary), true);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, status: "watching" }), true);
   assert.equal(isPRSummaryReadyToMerge({ ...base, testsPassed: null }), false);
   assert.equal(isPRSummaryReadyToMerge({ ...base, lintPassed: null }), false);
   assert.equal(isPRSummaryReadyToMerge({ ...base, mergeableState: "unstable" }), false);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, status: "processing" }), false);
+});
+
+test("buildPRReadinessChecks explains why a PR is not ready", () => {
+  const checks = buildPRReadinessChecks(makePr({
+    status: "processing",
+    testsPassed: false,
+    lintPassed: null,
+    mergeableState: "dirty",
+    feedbackItems: [
+      { ...resolvedFeedback[0], id: "1", status: "resolved" },
+      { ...resolvedFeedback[0], id: "2", status: "queued" },
+    ] as FeedbackItem[],
+  }));
+
+  assert.deepEqual(checks.map((check) => [check.key, check.passed]), [
+    ["work-state", false],
+    ["tests", false],
+    ["lint", false],
+    ["comments", false],
+    ["github", false],
+  ]);
+  assert.match(checks.find((check) => check.key === "comments")?.detail ?? "", /1 tracked feedback item/);
 });

--- a/client/src/lib/prReadiness.ts
+++ b/client/src/lib/prReadiness.ts
@@ -1,5 +1,12 @@
 import type { PR, PRSummary } from "@shared/schema";
-import { isPRReadyToMerge } from "@/lib/feedbackStatus";
+import { arePRFeedbackItemsResolved } from "@/lib/feedbackStatus";
+
+export type PRReadinessCheck = {
+  key: string;
+  label: string;
+  passed: boolean;
+  detail: string;
+};
 
 export function isGitHubReadyToMerge(pr: Pick<PRSummary, "mergeableState">): boolean {
   return pr.mergeableState === "clean";
@@ -8,7 +15,9 @@ export function isGitHubReadyToMerge(pr: Pick<PRSummary, "mergeableState">): boo
 export function isPRSummaryReadyToMerge(
   pr: Pick<PRSummary, "status" | "testsPassed" | "lintPassed" | "mergeableState">,
 ): boolean {
-  return pr.status === "done"
+  return pr.status !== "processing"
+    && pr.status !== "error"
+    && pr.status !== "archived"
     && pr.testsPassed === true
     && pr.lintPassed === true
     && isGitHubReadyToMerge(pr);
@@ -18,8 +27,64 @@ export function isPRDetailReadyToMerge(
   pr: Pick<PR, "status" | "testsPassed" | "lintPassed" | "mergeableState" | "feedbackItems">,
 ): boolean {
   return pr.status !== "processing"
+    && pr.status !== "error"
+    && pr.status !== "archived"
     && pr.testsPassed === true
     && pr.lintPassed === true
     && isGitHubReadyToMerge(pr)
-    && isPRReadyToMerge(pr.feedbackItems);
+    && arePRFeedbackItemsResolved(pr.feedbackItems);
+}
+
+export function buildPRReadinessChecks(
+  pr: Pick<PR, "status" | "testsPassed" | "lintPassed" | "mergeableState" | "feedbackItems">,
+): PRReadinessCheck[] {
+  const feedbackResolved = arePRFeedbackItemsResolved(pr.feedbackItems);
+  const unresolvedCount = pr.feedbackItems.filter((item) =>
+    item.status !== "resolved" && item.status !== "rejected"
+  ).length;
+
+  return [
+    {
+      key: "work-state",
+      label: "Automation idle",
+      passed: pr.status !== "processing",
+      detail: pr.status === "processing" ? "A work run is still active." : "No active work run.",
+    },
+    {
+      key: "tests",
+      label: "Tests passing",
+      passed: pr.testsPassed === true,
+      detail: pr.testsPassed === true
+        ? "Latest test result passed."
+        : pr.testsPassed === false
+          ? "Latest test result failed."
+          : "No test result synced yet.",
+    },
+    {
+      key: "lint",
+      label: "Lint passing",
+      passed: pr.lintPassed === true,
+      detail: pr.lintPassed === true
+        ? "Latest lint result passed."
+        : pr.lintPassed === false
+          ? "Latest lint result failed."
+          : "No lint result synced yet.",
+    },
+    {
+      key: "comments",
+      label: "Comments resolved",
+      passed: feedbackResolved,
+      detail: feedbackResolved
+        ? "All tracked review feedback is resolved or rejected."
+        : `${unresolvedCount} tracked feedback item${unresolvedCount === 1 ? "" : "s"} still need attention.`,
+    },
+    {
+      key: "github",
+      label: "GitHub mergeable",
+      passed: isGitHubReadyToMerge(pr),
+      detail: pr.mergeableState === "clean"
+        ? "GitHub reports this PR is ready to merge."
+        : `GitHub mergeable state is ${pr.mergeableState ?? "unknown"}.`,
+    },
+  ];
 }

--- a/client/src/lib/statusCopy.test.ts
+++ b/client/src/lib/statusCopy.test.ts
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { autoWorkStateTone, formatCurrentRunStatus, formatIssueAutoWorkState, formatIssueWorkStage, formatPRWorkState, prWorkStateTone } from "./statusCopy";
+
+test("formatPRWorkState separates run completion from merge readiness", () => {
+  assert.equal(formatPRWorkState("done"), "work finished");
+  assert.equal(formatPRWorkState("processing", "tests"), "verifying checks");
+  assert.equal(prWorkStateTone("done"), "neutral");
+});
+
+test("formatCurrentRunStatus keeps completed runs neutral in copy", () => {
+  assert.equal(formatCurrentRunStatus("completed"), "run finished");
+  assert.equal(formatCurrentRunStatus("running"), "running");
+});
+
+test("issue auto-work copy says ready to work instead of auto eligible", () => {
+  assert.equal(formatIssueAutoWorkState({ autoWorkEligible: true, autoWorkBlockedReason: null }), "ready to work");
+  assert.equal(formatIssueAutoWorkState({ autoWorkEligible: false, autoWorkBlockedReason: "blocked label" }), "blocked label");
+  assert.equal(autoWorkStateTone(true), "primary");
+});
+
+test("formatIssueWorkStage names completed issue work as work finished", () => {
+  assert.equal(formatIssueWorkStage({ workStage: "completed", workStatus: "idle" }), "work finished");
+});

--- a/client/src/lib/statusCopy.ts
+++ b/client/src/lib/statusCopy.ts
@@ -1,0 +1,50 @@
+import type { CurrentRunStatus, Issue, PR, PRStatus } from "@shared/schema";
+import type { StatusTone } from "@/lib/statusTones";
+
+export function formatPRWorkState(status: PRStatus, prStage?: PR["prStage"]): string {
+  if (status === "processing") {
+    if (prStage === "feedback_synced") return "feedback synced";
+    if (prStage === "triaged") return "triaged";
+    if (prStage === "applying") return "applying fixes";
+    if (prStage === "tests") return "verifying checks";
+    if (prStage === "done") return "work finished";
+    return "automation running";
+  }
+
+  if (status === "done") return "work finished";
+  if (status === "error") return "needs attention";
+  if (status === "archived") return "archived";
+  return "watching";
+}
+
+export function prWorkStateTone(status: PRStatus): StatusTone {
+  if (status === "error") return "destructive";
+  if (status === "processing") return "primary";
+  if (status === "archived") return "success";
+  return "neutral";
+}
+
+export function formatCurrentRunStatus(status: CurrentRunStatus["status"]): string {
+  if (status === "completed") return "run finished";
+  return status.replace("_", " ");
+}
+
+export function formatIssueWorkStage(issue: Pick<Issue, "workStage" | "workStatus">): string {
+  const stage = issue.workStage ?? (
+    issue.workStatus === "in_progress" ? "working" : issue.workStatus
+  );
+
+  if (stage === "completed") return "work finished";
+  return stage.replace("_", " ");
+}
+
+export function formatIssueAutoWorkState(
+  issue: Pick<Issue, "autoWorkEligible" | "autoWorkBlockedReason">,
+): string {
+  if (issue.autoWorkEligible) return "ready to work";
+  return issue.autoWorkBlockedReason ?? "manual only";
+}
+
+export function autoWorkStateTone(eligible: boolean | undefined): StatusTone {
+  return eligible ? "primary" : "neutral";
+}

--- a/client/src/lib/statusTones.ts
+++ b/client/src/lib/statusTones.ts
@@ -57,15 +57,16 @@ export function toneFailedBgClass(failed: boolean): string {
 export function prStatusTone(pr: Pick<PR, "status">): StatusTone {
   if (pr.status === "error") return "destructive";
   if (pr.status === "processing") return "primary";
-  if (pr.status === "done") return "success";
+  if (pr.status === "archived") return "success";
   return "neutral";
 }
 
-export function issueRowTone(issue: Pick<Issue, "workStatus" | "workPrUrl">): StatusTone {
+export function issueRowTone(issue: Pick<Issue, "workStatus" | "workPrUrl" | "workPrMergeable">): StatusTone {
   if (issue.workStatus === "failed") return "destructive";
   if (issue.workStatus === "in_progress") return "primary";
   if (issue.workStatus === "queued") return "primary";
-  if (issue.workPrUrl) return "success";
+  if (issue.workPrMergeable === true) return "success";
+  if (issue.workPrMergeable === false) return "warning";
   return "neutral";
 }
 
@@ -84,5 +85,5 @@ export function issueEvaluationTone(status: Issue["evaluationStatus"]): StatusTo
 }
 
 export function autoWorkTone(eligible: boolean | undefined): StatusTone {
-  return eligible ? "success" : "neutral";
+  return eligible ? "primary" : "neutral";
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -11,6 +11,8 @@ import { StatusChip } from "@/components/detail/StatusChip";
 import { EMPTY_ACTIVITY_SNAPSHOT } from "@/components/ActivityMenu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ACTIVITY_POLL_INTERVAL_MS } from "@/lib/polling";
+import { getActivityIdleReason } from "@/lib/activityIdle";
+import { formatActivityDetail, formatActivityLabel } from "@/lib/activityDisplay";
 
 type PRBreakdown = {
   total: number;
@@ -75,6 +77,8 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
       ? (item.startedAt ?? item.updatedAt)
       : item.updatedAt;
   const errorMessage = accent === "destructive" ? item.lastError : null;
+  const label = formatActivityLabel(item.label);
+  const detail = formatActivityDetail(item.detail);
 
   const labelClass = accent === "destructive"
     ? "inline-flex items-center gap-1 truncate text-[12px] font-medium text-destructive"
@@ -115,12 +119,12 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className={labelClass}>
           {leadingIcon}
-          {item.label}
+          {label}
         </span>
         <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(timestamp)}</span>
       </div>
-      {item.detail && (
-        <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{item.detail}</div>
+      {detail && (
+        <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{detail}</div>
       )}
       {errorMessage && (
         <div
@@ -264,7 +268,7 @@ function RepoCard({ stats }: { stats: RepoStats }) {
             <StatusChip tone="destructive" label={`${prCounts.error} error`} />
           )}
           {prCounts.done > 0 && (
-            <StatusChip tone="success" label={`${prCounts.done} done`} />
+            <StatusChip tone="neutral" label={`${prCounts.done} work finished`} />
           )}
           {prCounts.watching > 0 && (
             <StatusChip tone="neutral" label={`${prCounts.watching} watching`} />
@@ -281,7 +285,13 @@ function RepoCard({ stats }: { stats: RepoStats }) {
   );
 }
 
-function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }) {
+function DashboardActivityPanel({
+  activities,
+  idleReason,
+}: {
+  activities: ActivitySnapshot;
+  idleReason?: string | null;
+}) {
   return (
     <div className="flex flex-col gap-3">
       <div id="failed-activity" className="scroll-mt-4">
@@ -316,7 +326,7 @@ function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }
       >
         <div className="max-h-48 overflow-y-auto">
           {activities.inProgress.length === 0 ? (
-            <div className="px-3 py-2 text-[12px] text-muted-foreground">No active jobs.</div>
+            <div className="px-3 py-2 text-[12px] text-muted-foreground">{idleReason ?? "No active jobs."}</div>
           ) : (
             activities.inProgress.slice(0, 8).map((item) => (
               <ActivityRow
@@ -337,7 +347,7 @@ function DashboardActivityPanel({ activities }: { activities: ActivitySnapshot }
       >
         <div className="max-h-48 overflow-y-auto">
           {activities.queued.length === 0 ? (
-            <div className="px-3 py-2 text-[12px] text-muted-foreground">Queue is empty.</div>
+            <div className="px-3 py-2 text-[12px] text-muted-foreground">{idleReason ? "No work is queued." : "Queue is empty."}</div>
           ) : (
             activities.queued.slice(0, 8).map((item) => (
               <ActivityRow key={item.id} item={item} timeRef="queuedAt" />
@@ -388,6 +398,12 @@ export default function Dashboard() {
   const activeJobs = activities.inProgress.length + activities.queued.length;
   const failedJobs = activities.failed.length;
   const failedTotal = failedPRs + failedJobs;
+  const activityIdleReason = getActivityIdleReason({
+    activities,
+    autoEnabled: config ? config.autoPrs !== false || config.autoIssues !== false : undefined,
+    trackedCount: totalPRs + totalIssues,
+    trackedLabel: "item",
+  });
 
   const isLoading = prsLoading || issuesLoading;
 
@@ -487,7 +503,7 @@ export default function Dashboard() {
                 Activity
               </div>
               <div className="mt-3">
-                <DashboardActivityPanel activities={activities} />
+                <DashboardActivityPanel activities={activities} idleReason={activityIdleReason} />
               </div>
             </aside>
           </div>

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -1,6 +1,6 @@
 import { Component, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { AlertTriangle, CheckCircle2, CircleDashed, CircleSlash, ExternalLink, Loader2, Plus, RefreshCw, ShieldCheck, Trash2, Wrench, X } from "lucide-react";
+import { AlertTriangle, CheckCircle2, CircleDashed, CircleSlash, ExternalLink, Loader2, PanelRightClose, PanelRightOpen, Plus, RefreshCw, ShieldCheck, Trash2, Wrench, X } from "lucide-react";
 import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -19,8 +19,10 @@ import { MetaBreadcrumb, type MetaItem } from "@/components/detail/MetaBreadcrum
 import { StageProgressBar } from "@/components/detail/StageProgressBar";
 import { StatusChip } from "@/components/detail/StatusChip";
 import { buildIssueStages } from "@/lib/stages";
-import { autoWorkTone, issueEvaluationTone, issueRowTone, issueWorkStatusTone, toneRailClass } from "@/lib/statusTones";
+import { issueEvaluationTone, issueRowTone, issueWorkStatusTone, toneRailClass } from "@/lib/statusTones";
 import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
+import { getActivityIdleReason } from "@/lib/activityIdle";
+import { autoWorkStateTone, formatIssueAutoWorkState, formatIssueWorkStage } from "@/lib/statusCopy";
 
 const ISSUES_CACHE_KEY = "patchdeck:issues-cache:v2";
 const ISSUES_CACHE_MAX_AGE_MS = 5 * 60 * 1000;
@@ -186,28 +188,12 @@ function canStartIssueWork(issue: Issue): boolean {
     && Boolean(issue.autoWorkEligible);
 }
 
-function formatIssueWorkStage(issue: Issue): string {
-  const stage = issue.workStage ?? (
-    issue.workStatus === "in_progress" ? "working" : issue.workStatus
-  );
-
-  return stage.replace("_", " ");
-}
-
 function formatIssueWorkAttempt(issue: Issue): string | null {
   if (!issue.workJobId) {
     return null;
   }
 
   return `attempt ${issue.workAttemptCount ?? 1}`;
-}
-
-function formatAutoWorkState(issue: Issue): string {
-  if (issue.autoWorkEligible) {
-    return "auto eligible";
-  }
-
-  return issue.autoWorkBlockedReason ?? "manual only";
 }
 
 function formatEvaluationState(issue: Issue): string {
@@ -270,14 +256,14 @@ function issueLifecycleLabel(issue: Issue): string | null {
   }
 
   if (issue.workPrUrl && issue.workPrMergeable === false) {
-    return "re-opened after divergence";
+    return "pr needs attention";
   }
 
   if (issue.workPrUrl) {
-    return "worked, awaiting merge";
+    return null;
   }
 
-  return "worked";
+  return "work finished";
 }
 
 function shouldShowIssueAutomationState(issue: Issue): boolean {
@@ -464,7 +450,7 @@ function IssueRow({
             {verifyState && <VerifyStateBadge state={verifyState} />}
             {lifecycle && (
               <StatusChip
-                tone={lifecycle === "re-opened after divergence" ? "warning" : "success"}
+                tone={lifecycle === "pr needs attention" ? "warning" : "neutral"}
                 label={lifecycle}
                 testId="issue-lifecycle-badge"
               />
@@ -650,12 +636,18 @@ function IssueLogPanel({
   selectedKey,
   activities,
   queueStatusById,
+  idleReason,
+  isCollapsed,
+  onToggleCollapsed,
 }: {
   logs: LogEntry[];
   selected: boolean;
   selectedKey: string | null;
   activities: ActivitySnapshot;
   queueStatusById: Map<string, QueueStatusView>;
+  idleReason?: string | null;
+  isCollapsed: boolean;
+  onToggleCollapsed: () => void;
 }) {
   const [clearedLogIds, setClearedLogIds] = useState<Set<string>>(() => new Set());
   const viewLogs = useMemo(
@@ -667,17 +659,44 @@ function IssueLogPanel({
     setClearedLogIds(new Set());
   }, [selectedKey]);
 
+  if (isCollapsed) {
+    return (
+      <div className="flex h-10 w-full shrink-0 items-center justify-end border-t border-border px-2 lg:h-auto lg:w-10 lg:flex-col lg:justify-start lg:border-l lg:border-t-0 lg:px-0 lg:py-2" data-testid="issue-activity-panel-collapsed">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          data-testid="button-toggle-issue-activity-panel"
+          title="Expand activity"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <PanelRightOpen className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Expand activity</span>
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
-      <div className="flex shrink-0 border-b border-border">
+      <div className="flex shrink-0 items-center border-b border-border">
         <div
           className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
           data-testid="tab-issue-activity"
         >
           Activity
         </div>
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          data-testid="button-toggle-issue-activity-panel"
+          title="Collapse activity"
+          className="mr-2 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <PanelRightClose className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Collapse activity</span>
+        </button>
       </div>
-      <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} />
+      <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} idleReason={idleReason} />
       <div className="flex-1 overflow-y-auto" data-testid="issue-detail-logs">
         {!selected ? (
           <div className="p-4 text-[12px] text-muted-foreground">
@@ -915,6 +934,7 @@ function IssuesPage() {
   const [manualPullNumber, setManualPullNumber] = useState("");
   const [labelInput, setLabelInput] = useState("");
   const [areErrorsRolledUp, setAreErrorsRolledUp] = useState(false);
+  const [isActivityPanelCollapsed, setIsActivityPanelCollapsed] = useState(false);
   const normalizedIssueNumberSearch = normalizeNumberSearch(issueNumberSearch);
   const manualPullRepo = selectedRepo !== "all"
     ? selectedRepo
@@ -1059,7 +1079,7 @@ function IssuesPage() {
         queryClient.invalidateQueries({ queryKey: ["/api/activities"] }),
         queryClient.invalidateQueries({ queryKey: ["/api/logs", issue.id] }),
       ]);
-      toast({ description: `Queued work for #${issue.number}.` });
+      toast({ description: `Queued issue work safely for #${issue.number}.` });
     },
     onError: (error) => {
       toast({ variant: "destructive", description: `Could not queue issue work: ${error.message}` });
@@ -1103,7 +1123,7 @@ function IssuesPage() {
         return;
       }
 
-      toast({ description: `Queued work for ${queued.length} issue${queued.length === 1 ? "" : "s"}.` });
+      toast({ description: `Queued issue work safely for ${queued.length} issue${queued.length === 1 ? "" : "s"}.` });
     },
     onError: (error) => {
       toast({ variant: "destructive", description: `Could not start issue work: ${error.message}` });
@@ -1364,6 +1384,17 @@ function IssuesPage() {
     ? loadedIssueCount
     : issues.filter((issue) => issue.repo === selectedRepo).length;
   const totalScopeCount = selectedRepo === "all" ? totalIssueCount : (repoTotals[selectedRepo] ?? loadedScopeCount);
+  const activityIdleReason = getActivityIdleReason({
+    activities,
+    drainMode: globalDrainMode,
+    drainReason: runtime?.drainReason ?? null,
+    githubRateLimited: isGitHubThrottled,
+    githubRateLimitResetAt: githubRateLimit?.resetAt ?? null,
+    autoEnabled: config?.autoIssues !== false,
+    trackedCount: totalScopeCount,
+    eligibleCount: startableVisibleIssues.length,
+    trackedLabel: "issue",
+  });
 
   return (
     <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
@@ -1425,6 +1456,7 @@ function IssuesPage() {
               globalDrainMode={Boolean(runtime?.drainMode)}
               queueStatusById={queueStatusById}
               pollIntervalMs={ACTIVITY_POLL_INTERVAL_MS}
+              idleReason={activityIdleReason}
             />
           </>
         )}
@@ -1441,7 +1473,7 @@ function IssuesPage() {
       />
 
       <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
-        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[42rem] lg:border-b-0 lg:border-r">
+        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[34rem] xl:w-[36rem] lg:border-b-0 lg:border-r">
           <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
             <div>
               Watched issues
@@ -1470,13 +1502,13 @@ function IssuesPage() {
                       ? throttledTitle
                       : startableVisibleIssues.length === 0
                         ? "No visible auto-eligible idle issues to start"
-                        : `Start work for ${startableVisibleIssues.length} visible issue${startableVisibleIssues.length === 1 ? "" : "s"}`
+                        : `Queue work for ${startableVisibleIssues.length} visible issue${startableVisibleIssues.length === 1 ? "" : "s"}`
                 }
                 data-testid="button-start-visible-issue-work"
                 className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary px-2 py-0.5 text-[10px] uppercase tracking-wider text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {startVisibleWorkMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Wrench className="h-3 w-3" />}
-                {startVisibleWorkMutation.isPending ? "starting" : `start work (${startableVisibleIssues.length})`}
+                {startVisibleWorkMutation.isPending ? "queuing safely" : `queue work (${startableVisibleIssues.length})`}
               </button>
               <button
                 type="button"
@@ -1610,7 +1642,7 @@ function IssuesPage() {
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
               }`}
             >
-              worked ({workedIssueCount})
+              work finished ({workedIssueCount})
             </button>
             <button
               type="button"
@@ -1802,8 +1834,8 @@ function IssuesPage() {
                     {shouldShowIssueAutomationState(selectedIssue) && (
                       <>
                         <StatusChip
-                          tone={autoWorkTone(selectedIssue.autoWorkEligible)}
-                          label={formatAutoWorkState(selectedIssue)}
+                          tone={autoWorkStateTone(selectedIssue.autoWorkEligible)}
+                          label={formatIssueAutoWorkState(selectedIssue)}
                           testId="issue-auto-work-state"
                         />
                         <StatusChip
@@ -1861,13 +1893,13 @@ function IssuesPage() {
                     <button
                       type="button"
                       onClick={() => workMutation.mutate(selectedIssue)}
-                      disabled={workMutation.isPending || isActiveWorkStatus(selectedIssue.workStatus) || Boolean(runtime?.drainMode) || selectedIssueHasExternalPr}
+                      disabled={workMutation.isPending || isActiveWorkStatus(selectedIssue.workStatus) || Boolean(selectedIssueQueueStatus) || Boolean(runtime?.drainMode) || selectedIssueHasExternalPr}
                       title={
                         runtime?.drainMode
                           ? "Manual issue work is paused by drain mode"
                           : selectedIssueHasExternalPr
                             ? "Manual issue work is blocked because this issue already has a linked external PR"
-                            : "Work this issue"
+                            : "Queue this issue for work"
                       }
                       data-testid="button-work-issue"
                       className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
@@ -1880,7 +1912,7 @@ function IssuesPage() {
                       ) : (
                         <>
                           <Wrench className="h-3.5 w-3.5" />
-                          Work issue
+                          Queue work
                         </>
                       )}
                     </button>
@@ -2129,6 +2161,9 @@ function IssuesPage() {
           selectedKey={selectedIssue?.id ?? null}
           activities={activities}
           queueStatusById={queueStatusById}
+          idleReason={activityIdleReason}
+          isCollapsed={isActivityPanelCollapsed}
+          onToggleCollapsed={() => setIsActivityPanelCollapsed((current) => !current)}
         />
       </div>
     </div>

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -331,7 +331,7 @@ export default function Logs() {
           </div>
           <div className="max-h-56 overflow-y-auto">
             {activityItems.length === 0 ? (
-              <div className="px-2 py-2 text-[10px] text-muted-foreground">No active activity.</div>
+              <div className="px-2 py-2 text-[10px] text-muted-foreground">No automation running or queued.</div>
             ) : (
               activityItems.map((item) => (
                 <div key={item.id} className="border-b border-border/40 px-2 py-1.5 last:border-b-0">

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useMemo, useRef, useState, type MouseEvent, type React
 import { Link } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { AlertTriangle, Bot, ChevronDown, ChevronUp, Loader2, PanelRightClose, PanelRightOpen, Pause, Play, PlayCircle, RefreshCw } from "lucide-react";
+import { AlertTriangle, Bot, CheckCircle2, ChevronDown, ChevronUp, CircleDashed, Loader2, PanelRightClose, PanelRightOpen, Pause, Play, PlayCircle, RefreshCw } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
 import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, RuntimeState, WatchedRepo } from "@shared/schema";
 import { AppHeader } from "@/components/AppHeader";
@@ -18,6 +18,7 @@ import {
   countActiveFeedbackStatuses,
 } from "@/lib/feedbackStatus";
 import {
+  buildPRReadinessChecks,
   isPRDetailReadyToMerge,
   isPRSummaryReadyToMerge,
 } from "@/lib/prReadiness";
@@ -38,6 +39,8 @@ import { StatusChip } from "@/components/detail/StatusChip";
 import { buildPRStages } from "@/lib/stages";
 import { prStatusTone, toneRailClass } from "@/lib/statusTones";
 import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
+import { getActivityIdleReason } from "@/lib/activityIdle";
+import { formatPRWorkState } from "@/lib/statusCopy";
 
 type GitHubRateLimitState = {
   limited: boolean;
@@ -98,8 +101,8 @@ const PR_STATUS_FILTERS: { value: PrStatusFilter; label: string; testId: string 
   { value: "ready", label: "ready to merge", testId: "pr-ready-filter" },
   { value: "ci_failing", label: "ci failing", testId: "pr-ci-failing-filter" },
   { value: "attention", label: "needs attention", testId: "pr-attention-filter" },
-  { value: "processing", label: "processing", testId: "pr-processing-filter" },
-  { value: "done", label: "done", testId: "pr-done-filter" },
+  { value: "processing", label: "running", testId: "pr-processing-filter" },
+  { value: "done", label: "work finished", testId: "pr-done-filter" },
 ];
 
 function FilterChip({
@@ -139,31 +142,6 @@ function buildIssueLinkedPRIndex(issues: Issue[]): Map<string, Issue> {
     index.set(prIssueLinkKey(issue.repo, issue.workPrNumber), issue);
   }
   return index;
-}
-
-function formatStatusLabel(status: PR["status"], prStage?: PR["prStage"]): string {
-  if (status === "processing") {
-    if (prStage === "feedback_synced") return "feedback synced";
-    if (prStage === "triaged") return "triaged";
-    if (prStage === "applying") return "applying fixes";
-    if (prStage === "tests") return "running tests";
-    if (prStage === "done") return "completed";
-    return "autonomous run active";
-  }
-
-  if (status === "done") {
-    return "completed";
-  }
-
-  if (status === "error") {
-    return "attention needed";
-  }
-
-  if (status === "archived") {
-    return "archived";
-  }
-
-  return "watching";
 }
 
 function latestActivityForTarget(activities: ActivityItem[], targetId: string): ActivityItem | undefined {
@@ -355,6 +333,51 @@ function ReadyToMergeIndicator({
   );
 }
 
+function MergeReadinessChecklist({
+  checks,
+  ready,
+}: {
+  checks: ReturnType<typeof buildPRReadinessChecks>;
+  ready: boolean;
+}) {
+  return (
+    <div
+      className={`mt-2 rounded-md border px-3 py-2 text-[11px] ${
+        ready
+          ? "border-success-border bg-success-muted text-success-foreground"
+          : "border-warning-border bg-warning-muted text-warning-foreground"
+      }`}
+      data-testid="pr-merge-readiness-checklist"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-[10px] font-medium uppercase tracking-wider">
+          Merge readiness
+        </div>
+        <div className="rounded-md border border-current/40 px-1.5 py-0 text-[10px] uppercase tracking-wider">
+          {ready ? "ready" : "not ready"}
+        </div>
+      </div>
+      <div className="mt-2 grid gap-1 sm:grid-cols-2">
+        {checks.map((check) => (
+          <div key={check.key} className="flex min-w-0 items-start gap-1.5" data-testid="pr-readiness-check">
+            {check.passed ? (
+              <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" aria-hidden="true" />
+            ) : (
+              <CircleDashed className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            )}
+            <span className="min-w-0">
+              <span className="block text-[11px] font-medium text-foreground">{check.label}</span>
+              <span className="block truncate text-[10px] opacity-80" title={check.detail}>
+                {check.detail}
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function AgentIndicator({ pr }: { pr: PRSummary }) {
   const isProcessing = pr.status === "processing";
 
@@ -472,7 +495,7 @@ const PRRow = memo(function PRRow({
               {pr.repo}
             </a>
             <span>{formatGitHubUsername(pr.author)}</span>
-            <span>{formatStatusLabel(pr.status, pr.prStage)}</span>
+            <span>{formatPRWorkState(pr.status, pr.prStage)}</span>
             <QueueStatusBadge status={queueStatus} />
             {!watchEnabled && <WatchPausedIndicator />}
             <span>{pr.accepted + pr.rejected + pr.flagged} triaged</span>
@@ -896,12 +919,14 @@ function RightPanel({
   queueStatusById,
   isCollapsed,
   onToggleCollapsed,
+  idleReason,
 }: {
   prId: string | null;
   activities: ActivitySnapshot;
   queueStatusById: Map<string, QueueStatusView>;
   isCollapsed: boolean;
   onToggleCollapsed: () => void;
+  idleReason?: string | null;
 }) {
   if (isCollapsed) {
     return (
@@ -940,7 +965,7 @@ function RightPanel({
           <span className="sr-only">Collapse activity</span>
         </button>
       </div>
-      <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} />
+      <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} idleReason={idleReason} />
       <div className="flex-1 overflow-hidden">
         <LogPanel prId={prId} />
       </div>
@@ -1249,6 +1274,24 @@ export default function Dashboard() {
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
   const activeErrorCount = activities.failed.length + activities.warnings.length;
+  const eligiblePRCount = prs.filter((pr) =>
+    pr.watchEnabled
+    && pr.status !== "processing"
+    && pr.status !== "archived"
+    && !isPRSummaryReadyToMerge(pr)
+  ).length;
+  const activityIdleReason = getActivityIdleReason({
+    activities,
+    drainMode: globalDrainMode,
+    drainReason: runtimeState?.drainReason ?? null,
+    githubRateLimited: isGitHubThrottled,
+    githubRateLimitResetAt: githubRateLimit?.resetAt ?? null,
+    autoEnabled: config?.autoPrs !== false,
+    trackedCount: prs.length,
+    eligibleCount: eligiblePRCount,
+    trackedLabel: "PR",
+  });
+  const selectedPRReadinessChecks = selectedPR ? buildPRReadinessChecks(selectedPR) : [];
 
   const applyMutation = useMutation({
     mutationFn: async (id: string) => {
@@ -1259,9 +1302,10 @@ export default function Dashboard() {
       queryClient.invalidateQueries({ queryKey: ["/api/prs"] });
       queryClient.invalidateQueries({ queryKey: ["/api/activities"] });
       queryClient.invalidateQueries({ queryKey: ["/api/logs"] });
+      toast({ description: "Queued PR work safely." });
     },
     onError: (error) => {
-      showMutationError("Could not run babysitter", error);
+      showMutationError("Could not queue PR work", error);
     },
   });
 
@@ -1344,6 +1388,13 @@ export default function Dashboard() {
       showMutationError("Could not clear issue failure", error);
     },
   });
+  const selectedPRWorkButtonLabel = (() => {
+    if (globalDrainMode) return DRAIN_PAUSED_LABEL;
+    if (applyMutation.isPending) return "Queuing safely";
+    if (selectedPRQueueStatus?.label === "running" || selectedPR?.status === "processing") return "Running";
+    if (selectedPRQueueStatus) return "Queued safely";
+    return "Queue work";
+  })();
 
   return (
     <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
@@ -1407,6 +1458,7 @@ export default function Dashboard() {
               globalDrainMode={globalDrainMode}
               queueStatusById={queueStatusById}
               pollIntervalMs={ACTIVITY_POLL_INTERVAL_MS}
+              idleReason={activityIdleReason}
             />
           </>
         )}
@@ -1426,7 +1478,7 @@ export default function Dashboard() {
       <DashboardDrainBanner runtimeState={runtimeState} />
 
       <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
-        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[32rem] xl:w-[34rem] lg:border-b-0 lg:border-r">
+        <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[28rem] xl:w-[30rem] lg:border-b-0 lg:border-r">
           <div className="sticky top-0 z-10 flex shrink-0 border-b border-border bg-background">
             <button
               type="button"
@@ -1562,7 +1614,7 @@ export default function Dashboard() {
             <>
               {(() => {
                 const metaItems: MetaItem[] = [
-                  { key: "status", content: <span>status: <span className="text-foreground">{formatStatusLabel(selectedPR.status, selectedPR.prStage)}</span></span> },
+                  { key: "status", content: <span>work: <span className="text-foreground">{formatPRWorkState(selectedPR.status, selectedPR.prStage)}</span></span> },
                   { key: "author", content: <span>author: <span className="text-foreground/80">{formatGitHubUsername(selectedPR.author)}</span></span> },
                   { key: "items", content: <span><span className="font-mono text-foreground">{selectedPR.feedbackItems.length}</span> items</span> },
                 ];
@@ -1601,7 +1653,7 @@ export default function Dashboard() {
                   <>
                     <AgentIndicator pr={selectedPR} />
                     {!selectedPRWatchEnabled && <WatchPausedIndicator />}
-                    <StatusChip tone={prStatusTone(selectedPR)} pulsing={selectedPR.status === "processing"} label={formatStatusLabel(selectedPR.status, selectedPR.prStage)} />
+                    <StatusChip tone={prStatusTone(selectedPR)} pulsing={selectedPR.status === "processing"} label={formatPRWorkState(selectedPR.status, selectedPR.prStage)} />
                   </>
                 )}
                 externalLink={{ href: selectedPR.url, label: `${selectedPR.repo}#${selectedPR.number}` }}
@@ -1645,21 +1697,28 @@ export default function Dashboard() {
                     <button
                       type="button"
                       onClick={() => applyMutation.mutate(selectedPR.id)}
-                      disabled={applyMutation.isPending || selectedPR.status === "processing" || globalDrainMode || isGitHubThrottled}
+                      disabled={applyMutation.isPending || selectedPR.status === "processing" || Boolean(selectedPRQueueStatus) || globalDrainMode || isGitHubThrottled}
                       title={
                         globalDrainMode
                           ? DRAIN_PAUSED_TITLE
                           : isGitHubThrottled
                             ? throttledTitle
-                            : "Run babysitter now"
+                            : "Queue PR work safely"
                       }
                       data-testid="button-apply"
                       className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
-                      {applyMutation.isPending || selectedPR.status === "processing" ? (
-                        <><Loader2 className="h-3.5 w-3.5 animate-spin" />{selectedPR.status === "processing" ? "Running" : "Queuing"}</>
+                      {applyMutation.isPending || selectedPR.status === "processing" || selectedPRQueueStatus ? (
+                        <>
+                          {(applyMutation.isPending || selectedPR.status === "processing" || selectedPRQueueStatus?.label === "running") ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <CircleDashed className="h-3.5 w-3.5" />
+                          )}
+                          {selectedPRWorkButtonLabel}
+                        </>
                       ) : (
-                        <><PlayCircle className="h-3.5 w-3.5" />{globalDrainMode ? DRAIN_PAUSED_LABEL : "Run now"}</>
+                        <><PlayCircle className="h-3.5 w-3.5" />{selectedPRWorkButtonLabel}</>
                       )}
                     </button>
                   </>
@@ -1667,11 +1726,15 @@ export default function Dashboard() {
                 banner={(
                   <>
                     <CurrentRunStatusStrip run={selectedPR.currentRun} testId="selected-pr-current-run" />
+                    <MergeReadinessChecklist
+                      checks={selectedPRReadinessChecks}
+                      ready={isPRDetailReadyToMerge(selectedPR)}
+                    />
                     {isPRDetailReadyToMerge(selectedPR) && (
                       <ReadyToMergeIndicator
                         href={selectedPR.url}
                         testId="detail-ready-to-merge"
-                        label="All comments resolved — ready to merge"
+                        label="GitHub ready to merge"
                         hint="Open PR on GitHub →"
                         className="mt-2 gap-2 px-3 py-1.5 text-[12px] tracking-wider"
                         dotClassName="h-2 w-2"
@@ -1736,6 +1799,7 @@ export default function Dashboard() {
           queueStatusById={queueStatusById}
           isCollapsed={isActivityPanelCollapsed}
           onToggleCollapsed={() => setIsActivityPanelCollapsed((current) => !current)}
+          idleReason={activityIdleReason}
         />
       </div>
       <div className="fixed bottom-4 right-4 z-50">

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -925,7 +925,7 @@ export default function Settings() {
                             testIdPrefix={`tracked-repo-pr-monitor-${repo.repo.replace("/", "-")}`}
                           />
                           <div className="mt-1 text-[10px] text-muted-foreground">
-                            Manual still syncs PR status; skips auto babysit.
+                            Manual still syncs PR status; skips automatic PR work.
                           </div>
                         </div>
                         <div>
@@ -1202,7 +1202,7 @@ export default function Settings() {
                 <div>
                   <div className="text-sm">Fallback to next coding agent</div>
                   <div className="text-[11px] text-muted-foreground">
-                    If the configured agent cannot start or authenticate, retry the babysitter run with the other local agent.
+                    If the configured agent cannot start or authenticate, retry the automation run with the other local agent.
                   </div>
                 </div>
                 <input
@@ -1301,8 +1301,8 @@ export default function Settings() {
                 disabled={updateConfigMutation.isPending}
               />
               <SettingRow
-                label="Max concurrent babysit runs"
-                description="How many PRs the watcher babysits at once before queueing the rest"
+                label="Max concurrent PR work runs"
+                description="How many PRs can run at once before queueing the rest"
                 value={config?.maxConcurrentBabysitRuns ?? 3}
                 onChange={(v) => updateConfigMutation.mutate({ maxConcurrentBabysitRuns: v })}
                 defaultValue={DEFAULT_SETTING_VALUES.maxConcurrentBabysitRuns}
@@ -1689,7 +1689,7 @@ export default function Settings() {
                 <div>
                   <div className="text-sm">GitHub progress replies</div>
                   <div className="text-[11px] text-muted-foreground">
-                    Post public Accepted/running/completed status replies while the babysitter works on review comments.
+                    Post public Accepted/In progress/Verifying status replies while automation works on review comments.
                   </div>
                 </div>
                 <input

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -103,7 +103,7 @@ test("runtime queueBabysit enqueues a babysit job using the configured agent", a
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0]?.targetId, pr.id);
   assert.equal(jobs[0]?.payload.preferredAgent, "claude");
-  assert.equal(jobs[0]?.payload.activityLabel, "Babysitting PR #42");
+  assert.equal(jobs[0]?.payload.activityLabel, "Working PR #42");
   assert.equal(jobs[0]?.payload.activityDetail, "acme/widgets - feat: add widget");
   assert.equal(jobs[0]?.payload.activityTargetUrl, pr.url);
 });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -208,7 +208,7 @@ function fallbackJobLabel(job: BackgroundJob): string {
     case "sync_watched_repos":
       return "Sync watched repositories";
     case "babysit_pr":
-      return "Babysitting PR";
+      return "Working PR";
     case "process_release_run":
       return "Processing release";
     case "answer_pr_question":
@@ -234,6 +234,14 @@ type ActivityDescriptionContext = {
   socialChangelogsById: Map<string, SocialChangelog>;
   deploymentHealingSessionsByTarget: Map<string, DeploymentHealingSession>;
 };
+
+function normalizeActivityDescription(description: ActivityDescription): ActivityDescription {
+  return {
+    ...description,
+    label: description.label.replace(/^Babysitting PR\b/, "Working PR"),
+    detail: description.detail?.replace("Refilling babysitter queue", "Refilling PR work queue") ?? null,
+  };
+}
 
 function readJobStringPayload(job: BackgroundJob, key: string): string | null {
   const value = job.payload[key];
@@ -570,7 +578,7 @@ function formatRunPhaseLabel(phase: string | null | undefined): string {
   const normalized = phase.toLowerCase();
   if (normalized.includes("sync")) return "Syncing GitHub";
   if (normalized.includes("prompt")) return "Preparing work";
-  if (normalized.includes("agent-running") || normalized.includes("working")) return "Agent running";
+  if (normalized.includes("agent-running") || normalized.includes("working")) return "Automation running";
   if (normalized.includes("verify") || normalized.includes("ci")) return "Verifying";
   if (normalized.includes("opening_pr")) return "Opening PR";
   if (normalized.includes("completed") || normalized.includes("done")) return "Run finished";
@@ -748,7 +756,7 @@ function buildCliMissingFixSteps(agentLabel: AgentLabel, command: "claude" | "co
     "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
     `Verify with \`command -v ${command}\` and \`$SHELL -lc "command -v ${command}"\`.`,
     "Restart patchdeck after installing.",
-    "Rerun the babysitter for this PR.",
+    "Queue PR work again.",
   ];
 }
 
@@ -757,13 +765,13 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
     auth: [
       "Run `claude auth login` on this machine.",
       "Restart patchdeck if it was launched before you refreshed credentials.",
-      "Rerun the babysitter for this PR.",
+      "Queue PR work again.",
     ],
     cli_missing: buildCliMissingFixSteps("Claude", "claude"),
     unknown_agent: [
       "Open Settings and choose a supported coding agent.",
       "Restart patchdeck if the agent setting was changed outside the app.",
-      "Rerun the babysitter for this PR.",
+      "Queue PR work again.",
     ],
   },
   Codex: {
@@ -771,13 +779,13 @@ const AGENT_FIX_STEPS: Record<AgentLabel, Record<AgentUnavailabilityKind, string
       "Run `codex login` on this machine.",
       "Check ownership and permissions for ~/.codex, especially ~/.codex/sessions, so patchdeck can access Codex session files.",
       "Restart patchdeck if it was launched before you refreshed credentials.",
-      "Rerun the babysitter for this PR.",
+      "Queue PR work again.",
     ],
     cli_missing: buildCliMissingFixSteps("Codex", "codex"),
     unknown_agent: [
       "Open Settings and choose a supported coding agent.",
       "Restart patchdeck if the agent setting was changed outside the app.",
-      "Rerun the babysitter for this PR.",
+      "Queue PR work again.",
     ],
   },
 };
@@ -1011,7 +1019,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     (error) => {
       log.warn(
         { err: error instanceof Error ? error.message : String(error) },
-        "Repository babysitter watcher failed",
+        "Repository PR watcher failed",
       );
     },
   );
@@ -1805,11 +1813,12 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
   const describeActivityJob = (job: BackgroundJob, context: ActivityDescriptionContext): ActivityDescription => {
     const payloadDescription = readActivityPayload(job.payload);
-    if (payloadDescription) {
-      return payloadDescription;
-    }
 
     if (job.kind === "sync_watched_repos") {
+      if (payloadDescription) {
+        return normalizeActivityDescription(payloadDescription);
+      }
+
       return {
         label: "Sync watched repositories",
         detail: null,
@@ -1821,11 +1830,15 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const pr = context.prsById.get(job.targetId);
       if (pr) {
         return {
-          label: `Babysitting PR #${pr.number}`,
+          label: `Working PR #${pr.number}`,
           detail: `${pr.repo} - ${pr.title}`,
           targetUrl: pr.url,
         };
       }
+    }
+
+    if (payloadDescription) {
+      return normalizeActivityDescription(payloadDescription);
     }
 
     if (job.kind === "answer_pr_question") {
@@ -1932,7 +1945,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       id: job.id,
       severity: "warning",
       title: `${failure.agentLabel} ${titleSuffix}`,
-      message: `Babysitter could not run ${failure.agentLabel} for PR #${pr.number} in ${pr.repo} because ${reason}.`,
+      message: `Automation could not run ${failure.agentLabel} for PR #${pr.number} in ${pr.repo} because ${reason}.`,
       fixSteps: failure.fixSteps,
       targetId: job.targetId,
       targetUrl: pr.url,
@@ -1978,7 +1991,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       {
         preferredAgent,
         ...buildActivityPayload({
-          label: `Babysitting PR #${pr.number}`,
+          label: `Working PR #${pr.number}`,
           detail: `${pr.repo} - ${pr.title}`,
           targetUrl: pr.url,
         }),
@@ -2406,7 +2419,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       });
 
       await storage.addLog(pr.id, "info", `Registered PR #${parsed.number} from ${repoSlug}`);
-      await storage.addLog(pr.id, "info", `Repository ${repoSlug} added to auto-babysit watch list`);
+      await storage.addLog(pr.id, "info", `Repository ${repoSlug} added to automatic PR work watch list`);
 
       if (!config.watchedRepos.includes(repoSlug)) {
         await storage.updateConfig({
@@ -2528,15 +2541,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (runtime.drainMode) {
         await rejectManualRunDuringDrain(runtime, {
           pr,
-          logMessageBase: "Manual babysitter run blocked because drain mode is enabled",
+          logMessageBase: "Manual PR work blocked because drain mode is enabled",
         });
       }
 
       const config = await storage.getConfig();
       const repoSettings = await storage.getRepoSettings(pr.repo);
       const selectedAgent = resolveRepoCodingAgent(config, repoSettings);
-      await storage.updatePR(pr.id, { status: "processing" });
-      await storage.addLog(pr.id, "info", `Launching autonomous babysitter run using ${selectedAgent}`);
+      await storage.addLog(pr.id, "info", `Queued manual PR work using ${selectedAgent}`);
       await queueBabysitForRepo(pr, config);
 
       const updated = await storage.getPR(pr.id);
@@ -2550,14 +2562,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (runtime.drainMode) {
         await rejectManualRunDuringDrain(runtime, {
           pr,
-          logMessageBase: "Manual babysitter run blocked because drain mode is enabled",
+          logMessageBase: "Manual PR work blocked because drain mode is enabled",
         });
       }
 
       const config = await storage.getConfig();
       const repoSettings = await storage.getRepoSettings(pr.repo);
       const selectedAgent = resolveRepoCodingAgent(config, repoSettings);
-      await storage.addLog(pr.id, "info", `Manual babysitter trigger using ${selectedAgent}`);
+      await storage.addLog(pr.id, "info", `Queued manual PR work using ${selectedAgent}`);
       await queueBabysitForRepo(pr, config);
 
       const updated = await storage.getPR(pr.id);

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -880,7 +880,7 @@ test("syncAndBabysitTrackedRepos enqueues babysit_pr jobs when a background sche
   });
   assert.equal(jobs.length, 1);
   assert.equal(jobs[0].payload.preferredAgent, "claude");
-  assert.equal(jobs[0].payload.activityLabel, "Babysitting PR #42");
+  assert.equal(jobs[0].payload.activityLabel, "Working PR #42");
   assert.equal(jobs[0].payload.activityDetail, "octo/example - Example PR");
   assert.equal(jobs[0].payload.activityTargetUrl, pr.url);
 });
@@ -1811,7 +1811,7 @@ test("syncAndBabysitTrackedRepos skips automatic babysits when pr watch is pause
   const logs = await storage.getLogs(pr.id);
   assert.equal(updated?.watchEnabled, false);
   assert.deepEqual(babysitCalls, []);
-  assert.ok(!logs.some((log) => log.message.includes("Watcher queued autonomous babysitter run")));
+  assert.ok(!logs.some((log) => log.message.includes("Watcher queued automatic PR work")));
 });
 
 test("syncAndBabysitTrackedRepos caps feedback sync attempts per tick while automation is paused", async () => {
@@ -2048,7 +2048,7 @@ test("syncAndBabysitTrackedRepos resumes automatic babysits when pr watch is re-
 
   const logs = await storage.getLogs(pr.id);
   assert.deepEqual(babysitCalls, [pr.id]);
-  assert.ok(logs.some((log) => log.message.includes("Watcher queued autonomous babysitter run")));
+  assert.ok(logs.some((log) => log.message.includes("Watcher queued automatic PR work")));
 });
 
 test("syncAndBabysitTrackedRepos pauses automation when the selected agent is unhealthy", async () => {
@@ -2632,7 +2632,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   const updated = await storage.getPR(pr.id);
   const logs = await storage.getLogs(pr.id);
   const runs = await storage.listAgentRuns();
-  const fixRunLog = logs.find((log) => log.phase === "run" && log.message.includes("Babysitter preparing fix run"));
+  const fixRunLog = logs.find((log) => log.phase === "run" && log.message.includes("Preparing PR work"));
 
   assert.equal(updated?.status, "watching");
   assert.equal(updated?.accepted, 1);
@@ -2644,7 +2644,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.ok(fixRunLog);
   assert.equal(
     fixRunLog.message,
-    "Babysitter preparing fix run with 1 comment task(s), 0 status task(s), 0 documentation task(s), and 1 GitHub follow-up task(s) using codex",
+    "Preparing PR work with 1 comment task(s), 0 status task(s), 0 documentation task(s), and 1 GitHub follow-up task(s) using codex",
   );
   assert.equal(fixRunLog.metadata?.followUpTasks, 1);
   assert.equal(fixRunLog.metadata?.docsTasks, 0);
@@ -2666,7 +2666,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.ok(logs.some((log) => log.phase === "worktree" && log.message.includes(`Preparing worktree in ${worktreeRoot}`)));
   assert.ok(logs.some((log) => log.phase === "github.followup" && log.message.includes("GitHub follow-up complete for gh-review-comment-1")));
   assert.ok(logs.some((log) => log.phase === "verify.github" && log.message.includes("GitHub audit trail verified")));
-  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("Babysitter run complete")));
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("PR work run complete")));
   assert.doesNotMatch(receivedPrompt, /commit and push/i);
   assert.doesNotMatch(receivedPrompt, /git push/i);
   assert.match(receivedPrompt, /If dependencies are missing, install them/i);
@@ -3422,13 +3422,13 @@ test("babysitPR posts progress replies when GitHub progress replies are enabled"
 
     await babysitter.babysitPR(pr.id, "codex");
 
-    const expectedAcceptedLine = "\u23f3 **Accepted** \u2014 queued for a code change.";
+    const expectedAcceptedLine = "**Accepted** \u2014 queued for a code change.";
     const expectedAcceptedStatus = `${expectedAcceptedLine}\n\n${APP_COMMENT_FOOTER}`;
     const expectedFinalStatusBody = [
       expectedAcceptedLine,
-      "\ud83e\uddf0 **In progress** \u2014 applying the accepted fix.",
-      "\u2705 **Verifying** \u2014 checking the applied changes.",
-      "\ud83c\udf89 **Resolved** \u2014 addressed in commit `def456`.",
+      "**In progress** \u2014 applying the accepted fix.",
+      "**Verifying** \u2014 checking the applied changes.",
+      "**Resolved** \u2014 addressed in commit `def456`.",
       "",
       APP_COMMENT_FOOTER,
     ].join("\n");
@@ -3751,7 +3751,7 @@ test("babysitPR keeps failed GitHub progress replies concise", async () => {
     const body = statusReplyRefs.get(existingItem.id)?.body ?? "";
     assert.match(
       body,
-      /\u274c \*\*Needs attention\*\* \u2014 automatic fix failed: TypeScript check failed/,
+      /\*\*Needs attention\*\* \u2014 automatic fix failed: TypeScript check failed/,
     );
   } finally {
     delete process.env.CODEFACTORY_HOME;
@@ -3930,7 +3930,7 @@ test("babysitPR treats footerless status replies as non-actionable", async () =>
   await storage.updateConfig({ autoUpdateDocs: false });
   const statusReply = makeFeedbackItem({
     author: "octocat",
-    body: "\ud83e\uddf0 **In progress** \u2014 applying the accepted fix.",
+    body: "**In progress** \u2014 applying the accepted fix.",
     bodyHtml: "<p><strong>In progress</strong> - applying the accepted fix.</p>",
     decision: null,
     status: "pending",
@@ -6600,7 +6600,7 @@ test("babysitPR pushes a clean base merge when GitHub mergeability is stale", as
   assert.equal(updated?.status, "watching");
   assert.deepEqual(pushedCommands, [["push", "origin", "HEAD:feature/verbose"]]);
   assert.ok(logs.some((log) => log.phase === "conflict" && log.message.includes("Merge completed without conflicts")));
-  assert.ok(logs.some((log) => log.phase === "verify.git.push" && log.message.includes("Pushed babysitter commit")));
+  assert.ok(logs.some((log) => log.phase === "verify.git.push" && log.message.includes("Pushed automation commit")));
 
   delete process.env.CODEFACTORY_HOME;
 });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -72,8 +72,8 @@ import {
   shouldResolveReviewConversation,
 } from "./feedbackLifecycle";
 
-const DEFAULT_GIT_USER_NAME = "PR Babysitter";
-const DEFAULT_GIT_USER_EMAIL = "pr-babysitter@local";
+const DEFAULT_GIT_USER_NAME = "PatchDeck";
+const DEFAULT_GIT_USER_EMAIL = "patchdeck@local";
 const AGENT_HEALTH_CACHE_TTL_MS = 60_000;
 const DEPENDENCY_PREFLIGHT_FAILURE_PREFIX = "Dependency preflight failed:";
 const DEPENDENCY_PREFLIGHT_FAILURE_KIND = "dependency_preflight";
@@ -224,17 +224,17 @@ const defaultBabysitterRuntime: BabysitterRuntime = {
 };
 
 const STATUS_MESSAGES = {
-  accepted: "\u23f3 **Accepted** — queued for a code change.",
-  agentRunning: (_agent: CodingAgent) => "\ud83e\uddf0 **In progress** — applying the accepted fix.",
+  accepted: "**Accepted** — queued for a code change.",
+  agentRunning: (_agent: CodingAgent) => "**In progress** — applying the accepted fix.",
   agentFailed: (_agent: CodingAgent, reason?: string) => reason
-    ? `\u274c **Needs attention** — automatic fix failed: ${reason}`
-    : "\u274c **Needs attention** — automatic fix failed.",
-  agentCompleted: "\u2705 **Verifying** — checking the applied changes.",
+    ? `**Needs attention** — automatic fix failed: ${reason}`
+    : "**Needs attention** — automatic fix failed.",
+  agentCompleted: "**Verifying** — checking the applied changes.",
   resolved: (headSha: string) => {
     const shortSha = headSha.trim().slice(0, 7);
     return shortSha
-      ? `\ud83c\udf89 **Resolved** — addressed in commit \`${shortSha}\`.`
-      : "\ud83c\udf89 **Resolved** — addressed in the latest update.";
+      ? `**Resolved** — addressed in commit \`${shortSha}\`.`
+      : "**Resolved** — addressed in the latest update.";
   },
 } as const;
 
@@ -778,7 +778,7 @@ function buildTerminalConflictRepairReason(params: {
     : params.baseRef || "unknown base";
   const files = params.conflictFiles.length > 0 ? params.conflictFiles.join(", ") : "the same conflict paths";
   const suffix = params.lastReason ? ` Last failure: ${params.lastReason}` : "";
-  return `Merge conflict repair failed twice for ${files} at head ${headLabel} against base ${baseLabel}; stopping automatic babysitter runs until the PR head or base changes.${suffix}`;
+  return `Merge conflict repair failed twice for ${files} at head ${headLabel} against base ${baseLabel}; stopping automatic PR work until the PR head or base changes.${suffix}`;
 }
 
 function sameStrings(left: string[], right: string[]): boolean {
@@ -1446,7 +1446,7 @@ export class PRBabysitter {
       {
         ...buildActivityPayload({
           label: "Backfilling deferred PR work",
-          detail: "Refilling babysitter queue after the active batch drains",
+          detail: "Refilling PR work queue after the active batch drains",
           targetUrl: null,
         }),
         deferredBabysitBackfill: true,
@@ -2369,7 +2369,7 @@ export class PRBabysitter {
               status: "error",
               lastChecked,
             });
-            await this.storage.addLog(local.id, "warn", "Dependency preflight previously failed for this PR head; skipping automatic babysitter run until the head changes", {
+            await this.storage.addLog(local.id, "warn", "Dependency preflight previously failed for this PR head; skipping automatic PR work until the head changes", {
               phase: "watcher",
               metadata: {
                 repo: repoSlug,
@@ -2459,7 +2459,7 @@ export class PRBabysitter {
           }
           babysitEnqueues += 1;
           inFlightBabysitJobs += 1;
-          await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
+          await this.storage.addLog(local.id, "info", "Watcher queued automatic PR work", {
             phase: "watcher",
             metadata: { repo: repoSlug },
           });
@@ -2470,14 +2470,14 @@ export class PRBabysitter {
             {
               preferredAgent: currentConfig.codingAgent as CodingAgent,
               ...buildActivityPayload({
-                label: `Babysitting PR #${local.number}`,
+                label: `Working PR #${local.number}`,
                 detail: `${local.repo} - ${local.title}`,
                 targetUrl: local.url,
               }),
             },
           );
         } else {
-          await this.storage.addLog(local.id, "info", "Watcher queued autonomous babysitter run", {
+          await this.storage.addLog(local.id, "info", "Watcher queued automatic PR work", {
             phase: "watcher",
             metadata: { repo: repoSlug },
           });
@@ -2497,7 +2497,7 @@ export class PRBabysitter {
                 ? "concurrency cap"
                 : "per-sweep cap",
           },
-          "Deferred babysit runs to a later sweep to pace GitHub usage",
+          "Deferred PR work to a later sweep to pace GitHub usage",
         );
       }
     }
@@ -2594,7 +2594,7 @@ export class PRBabysitter {
     if (runtimeState.drainMode && !options?.allowDuringDrain) {
       const pr = await this.storage.getPR(prId);
       if (pr) {
-        await this.storage.addLog(pr.id, "warn", "Babysitter run skipped because drain mode is enabled", {
+        await this.storage.addLog(pr.id, "warn", "PR work skipped because drain mode is enabled", {
           phase: "run",
         });
       }
@@ -2609,7 +2609,7 @@ export class PRBabysitter {
         const activeAgeMs = Number.isNaN(activeStartedAtMs)
           ? null
           : Math.max(0, this.now().getTime() - activeStartedAtMs);
-        await this.storage.addLog(pr.id, "warn", "Babysitter run skipped because another run is already in progress", {
+        await this.storage.addLog(pr.id, "warn", "PR work skipped because another run is already in progress", {
           phase: "run",
           metadata: {
             reason: "in_progress",
@@ -3056,7 +3056,7 @@ export class PRBabysitter {
         prStage: "applying",
         lastChecked: new Date().toISOString(),
       });
-      await queueLog(prId, "info", `Babysitter run started using preferred agent ${preferredAgent}${recoveryMode ? " (recovery)" : ""}`, {
+      await queueLog(prId, "info", `PR work started using preferred agent ${preferredAgent}${recoveryMode ? " (recovery)" : ""}`, {
         phase: "run",
         metadata: { preferredAgent, recoveryMode },
       });
@@ -3731,7 +3731,7 @@ export class PRBabysitter {
       }
 
       if (!needsWorktree && !shouldRunCIHealingAgent && followUpTasks.length === 0 && !hasConflicts && failingCheckSnapshots.length === 0) {
-        await queueLog(pr.id, "info", `Babysitter checked PR #${pr.number}; no necessary fixes identified`, {
+        await queueLog(pr.id, "info", `Checked PR #${pr.number}; no necessary fixes identified`, {
           phase: "run",
         });
         await this.storage.updatePR(pr.id, {
@@ -3767,7 +3767,7 @@ export class PRBabysitter {
         await queueLog(
           pr.id,
           "info",
-          `Babysitter preparing fix run with ${effectiveCommentTasks.length} comment task(s), ${statusTasks.length} status task(s), ${hasDocsTask ? 1 : 0} documentation task(s), and ${followUpTasks.length} GitHub follow-up task(s)${docsAssessmentNeeded ? ", with documentation assessment" : ""}${hasConflicts ? ", plus merge conflict resolution" : ""}${shouldRunForcedReplay ? ", with forced prompt replay" : ""} using ${agent}`,
+          `Preparing PR work with ${effectiveCommentTasks.length} comment task(s), ${statusTasks.length} status task(s), ${hasDocsTask ? 1 : 0} documentation task(s), and ${followUpTasks.length} GitHub follow-up task(s)${docsAssessmentNeeded ? ", with documentation assessment" : ""}${hasConflicts ? ", plus merge conflict resolution" : ""}${shouldRunForcedReplay ? ", with forced prompt replay" : ""} using ${agent}`,
           {
             phase: "run",
             metadata: {
@@ -4225,7 +4225,7 @@ export class PRBabysitter {
                 context: "merge conflict resolution",
               });
 
-              await queueLog(pr.id, "info", "Merge conflicts resolved and committed by babysitter", {
+              await queueLog(pr.id, "info", "Merge conflicts resolved and committed by PatchDeck", {
                 phase: "conflict",
               });
             } else {
@@ -4340,7 +4340,7 @@ export class PRBabysitter {
             phase: "verify.git.status",
             context: "agent run",
           });
-          await queueLog(pr.id, "info", "Worktree is clean after babysitter finalization", {
+          await queueLog(pr.id, "info", "Worktree is clean after PR work finalization", {
             phase: "verify.git.status",
           });
 
@@ -4393,7 +4393,7 @@ export class PRBabysitter {
               cwd: worktreePath,
               timeoutMs: 120000,
               phase: "verify.git.push",
-              successMessage: `Pushed babysitter commit to ${remoteName}/${pullSummary.headRef}`,
+              successMessage: `Pushed automation commit to ${remoteName}/${pullSummary.headRef}`,
             });
             if (pushResult.code !== 0) {
               throw new Error(formatGitFailure(`pushing ${remoteName}/${pullSummary.headRef}`, pushResult));
@@ -4405,7 +4405,7 @@ export class PRBabysitter {
               args: ["-C", repoCacheDir, "fetch", remoteName, pullSummary.headRef],
               timeoutMs: 120000,
               phase: "verify.git.fetch-head",
-              successMessage: `Fetched ${remoteName}/${pullSummary.headRef} after babysitter push`,
+              successMessage: `Fetched ${remoteName}/${pullSummary.headRef} after automation push`,
             });
             if (refreshedRemoteFetch.code !== 0) {
               throw new Error(formatGitFailure(`fetching ${remoteName}/${pullSummary.headRef} after push`, refreshedRemoteFetch));
@@ -4417,7 +4417,7 @@ export class PRBabysitter {
               args: ["-C", repoCacheDir, "rev-parse", "FETCH_HEAD"],
               timeoutMs: 5000,
               phase: "verify.git.remote-head",
-              successMessage: "Collected remote PR head SHA after babysitter push",
+              successMessage: "Collected remote PR head SHA after automation push",
             });
             if (refreshedRemoteHead.code !== 0) {
               throw new Error(formatGitFailure("reading remote PR head after push", refreshedRemoteHead));
@@ -4426,7 +4426,7 @@ export class PRBabysitter {
           }
 
           if (localCommitCreated && remoteHeadSha !== localHeadSha) {
-            throw new Error("Babysitter created a local commit but could not verify it on the PR head branch");
+            throw new Error("Automation created a local commit but could not verify it on the PR head branch");
           }
 
           branchMoved = remoteHeadSha !== pullSummary.headSha;
@@ -4509,7 +4509,7 @@ export class PRBabysitter {
         await queueLog(
           pr.id,
           "info",
-          `Babysitter found ${followUpTasks.length} accepted feedback item(s) awaiting GitHub follow-up`,
+          `Found ${followUpTasks.length} accepted feedback item(s) awaiting GitHub follow-up`,
           {
             phase: "run",
             metadata: {
@@ -4865,7 +4865,7 @@ export class PRBabysitter {
         status: "watching",
         lastChecked: new Date().toISOString(),
       });
-      await queueLog(pr.id, "info", "Babysitter run complete", {
+      await queueLog(pr.id, "info", "PR work run complete", {
         phase: "run",
         metadata: { remoteName: remoteNameForLogs, branchMoved },
       });
@@ -4889,7 +4889,7 @@ export class PRBabysitter {
         // agent/processing failure. GitHub errors that happen *after* the
         // app successfully pushed code are warnings, not failures.
         const logLevel = isNonCritical ? "warn" : "error";
-        const logPrefix = isNonCritical ? "Babysitter warning" : "Babysitter error";
+        const logPrefix = isNonCritical ? "PR work warning" : "PR work error";
 
         await queueLog(currentPr.id, logLevel, `${logPrefix}: ${message}`, {
           phase: "run",
@@ -4989,9 +4989,9 @@ export class PRBabysitter {
             : "run.failed",
         lastError: finalMessage,
       });
-      log.warn({ err: finalMessage, prId }, "Babysitter failure");
+      log.warn({ err: finalMessage, prId }, "PR automation failure");
       if (error instanceof Error && error.stack) {
-        log.debug({ stack: error.stack, prId }, "Babysitter failure stack");
+        log.debug({ stack: error.stack, prId }, "PR automation failure stack");
       }
       if (options?.rethrowOnFailure && !isDependencyPreflightFailureMessage(message)) {
         throw rethrowError;

--- a/server/issueWorkAgent.test.ts
+++ b/server/issueWorkAgent.test.ts
@@ -79,13 +79,13 @@ test("runIssueWorkRepair commits, pushes, and verifies the issue branch", async 
       if (key === "git @/tmp/worktree config --get user.name") {
         return { stdout: "", stderr: "", code: 1 };
       }
-      if (key === "git @/tmp/worktree config user.name PR Babysitter") {
+      if (key === "git @/tmp/worktree config user.name PatchDeck") {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === "git @/tmp/worktree config --get user.email") {
         return { stdout: "", stderr: "", code: 1 };
       }
-      if (key === "git @/tmp/worktree config user.email pr-babysitter@local") {
+      if (key === "git @/tmp/worktree config user.email patchdeck@local") {
         return { stdout: "", stderr: "", code: 0 };
       }
       if (key === "git -C /tmp/worktree status --porcelain") {

--- a/server/issueWorkAgent.ts
+++ b/server/issueWorkAgent.ts
@@ -5,8 +5,8 @@ import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 import type { IssueSubtask, IssueSubtaskStatus } from "@shared/schema";
 import path from "node:path";
 
-const DEFAULT_GIT_USER_NAME = "PR Babysitter";
-const DEFAULT_GIT_USER_EMAIL = "pr-babysitter@local";
+const DEFAULT_GIT_USER_NAME = "PatchDeck";
+const DEFAULT_GIT_USER_EMAIL = "patchdeck@local";
 
 export type IssueWorkPromptInput = {
   repo: string;

--- a/server/mcp.ts
+++ b/server/mcp.ts
@@ -108,7 +108,7 @@ const TOOLS: Tool[] = [
     name: "sync_repos",
     description:
       "Force an immediate sync cycle across all watched repositories. " +
-      "Fetches the latest PR feedback from GitHub and runs the babysitter logic.",
+      "Fetches the latest PR feedback from GitHub and runs PR automation.",
     inputSchema: { type: "object", properties: {}, required: [] },
   },
 
@@ -140,7 +140,7 @@ const TOOLS: Tool[] = [
     name: "add_pr",
     description:
       "Register a GitHub pull request with PatchDeck by URL. " +
-      "PatchDeck will start watching the PR and run the babysitter.",
+      "PatchDeck will start watching the PR and queue safe PR work.",
     inputSchema: {
       type: "object",
       properties: {
@@ -205,7 +205,7 @@ const TOOLS: Tool[] = [
   {
     name: "babysit_pr",
     description:
-      "Run a full babysit cycle on a PR: sync feedback → triage → apply fixes → report. " +
+      "Run a full PR work cycle: sync feedback, triage, apply fixes, and report. " +
       "This is the highest-level operation for a single PR.",
     inputSchema: {
       type: "object",

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -469,6 +469,31 @@ test("POST /api/prs/:id/babysit enqueues a durable babysit_pr job", async () => 
   }
 });
 
+test("POST /api/prs/:id/apply queues PR work without marking it active before lease", async () => {
+  const harness = await createHarness();
+  const pr = await seedPR(harness.storage);
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/prs/${pr.id}/apply`, {
+      method: "POST",
+    });
+
+    assert.equal(response.status, 200);
+
+    const updated = await harness.storage.getPR(pr.id);
+    assert.equal(updated?.status, "watching");
+
+    const jobs = await harness.storage.listBackgroundJobs({
+      kind: "babysit_pr",
+      status: "queued",
+    });
+    assert.equal(jobs.length, 1);
+    assert.equal(jobs[0].targetId, pr.id);
+  } finally {
+    await harness.close();
+  }
+});
+
 for (const endpoint of ["apply", "babysit"] as const) {
   test(`POST /api/prs/:id/${endpoint} reports drain reason and records blocked manual attempt`, async () => {
     const harness = await createHarness();
@@ -499,7 +524,7 @@ for (const endpoint of ["apply", "babysit"] as const) {
       assert.ok(logs.some((log) =>
         log.level === "warn"
         && log.phase === "run"
-        && log.message.includes("Manual babysitter run blocked because drain mode is enabled")
+        && log.message.includes("Manual PR work blocked because drain mode is enabled")
         && log.message.includes("codex health check timed out")
       ));
     } finally {
@@ -689,7 +714,7 @@ test("GET /api/activities lists failed, in-progress, and queued jobs", async () 
     assert.equal(body.inProgress[0]?.id, runningJob.id);
     assert.equal(body.inProgress[0]?.kind, "babysit_pr");
     assert.equal(body.inProgress[0]?.status, "in_progress");
-    assert.equal(body.inProgress[0]?.label, "Babysitting PR #77");
+    assert.equal(body.inProgress[0]?.label, "Working PR #77");
     assert.equal(body.inProgress[0]?.detail, "acme/widgets - fix activity menu");
     assert.equal(body.inProgress[0]?.targetId, pr.id);
     assert.equal(body.inProgress[0]?.targetUrl, pr.url);
@@ -752,7 +777,7 @@ test("GET /api/activities batches PR activity metadata", async () => {
     assert.deepEqual(
       body.queued.map((item) => [item.label, item.detail, item.targetUrl]),
       [
-        ["Babysitting PR #77", "acme/widgets - fix activity menu", firstPr.url],
+        ["Working PR #77", "acme/widgets - fix activity menu", firstPr.url],
         ["Answering question for PR #78", "acme/widgets - answer follow-up", secondPr.url],
       ],
     );
@@ -934,7 +959,7 @@ test("GET /api/activities warns when a babysitter job fails from agent authentic
     assert.deepEqual(body.warnings[0]?.fixSteps, [
       "Run `claude auth login` on this machine.",
       "Restart patchdeck if it was launched before you refreshed credentials.",
-      "Rerun the babysitter for this PR.",
+      "Queue PR work again.",
     ]);
     assert.equal(body.warnings[0]?.targetId, pr.id);
     assert.equal(body.warnings[0]?.targetUrl, pr.url);
@@ -991,7 +1016,7 @@ test("GET /api/activities warns when a babysitter job fails from Codex session p
       "Run `codex login` on this machine.",
       "Check ownership and permissions for ~/.codex, especially ~/.codex/sessions, so patchdeck can access Codex session files.",
       "Restart patchdeck if it was launched before you refreshed credentials.",
-      "Rerun the babysitter for this PR.",
+      "Queue PR work again.",
     ]);
   } finally {
     await harness.close();
@@ -1052,7 +1077,7 @@ for (const agent of [
         "For nvm installs, add the active Node bin directory to a login-shell startup file such as ~/.zprofile; for example: export PATH=\"$HOME/.nvm/versions/node/<version>/bin:$PATH\".",
         `Verify with \`command -v ${agent.preferredAgent}\` and \`$SHELL -lc "command -v ${agent.preferredAgent}"\`.`,
         "Restart patchdeck after installing.",
-        "Rerun the babysitter for this PR.",
+        "Queue PR work again.",
       ]);
     } finally {
       await harness.close();


### PR DESCRIPTION
## Summary
- Separates work-run state from merge readiness so completed runs no longer imply ready-to-merge.
- Adds merge-readiness checks, idle reasons, queue-safe button copy, and collapsible issue activity.
- Updates public/operator wording from babysitter-style labels to PR work/automation language, including stale activity payload display.

## Verification
- node --import tsx --test client/src/lib/activityDisplay.test.ts client/src/lib/activityIdle.test.ts client/src/lib/statusCopy.test.ts client/src/lib/activityQueue.test.ts client/src/lib/fullAppQaSurface.test.ts
- node --import tsx --test server/routes.test.ts server/appRuntime.test.ts server/babysitter.test.ts server/issueWorkAgent.test.ts
- npm run check
- git diff --check
- Playwright localhost check confirmed activity UI shows Working PR / Refilling PR work queue and no legacy Babysitting PR copy.