### PR TITLE
fix: align page design elements

### DIFF
--- a/client/src/components/ActivityMenu.tsx
+++ b/client/src/components/ActivityMenu.tsx
@@ -164,7 +164,7 @@ export function ActivityMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className="inline-flex items-center gap-1 border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        className="inline-flex min-h-8 items-center gap-1 border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background sm:min-h-0"
         aria-label="Open activity menu"
         data-testid="activity-menu-trigger"
       >
@@ -172,7 +172,7 @@ export function ActivityMenu({
         <span>activity</span>
         <span className="text-foreground">{totalCount}</span>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-80 p-0">
+      <DropdownMenuContent align="end" className="max-h-[calc(100dvh-6rem)] w-[calc(100vw-1rem)] max-w-sm overflow-y-auto p-0 sm:w-80">
         <div className="border-b border-border px-2 py-2">
           <div className="flex items-center justify-between gap-2">
             <div className="text-[12px] font-medium">Activities</div>

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -31,7 +31,7 @@ const SECONDARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; hre
 ];
 
 function navLinkClass(selected: boolean) {
-  return `rounded-md border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+  return `inline-flex min-h-8 items-center rounded-md border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background sm:min-h-0 ${
     selected
       ? "border-primary/40 bg-primary/10 text-primary"
       : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
@@ -386,7 +386,7 @@ export function AppHeader({
           </div>
         ) : null}
         {actions ? (
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 [&_button]:min-h-8 [&_select]:min-h-8 sm:[&_button]:min-h-0 sm:[&_select]:min-h-0">
             {actions}
           </div>
         ) : null}

--- a/client/src/components/detail/DetailHeader.tsx
+++ b/client/src/components/detail/DetailHeader.tsx
@@ -33,13 +33,13 @@ export function DetailHeader({
 }: DetailHeaderProps) {
   const titleClass = titleMultiline
     ? "line-clamp-2 break-words text-[15px] font-semibold leading-snug tracking-tight"
-    : "truncate text-[15px] font-semibold tracking-tight";
+    : "line-clamp-2 break-words text-[15px] font-semibold leading-snug tracking-tight sm:block sm:truncate";
   const accentClass = accentTone ? ` border-t-2 ${toneHeaderAccentClass(accentTone)}` : "";
   const failedBg = toneFailedBgClass(failed);
 
   return (
     <div className={`shrink-0 border-b border-border px-4 py-3${accentClass}${failedBg ? ` ${failedBg}` : ""}`}>
-      <div className="mb-1 flex items-start justify-between gap-4">
+      <div className="mb-1 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             {statusDot}
@@ -52,10 +52,10 @@ export function DetailHeader({
                 href={externalLink.href}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex shrink-0 items-center gap-1 font-mono text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                className="inline-flex max-w-full shrink-0 items-center gap-1 font-mono text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
                 <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                {externalLink.label}
+                <span className="min-w-0 truncate">{externalLink.label}</span>
               </a>
             )}
           </div>
@@ -64,8 +64,10 @@ export function DetailHeader({
           {stageBar && <div className="mt-2">{stageBar}</div>}
         </div>
         {actions && (
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-            {actions}
+          <div className="-mx-1 flex min-w-0 overflow-x-auto px-1 pb-1 sm:mx-0 sm:shrink-0 sm:flex-wrap sm:justify-end sm:overflow-visible sm:px-0 sm:pb-0 [&>*]:shrink-0">
+            <div className="flex min-w-max items-center gap-2 sm:min-w-0 sm:flex-wrap sm:justify-end [&_button]:min-h-8 sm:[&_button]:min-h-0">
+              {actions}
+            </div>
           </div>
         )}
       </div>

--- a/client/src/components/detail/MetaBreadcrumb.tsx
+++ b/client/src/components/detail/MetaBreadcrumb.tsx
@@ -11,8 +11,10 @@ export function MetaBreadcrumb({ items }: { items: MetaItem[] }) {
     <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
       {items.map((item, idx) => (
         <Fragment key={item.key}>
-          {idx > 0 && <span className="text-border" aria-hidden="true">·</span>}
-          {item.content}
+          {idx > 0 && <span className="hidden text-border sm:inline" aria-hidden="true">·</span>}
+          <span className="inline-flex min-w-0 max-w-full items-center whitespace-nowrap">
+            {item.content}
+          </span>
         </Fragment>
       ))}
     </div>

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -257,6 +257,7 @@ function assertHasRoutes(
 
 test("full app QA route matrix is wired through the hash router", async () => {
   const { sourceFile } = await parseProjectFile("client/src/App.tsx");
+  const { sourceFile: notFoundSourceFile } = await parseProjectFile("client/src/pages/not-found.tsx");
 
   assertHasExpression(sourceFile, "hash router", /\buseHashLocation\b/);
   assertHasRoutes(sourceFile, [
@@ -267,6 +268,8 @@ test("full app QA route matrix is wired through the hash router", async () => {
     { label: "logs", path: "/logs", component: "Logs" },
     { label: "not found fallback", component: "NotFound" },
   ]);
+  assertHasExpression(notFoundSourceFile, "shared header", /<AppHeader\s+active="dashboard"/);
+  assertHasStringValue(notFoundSourceFile, "not found panel test id", "not-found-panel");
 });
 
 test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows wired", async () => {

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -575,3 +575,21 @@ test("activity menu keeps the QA-tested trigger, drain note, and poll footer wir
   assertHasTestId(sourceFile, "activity poll footer", "activity-poll-footer");
   assertHasStringValue(sourceFile, "queued drain copy", "Queued automation is paused until drain mode is disabled.");
 });
+
+test("mobile layout primitives keep narrow viewport constraints wired", async () => {
+  const { sourceFile: appHeaderSourceFile } = await parseProjectFile("client/src/components/AppHeader.tsx");
+  const { sourceFile: activityMenuSourceFile } = await parseProjectFile("client/src/components/ActivityMenu.tsx");
+  const { sourceFile: detailHeaderSourceFile } = await parseProjectFile("client/src/components/detail/DetailHeader.tsx");
+  const { sourceFile: metaBreadcrumbSourceFile } = await parseProjectFile("client/src/components/detail/MetaBreadcrumb.tsx");
+  const { sourceFile: prsSourceFile } = await parseProjectFile("client/src/pages/prs.tsx");
+  const { sourceFile: issuesSourceFile } = await parseProjectFile("client/src/pages/issues.tsx");
+
+  assertHasStringValue(appHeaderSourceFile, "mobile header tap target", /min-h-8/);
+  assertHasStringValue(activityMenuSourceFile, "mobile activity menu viewport width", /w-\[calc\(100vw-1rem\)\]/);
+  assertHasStringValue(activityMenuSourceFile, "mobile activity menu viewport height", /max-h-\[calc\(100dvh-6rem\)\]/);
+  assertHasStringValue(detailHeaderSourceFile, "mobile detail header stacks actions", /flex-col gap-3 sm:flex-row/);
+  assertHasStringValue(detailHeaderSourceFile, "mobile detail action rail scrolls", /overflow-x-auto/);
+  assertHasStringValue(metaBreadcrumbSourceFile, "mobile metadata avoids word columns", /whitespace-nowrap/);
+  assertHasStringValue(prsSourceFile, "mobile PR activity panel is viewport bounded", /max-h-\[42dvh\]/);
+  assertHasStringValue(issuesSourceFile, "mobile issue activity panel is viewport bounded", /max-h-\[42dvh\]/);
+});

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -147,7 +147,7 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
               target="_blank"
               rel="noreferrer noopener"
               onClick={(event) => event.stopPropagation()}
-              className="inline-flex items-center gap-1 underline decoration-border underline-offset-2 hover:text-foreground"
+              className="inline-flex items-center gap-1 underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             >
               <ExternalLink className="h-3 w-3" />
               GitHub

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -677,7 +677,7 @@ function IssueLogPanel({
   }
 
   return (
-    <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
+    <div className="flex max-h-[42dvh] min-h-0 w-full shrink-0 flex-col border-t border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
       <div className="flex shrink-0 items-center border-b border-border">
         <div
           className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,21 +1,40 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, ArrowLeft } from "lucide-react";
+import { Link } from "wouter";
+import { AppHeader } from "@/components/AppHeader";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
-      <Card className="w-full max-w-md mx-4">
-        <CardContent className="pt-6">
-          <div className="flex mb-4 gap-2">
-            <AlertCircle className="h-8 w-8 text-red-500" />
-            <h1 className="text-2xl font-bold text-gray-900">404 Page Not Found</h1>
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <AppHeader active="dashboard" />
+      <main className="flex flex-1 items-center justify-center px-4 py-10">
+        <section
+          className="w-full max-w-md rounded-md border border-border bg-muted/20 px-4 py-5"
+          data-testid="not-found-panel"
+        >
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-warning-foreground" aria-hidden="true" />
+            <div className="min-w-0">
+              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                Not found
+              </div>
+              <h1 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+                Page not found
+              </h1>
+              <p className="mt-2 text-[12px] leading-5 text-muted-foreground">
+                This route is not available in PatchDeck.
+              </p>
+            </div>
           </div>
 
-          <p className="mt-4 text-sm text-gray-600">
-            Did you forget to add the page to the router?
-          </p>
-        </CardContent>
-      </Card>
+          <Link
+            href="/"
+            className="mt-4 inline-flex cursor-pointer items-center gap-1 rounded-md border border-border px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
+            Dashboard
+          </Link>
+        </section>
+      </main>
     </div>
   );
 }

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -946,7 +946,7 @@ function RightPanel({
   }
 
   return (
-    <div className="flex min-h-[24rem] w-full shrink-0 flex-col border-t border-border lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
+    <div className="flex max-h-[42dvh] min-h-0 w-full shrink-0 flex-col border-t border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
       <div className="flex shrink-0 items-center border-b border-border">
         <div
           className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -309,7 +309,7 @@ function SettingsTOC() {
               <button
                 type="button"
                 onClick={() => scrollToSettingsSection(group.id)}
-                className="block w-full rounded px-2 py-1 text-left text-foreground transition-colors hover:bg-muted"
+                className="block w-full rounded px-2 py-1 text-left text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
                 {group.label}
               </button>
@@ -319,7 +319,7 @@ function SettingsTOC() {
                 <button
                   type="button"
                   onClick={() => scrollToSettingsSection(item.id)}
-                  className="block w-full rounded px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  className="block w-full rounded px-2 py-1 text-left text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
                   {item.label}
                 </button>
@@ -1913,7 +1913,7 @@ function StringListRow({
           type="button"
           onClick={addValue}
           disabled={!draft.trim() || disabled}
-          className="border border-border px-2 py-1 text-xs hover:bg-muted disabled:opacity-50"
+          className="border border-border px-2 py-1 text-xs transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
         >
           add
         </button>
@@ -1931,7 +1931,7 @@ function StringListRow({
                 onClick={() => removeValue(index)}
                 disabled={disabled}
                 aria-label={`Remove ${value}`}
-                className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+                className="text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
               >
                 ×
               </button>


### PR DESCRIPTION
## Summary
- bring the not-found route into the shared PatchDeck app shell and theme tokens
- add missing keyboard focus states for dashboard GitHub links and settings navigation/list controls
- improve mobile layout for PR/Issue detail headers, activity menu sizing, header tap targets, metadata wrapping, and stacked activity panels
- extend the full app QA route test to cover the themed not-found page and mobile layout primitives

## Verification
- node --import tsx --test client/src/lib/fullAppQaSurface.test.ts
- npm run check
- npm run test:all
- git diff --check
- live Playwright route audit at 375px for Dashboard, PRs, Issues, Logs, Settings, and Releases
- live Playwright activity menu check at 375px