### PR TITLE
fix: keep queued PR work monitored

### DIFF
--- a/client/src/components/ActivityMenu.tsx
+++ b/client/src/components/ActivityMenu.tsx
@@ -1,9 +1,11 @@
 import { Activity as ActivityIcon } from "lucide-react";
+import { Link } from "wouter";
 import type { ActivityItem, ActivitySnapshot, BackgroundJobKind } from "@shared/schema";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import type { QueueStatusView } from "@/lib/activityQueue";
 import { formatActivityDetail, formatActivityLabel } from "@/lib/activityDisplay";
+import { getActivityTargetRoute } from "@/lib/activityTargetRoute";
 
 export const EMPTY_ACTIVITY_SNAPSHOT: ActivitySnapshot = {
   failed: [],
@@ -43,7 +45,7 @@ function ActivityKindBadge({ kind }: { kind: BackgroundJobKind }) {
   const meta = ACTIVITY_KIND_META[kind];
   return (
     <span
-      className={`shrink-0 border px-1 text-[9px] uppercase leading-4 tracking-wider ${meta.className}`}
+      className={`shrink-0 border px-1 text-label uppercase leading-4 tracking-wider ${meta.className}`}
     >
       {meta.label}
     </span>
@@ -53,6 +55,7 @@ function ActivityKindBadge({ kind }: { kind: BackgroundJobKind }) {
 function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueStatus: QueueStatusView | null }) {
   const label = formatActivityLabel(activity.label);
   const detail = formatActivityDetail(activity.detail);
+  const targetRoute = getActivityTargetRoute(activity.kind);
   const timeLabel = activity.status === "failed"
     ? formatClock(activity.updatedAt)
     : activity.status === "in_progress"
@@ -73,17 +76,17 @@ function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueS
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-1.5">
           <ActivityKindBadge kind={activity.kind} />
-          <span className="min-w-0 truncate text-[12px] leading-4 text-foreground">{label}</span>
+          <span className="min-w-0 truncate text-body leading-4 text-foreground">{label}</span>
         </span>
         {detail && (
-          <span className="block truncate text-[11px] leading-4 text-muted-foreground">{detail}</span>
+          <span className="block truncate text-label leading-4 text-muted-foreground">{detail}</span>
         )}
         <div className="mt-1">
           <QueueStatusBadge status={queueStatus} />
         </div>
         {activity.status === "failed" && activity.lastError && (
           <span
-            className="block whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
+            className="block whitespace-pre-wrap break-words text-label leading-4 text-destructive"
             title={activity.lastError}
           >
             {activity.lastError}
@@ -91,21 +94,19 @@ function ActivityRow({ activity, queueStatus }: { activity: ActivityItem; queueS
         )}
       </span>
       {timeLabel && (
-        <span className="shrink-0 text-[10px] leading-4 text-muted-foreground">{timeLabel}</span>
+        <span className="shrink-0 text-label leading-4 text-muted-foreground">{timeLabel}</span>
       )}
     </div>
   );
 
-  if (activity.targetUrl) {
+  if (targetRoute) {
     return (
-      <a
-        href={activity.targetUrl}
-        target="_blank"
-        rel="noopener noreferrer"
+      <Link
+        href={targetRoute}
         className="block outline-none hover:bg-muted focus:bg-muted focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
       >
         {content}
-      </a>
+      </Link>
     );
   }
 
@@ -125,7 +126,7 @@ function ActivitySection({
 }) {
   return (
     <div className="py-1">
-      <div className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">{title}</div>
+      <div className="px-2 py-1 text-label uppercase tracking-wider text-muted-foreground">{title}</div>
       {items.length > 0 ? (
         <div className="max-h-52 overflow-y-auto">
           {items.map((activity) => (
@@ -133,7 +134,7 @@ function ActivitySection({
           ))}
         </div>
       ) : (
-        <div className="px-2 pb-2 text-[11px] text-muted-foreground">{emptyLabel}</div>
+        <div className="px-2 pb-2 text-label text-muted-foreground">{emptyLabel}</div>
       )}
     </div>
   );
@@ -164,7 +165,7 @@ export function ActivityMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className="inline-flex min-h-8 items-center gap-1 border border-border px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background sm:min-h-0"
+        className="inline-flex min-h-8 items-center gap-1 border border-border px-2 py-0.5 text-label text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background sm:min-h-0"
         aria-label="Open activity menu"
         data-testid="activity-menu-trigger"
       >
@@ -175,20 +176,20 @@ export function ActivityMenu({
       <DropdownMenuContent align="end" className="max-h-[calc(100dvh-6rem)] w-[calc(100vw-1rem)] max-w-sm overflow-y-auto p-0 sm:w-80">
         <div className="border-b border-border px-2 py-2">
           <div className="flex items-center justify-between gap-2">
-            <div className="text-[12px] font-medium">Activities</div>
+            <div className="text-body font-medium">Activities</div>
             {failedCount > 0 && (
               <button
                 type="button"
                 onClick={onClearFailed}
                 disabled={isClearingFailed}
-                className="border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="border border-border px-1.5 py-0.5 text-label uppercase tracking-wider text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 data-testid="clear-failed-activities"
               >
                 {isClearingFailed ? "clearing" : "clear failed"}
               </button>
             )}
           </div>
-          <div className="text-[11px] text-muted-foreground">
+          <div className="text-label text-muted-foreground">
             {failedCount} failed / {inProgressCount} in progress / {queuedCount} queued
           </div>
         </div>
@@ -214,7 +215,7 @@ export function ActivityMenu({
         />
         {idleReason && totalCount === 0 && (
           <div
-            className="border-t border-border px-2 py-2 text-[11px] leading-4 text-warning-foreground"
+            className="border-t border-border px-2 py-2 text-label leading-4 text-warning-foreground"
             data-testid="activity-idle-reason"
           >
             {idleReason}
@@ -222,7 +223,7 @@ export function ActivityMenu({
         )}
         {globalDrainMode && queuedCount > 0 && (
           <div
-            className="border-t border-border px-2 py-2 text-[11px] text-muted-foreground"
+            className="border-t border-border px-2 py-2 text-label text-muted-foreground"
             data-testid="activity-drain-note"
           >
             {QUEUED_DRAIN_COPY}
@@ -230,7 +231,7 @@ export function ActivityMenu({
         )}
         {pollIntervalMs !== undefined && (
           <div
-            className="border-t border-border px-2 py-1.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+            className="border-t border-border px-2 py-1.5 text-label uppercase tracking-wider text-muted-foreground"
             data-testid="activity-poll-footer"
           >
             poll <span className="font-mono text-foreground/80">{formatPollLabel(pollIntervalMs)}</span>

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -31,7 +31,7 @@ const SECONDARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; hre
 ];
 
 function navLinkClass(selected: boolean) {
-  return `inline-flex min-h-8 items-center rounded-md border px-2 py-1 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background sm:min-h-0 ${
+  return `inline-flex min-h-8 items-center rounded-md border px-2 py-1 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background sm:min-h-0 ${
     selected
       ? "border-primary/40 bg-primary/10 text-primary"
       : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
@@ -193,7 +193,7 @@ function AutoModeButton() {
           title={tooltip}
           aria-label={tooltip}
           data-testid="auto-mode-indicator"
-          className={`inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${chipClass}`}
+          className={`inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-0.5 text-label font-medium uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${chipClass}`}
         >
           <span aria-hidden="true" className={`inline-block h-1.5 w-1.5 rounded-full ${dotClass}`} />
           {label}
@@ -201,17 +201,17 @@ function AutoModeButton() {
       </PopoverTrigger>
       <PopoverContent align="end" className="w-64 p-3">
         <div className="mb-2 flex items-center justify-between">
-          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+          <span className="text-label font-medium uppercase tracking-wider text-muted-foreground">
             Auto mode
           </span>
-          <span className={`inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider ${drainMode ? "text-warning-foreground" : "text-muted-foreground"}`}>
+          <span className={`inline-flex items-center gap-1.5 text-label font-medium uppercase tracking-wider ${drainMode ? "text-warning-foreground" : "text-muted-foreground"}`}>
             <span className={`inline-block h-1.5 w-1.5 rounded-full ${dotClass}`} />
             {label}
           </span>
         </div>
 
         {drainMode && (
-          <div className="mb-3 rounded-md border border-warning-border bg-warning-muted px-2 py-1.5 text-[11px] text-warning-foreground">
+          <div className="mb-3 rounded-md border border-warning-border bg-warning-muted px-2 py-1.5 text-label text-warning-foreground">
             Drain mode is active in Settings. Automation is paused regardless of these switches.
           </div>
         )}
@@ -221,8 +221,8 @@ function AutoModeButton() {
             className="flex cursor-pointer items-center justify-between gap-3 rounded-md px-1 py-1.5"
           >
             <label htmlFor="auto-mode-prs" className="flex min-w-0 cursor-pointer flex-col">
-              <span className="text-[12px] font-medium text-foreground">Pull requests</span>
-              <span className="text-[10px] text-muted-foreground">
+              <span className="text-body font-medium text-foreground">Pull requests</span>
+              <span className="text-label text-muted-foreground">
                 Watcher queues safe automation runs on watched PRs. Per-repo overrides live in Settings.
               </span>
             </label>
@@ -239,8 +239,8 @@ function AutoModeButton() {
             className="flex cursor-pointer items-center justify-between gap-3 rounded-md px-1 py-1.5"
           >
             <label htmlFor="auto-mode-issues" className="flex min-w-0 cursor-pointer flex-col">
-              <span className="text-[12px] font-medium text-foreground">Issues</span>
-              <span className="text-[10px] text-muted-foreground">
+              <span className="text-body font-medium text-foreground">Issues</span>
+              <span className="text-label text-muted-foreground">
                 Agent auto-evaluates and works eligible issues.
               </span>
             </label>
@@ -255,7 +255,7 @@ function AutoModeButton() {
         </div>
 
         <div className="mt-3 flex items-center justify-between gap-3 border-t border-border pt-2">
-          <div className="min-w-0 flex-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <div className="min-w-0 flex-1 text-label uppercase tracking-wider text-muted-foreground">
             Background sync
           </div>
           <button
@@ -267,7 +267,7 @@ function AutoModeButton() {
             )}
             disabled={drainPending}
             data-testid="auto-mode-drain-toggle"
-            className="inline-flex min-h-[28px] items-center rounded-md border border-border px-2.5 py-1.5 text-[10px] uppercase tracking-wider text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+            className="inline-flex min-h-[28px] items-center rounded-md border border-border px-2.5 py-1.5 text-label uppercase tracking-wider text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
           >
             {drainPending ? "…" : drainMode ? "Resume all" : "Pause all"}
           </button>
@@ -275,7 +275,7 @@ function AutoModeButton() {
 
         <Link
           href="/settings"
-          className="mt-3 inline-flex text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          className="mt-3 inline-flex text-label uppercase tracking-wider text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         >
           Manage in settings →
         </Link>
@@ -333,7 +333,7 @@ function GitHubRateLimitNotice() {
     <Link
       href="/settings"
       title={tooltip}
-      className="inline-flex max-w-[320px] items-center truncate whitespace-nowrap rounded-md border border-warning-border bg-warning-muted px-2.5 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:border-warning hover:bg-warning-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      className="inline-flex max-w-[320px] items-center truncate whitespace-nowrap rounded-md border border-warning-border bg-warning-muted px-2.5 py-1 text-label uppercase tracking-wider text-warning-foreground transition-colors hover:border-warning hover:bg-warning-muted/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
     >
       {label}
     </Link>
@@ -358,7 +358,7 @@ export function AppHeader({
           aria-label="PatchDeck dashboard"
         >
           <PatchdeckMark />
-          <span className="text-sm font-semibold tracking-tight">PatchDeck</span>
+          <span className="text-title font-semibold tracking-tight">PatchDeck</span>
         </Link>
         <nav aria-label="Primary" className="flex flex-wrap items-center gap-1">
           {PRIMARY_NAV_ITEMS.map((item) => {
@@ -381,7 +381,7 @@ export function AppHeader({
       </div>
       <div className="flex min-w-0 flex-wrap items-center gap-2 lg:justify-self-end lg:justify-end">
         {status ? (
-          <div className="flex min-w-0 flex-wrap items-center gap-2 border-l border-border/70 pl-2 text-[11px] text-muted-foreground lg:border-l-0 lg:pl-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 border-l border-border/70 pl-2 text-label text-muted-foreground lg:border-l-0 lg:pl-0">
             {status}
           </div>
         ) : null}

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -16,6 +16,21 @@ type GitHubRateLimitState = {
   resetAt: string | null;
   recentlyLimited: boolean;
   lastLimitedAt: string | null;
+  resources?: {
+    core?: GitHubRateLimitResourceState;
+    graphql?: GitHubRateLimitResourceState;
+    search?: GitHubRateLimitResourceState;
+  };
+};
+
+type GitHubRateLimitResourceState = {
+  limited: boolean;
+  resetAt: string | null;
+  recentlyLimited: boolean;
+  lastLimitedAt: string | null;
+  budget: { remaining: number; limit: number; percentRemaining: number; resetAt: string | null } | null;
+  belowReserve: boolean;
+  belowFloor: boolean;
 };
 
 const PRIMARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [
@@ -295,6 +310,9 @@ function GitHubRateLimitNotice() {
   });
   const explicitlyLimited = githubRateLimit?.limited === true;
   const recentlyLimited = githubRateLimit?.recentlyLimited === true;
+  const coreBudget = githubRateLimit?.resources?.core?.budget ?? null;
+  const coreBudgetTight = githubRateLimit?.resources?.core?.belowReserve === true;
+  const coreBudgetFloor = githubRateLimit?.resources?.core?.belowFloor === true;
   const { data: activities } = useQuery<ActivitySnapshot>({
     queryKey: ["/api/activities"],
     refetchInterval: ACTIVITY_POLL_INTERVAL_MS,
@@ -307,7 +325,7 @@ function GitHubRateLimitNotice() {
       .find((message) => message.toLowerCase().includes("rate limit")) ?? null
     : null;
 
-  if (!explicitlyLimited && !recentlyLimited && !activityRateLimitMessage) {
+  if (!explicitlyLimited && !recentlyLimited && !coreBudgetTight && !activityRateLimitMessage) {
     return null;
   }
 
@@ -319,6 +337,10 @@ function GitHubRateLimitNotice() {
     ? resetTime
       ? `GitHub rate limited until ${resetTime}`
       : "GitHub rate limited"
+    : coreBudgetFloor
+      ? "GitHub budget floor"
+    : coreBudgetTight
+      ? "GitHub budget reserve"
     : recentlyLimited
       ? "GitHub rate limit hit recently"
     : "GitHub rate limit hit in recent activity";
@@ -327,6 +349,14 @@ function GitHubRateLimitNotice() {
     ? resetTime
       ? `GitHub rate limit active until ${resetTime}. Open settings for token configuration.`
       : "GitHub rate limit active. Open settings for token configuration."
+    : coreBudgetFloor
+      ? coreBudget
+        ? `GitHub core budget is ${coreBudget.remaining}/${coreBudget.limit} (${coreBudget.percentRemaining}%). All GitHub jobs are waiting.`
+        : "GitHub core budget is below the hard floor. GitHub jobs are waiting."
+    : coreBudgetTight
+      ? coreBudget
+        ? `GitHub core budget is ${coreBudget.remaining}/${coreBudget.limit} (${coreBudget.percentRemaining}%). Passive PR monitor jobs are deferring.`
+        : "GitHub core budget is in reserve. Passive PR monitor jobs are deferring."
     : activityRateLimitMessage ?? "GitHub rate limit errors detected in recent activity. Open settings for token configuration.";
 
   return (

--- a/client/src/components/CurrentRunStatusStrip.tsx
+++ b/client/src/components/CurrentRunStatusStrip.tsx
@@ -35,9 +35,9 @@ export function CurrentRunStatusStrip({ run, testId }: CurrentRunStatusStripProp
   return (
     <div
       data-testid={testId}
-      className={`mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 border px-3 py-2 text-[11px] ${statusClass(run.status)}`}
+      className={`mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 border px-3 py-2 text-label ${statusClass(run.status)}`}
     >
-      <span className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider">
+      <span className="inline-flex items-center gap-1 text-label font-medium uppercase tracking-wider">
         <StatusIcon status={run.status} />
         {formatCurrentRunStatus(run.status)}
       </span>

--- a/client/src/components/DashboardErrorsPanel.tsx
+++ b/client/src/components/DashboardErrorsPanel.tsx
@@ -42,13 +42,13 @@ export function DashboardErrorsPanel({
       data-testid="dashboard-errors-panel"
     >
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <div className="inline-flex items-center gap-2 text-[12px] font-medium uppercase tracking-wider text-destructive">
+        <div className="inline-flex items-center gap-2 text-body font-medium uppercase tracking-wider text-destructive">
           <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
           Needs attention
           <span className="font-mono text-foreground">{activities.failed.length}</span>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <div className="text-[11px] text-muted-foreground">
+          <div className="text-label text-muted-foreground">
             Failed jobs stay here until retried or cleared from activity.
           </div>
           <button
@@ -56,7 +56,7 @@ export function DashboardErrorsPanel({
             onClick={onClearFailed}
             disabled={isClearingFailed}
             data-testid="dashboard-clear-failed-activities"
-            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           >
             {isClearingFailed ? (
               "Clearing"
@@ -72,7 +72,7 @@ export function DashboardErrorsPanel({
             onClick={onToggleRolledUp}
             aria-expanded={!rolledUp}
             data-testid="dashboard-errors-rollup-toggle"
-            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           >
             {rolledUp ? <ChevronDown className="h-3 w-3" aria-hidden="true" /> : <ChevronUp className="h-3 w-3" aria-hidden="true" />}
             {rolledUp ? "Expand" : "Roll up"}
@@ -81,7 +81,7 @@ export function DashboardErrorsPanel({
       </div>
       {rolledUp ? (
         <div
-          className="truncate text-[11px] text-muted-foreground"
+          className="truncate text-label text-muted-foreground"
           data-testid="dashboard-errors-rollup-summary"
           title={latestError?.lastError ?? latestError?.detail ?? latestError?.label}
         >
@@ -98,9 +98,9 @@ export function DashboardErrorsPanel({
               >
                 <div className="flex min-w-0 items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <div className="truncate text-[13px] font-medium text-foreground">{activity.label}</div>
+                    <div className="truncate text-body font-medium text-foreground">{activity.label}</div>
                     {activity.detail && (
-                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{activity.detail}</div>
+                      <div className="mt-0.5 truncate text-label text-muted-foreground">{activity.detail}</div>
                     )}
                   </div>
                   <div className="flex shrink-0 flex-wrap justify-end gap-2">
@@ -109,7 +109,7 @@ export function DashboardErrorsPanel({
                         type="button"
                         onClick={() => onClearIssueFailure(activity)}
                         disabled={isClearingIssueFailure}
-                        className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                        className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                         data-testid="dashboard-clear-issue-failure"
                       >
                         {isClearingIssueFailure ? (
@@ -127,7 +127,7 @@ export function DashboardErrorsPanel({
                         href={activity.targetUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                        className="shrink-0 rounded-md border border-destructive/50 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                       >
                         Open
                       </a>
@@ -136,7 +136,7 @@ export function DashboardErrorsPanel({
                 </div>
                 {activity.lastError && (
                   <div
-                    className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-[11px] leading-4 text-destructive"
+                    className="mt-2 line-clamp-3 whitespace-pre-wrap break-words text-label leading-4 text-destructive"
                     title={activity.lastError}
                   >
                     {activity.lastError}
@@ -146,7 +146,7 @@ export function DashboardErrorsPanel({
             ))}
           </div>
           {activities.failed.length > 4 && (
-            <div className="mt-2 text-[11px] text-muted-foreground">
+            <div className="mt-2 text-label text-muted-foreground">
               {activities.failed.length - 4} more failed job{activities.failed.length - 4 === 1 ? "" : "s"} in activity.
             </div>
           )}

--- a/client/src/components/GitHubReleaseCard.tsx
+++ b/client/src/components/GitHubReleaseCard.tsx
@@ -29,24 +29,24 @@ export function GitHubReleaseCard({
       <div className="flex flex-wrap items-start justify-between gap-3 px-4 py-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 font-mono text-[11px] font-medium uppercase tracking-wider text-primary">
+            <span className="rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 font-mono text-label font-medium uppercase tracking-wider text-primary">
               {release.tagName || `release-${release.id}`}
             </span>
             {release.draft && (
-              <span className="rounded-md border border-warning-border bg-warning-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider text-warning-foreground">
+              <span className="rounded-md border border-warning-border bg-warning-muted px-1.5 py-0 text-label font-medium uppercase tracking-wider text-warning-foreground">
                 draft
               </span>
             )}
             {release.prerelease && (
-              <span className="rounded-md border border-warning-border bg-warning-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider text-warning-foreground">
+              <span className="rounded-md border border-warning-border bg-warning-muted px-1.5 py-0 text-label font-medium uppercase tracking-wider text-warning-foreground">
                 pre-release
               </span>
             )}
-            <span className="truncate text-[15px] font-semibold tracking-tight">
+            <span className="truncate text-title font-semibold tracking-tight">
               {release.name || release.tagName}
             </span>
           </div>
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-label text-muted-foreground">
             <span className="font-mono text-foreground/80">{repoSlug}</span>
             <span className="text-border" aria-hidden="true">·</span>
             <span>
@@ -61,7 +61,7 @@ export function GitHubReleaseCard({
               onClick={() => setExpanded((prev) => !prev)}
               aria-expanded={expanded}
               data-testid={`toggle-release-${release.id}`}
-              className="cursor-pointer rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+              className="cursor-pointer rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             >
               {expanded ? "Hide" : "Notes"}
             </button>
@@ -70,7 +70,7 @@ export function GitHubReleaseCard({
             href={release.htmlUrl}
             target="_blank"
             rel="noreferrer noopener"
-            className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           >
             <ExternalLink className="h-3 w-3" />
             GitHub
@@ -81,11 +81,11 @@ export function GitHubReleaseCard({
         <div className="border-t border-border px-4 py-3">
           {release.bodyHtml ? (
             <div
-              className="feedback-markdown text-[12px] leading-relaxed"
+              className="feedback-markdown text-body leading-relaxed"
               dangerouslySetInnerHTML={{ __html: release.bodyHtml }}
             />
           ) : (
-            <pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-foreground/85">
+            <pre className="whitespace-pre-wrap break-words font-mono text-body leading-relaxed text-foreground/85">
               {release.body}
             </pre>
           )}

--- a/client/src/components/GlobalActivityPanel.tsx
+++ b/client/src/components/GlobalActivityPanel.tsx
@@ -1,7 +1,9 @@
+import { Link } from "wouter";
 import type { ActivityItem, ActivitySnapshot } from "@shared/schema";
 import { QueueStatusBadge } from "@/components/QueueStatusBadge";
 import type { QueueStatusView } from "@/lib/activityQueue";
 import { formatActivityDetail, formatActivityLabel } from "@/lib/activityDisplay";
+import { getActivityTargetRoute } from "@/lib/activityTargetRoute";
 
 function formatClock(timestamp: string | null): string | null {
   if (!timestamp) {
@@ -25,14 +27,14 @@ export function GlobalActivityPanel({
   return (
     <div className="shrink-0 border-b border-border px-3 py-2" data-testid="global-activity-panel">
       <div className="flex items-center justify-between gap-2">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Automation</div>
-        <div className="flex shrink-0 items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        <div className="text-label font-medium uppercase tracking-wider text-muted-foreground">Automation</div>
+        <div className="flex shrink-0 items-center gap-2 text-label uppercase tracking-wider text-muted-foreground">
           <span><span className="font-mono text-foreground/80">{activities.inProgress.length}</span> running</span>
           <span><span className="font-mono text-foreground/80">{activities.queued.length}</span> queued</span>
         </div>
       </div>
       {visibleActivities.length === 0 ? (
-        <div className="mt-2 text-[11px] leading-4 text-muted-foreground" data-testid="global-activity-idle-reason">
+        <div className="mt-2 text-label leading-4 text-muted-foreground" data-testid="global-activity-idle-reason">
           {idleReason ?? "No automation running or queued."}
         </div>
       ) : (
@@ -67,35 +69,36 @@ function GlobalActivityRow({
   const timeLabel = activity.status === "in_progress"
     ? formatClock(activity.startedAt) ?? formatClock(activity.updatedAt)
     : formatClock(activity.availableAt) ?? formatClock(activity.updatedAt);
+  const targetRoute = getActivityTargetRoute(activity.kind);
   const content = (
     <div
       className="min-w-0 rounded-md border border-border/70 bg-background px-2 py-1.5"
       data-testid="global-activity-row"
     >
       <div className="flex min-w-0 items-center gap-2">
-        <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-[9px] uppercase tracking-wider ${statusClass}`}>
+        <span className={`shrink-0 rounded-md border px-1.5 py-0.5 text-label uppercase tracking-wider ${statusClass}`}>
           {activity.status === "in_progress" ? "running" : activity.status}
         </span>
-        <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">{label}</span>
-        {timeLabel && <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{timeLabel}</span>}
+        <span className="min-w-0 flex-1 truncate text-body text-foreground">{label}</span>
+        {timeLabel && <span className="shrink-0 font-mono text-label text-muted-foreground">{timeLabel}</span>}
       </div>
       {detail && (
-        <div className="mt-1 truncate text-[11px] text-muted-foreground">{detail}</div>
+        <div className="mt-1 truncate text-label text-muted-foreground">{detail}</div>
       )}
       <div className="mt-1">
         <QueueStatusBadge status={queueStatus} />
       </div>
       {activity.lastError && (
-        <div className="mt-1 line-clamp-2 text-[11px] text-destructive">{activity.lastError}</div>
+        <div className="mt-1 line-clamp-2 text-label text-destructive">{activity.lastError}</div>
       )}
     </div>
   );
 
-  if (activity.targetUrl) {
+  if (targetRoute) {
     return (
-      <a href={activity.targetUrl} target="_blank" rel="noopener noreferrer" className="block outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <Link href={targetRoute} className="block outline-none focus-visible:ring-1 focus-visible:ring-ring">
         {content}
-      </a>
+      </Link>
     );
   }
 

--- a/client/src/components/OnboardingPanel.tsx
+++ b/client/src/components/OnboardingPanel.tsx
@@ -156,7 +156,7 @@ export function getOnboardingPanelState(status: OnboardingStatus) {
 
 function InlineCode({ children }: { children: string }) {
   return (
-    <code className="rounded-md border border-border bg-muted/30 px-1 py-0.5 text-[11px] font-mono">
+    <code className="rounded-md border border-border bg-muted/30 px-1 py-0.5 text-label font-mono">
       {children}
     </code>
   );
@@ -165,10 +165,10 @@ function InlineCode({ children }: { children: string }) {
 function Step({ number, children }: { number: number; children: ReactNode }) {
   return (
     <div className="flex gap-2.5">
-      <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center border border-border text-[10px] text-muted-foreground">
+      <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center border border-border text-label text-muted-foreground">
         {number}
       </span>
-      <div className="flex-1 text-[12px] leading-relaxed">{children}</div>
+      <div className="flex-1 text-body leading-relaxed">{children}</div>
     </div>
   );
 }
@@ -185,17 +185,17 @@ function StepCard({
   return (
     <div className={`border px-3 py-3 ${step.complete ? "border-border bg-background/60" : "border-warning-border bg-warning-muted"}`}>
       <div className="flex gap-3">
-        <span className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center border text-[10px] ${step.complete ? "border-border text-foreground" : "border-warning-border text-warning-foreground"}`}>
+        <span className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center border text-label ${step.complete ? "border-border text-foreground" : "border-warning-border text-warning-foreground"}`}>
           {step.complete ? "✓" : index}
         </span>
         <div className="min-w-0 flex-1 space-y-1.5">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-wider">{step.title}</span>
-            <span className={`border px-1.5 py-0 text-[10px] uppercase tracking-wider ${step.complete ? "border-border text-muted-foreground" : "border-warning-border text-warning-foreground"}`}>
+            <span className="text-label font-medium uppercase tracking-wider">{step.title}</span>
+            <span className={`border px-1.5 py-0 text-label uppercase tracking-wider ${step.complete ? "border-border text-muted-foreground" : "border-warning-border text-warning-foreground"}`}>
               {step.complete ? "done" : "next"}
             </span>
           </div>
-          <p className="text-[12px] text-muted-foreground">{step.description}</p>
+          <p className="text-body text-muted-foreground">{step.description}</p>
           {children}
         </div>
       </div>
@@ -334,11 +334,11 @@ export function OnboardingPanel() {
           className="flex items-center gap-2 text-left"
         >
           <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-foreground" />
-          <span className="text-[11px] font-medium uppercase tracking-wider">
+          <span className="text-label font-medium uppercase tracking-wider">
             Getting started
           </span>
-          <span className="text-[11px] text-muted-foreground">{summary}</span>
-          <span className="text-[10px] text-muted-foreground">{expanded ? "▲" : "▼"}</span>
+          <span className="text-label text-muted-foreground">{summary}</span>
+          <span className="text-label text-muted-foreground">{expanded ? "▲" : "▼"}</span>
         </button>
         <button
           onClick={() => {
@@ -347,7 +347,7 @@ export function OnboardingPanel() {
             }
             setDismissedKey(dismissalKey);
           }}
-          className="text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+          className="text-label uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
         >
           dismiss
         </button>
@@ -356,10 +356,10 @@ export function OnboardingPanel() {
       {expanded && (
         <div className="border-t border-border px-4 py-4 space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            <div className="text-label uppercase tracking-wider text-muted-foreground">
               Setup checklist
             </div>
-            <div className="text-[11px] text-muted-foreground">
+            <div className="text-label text-muted-foreground">
               {completedCount} of {steps.length} complete
             </div>
           </div>
@@ -370,9 +370,9 @@ export function OnboardingPanel() {
                 {step.id === "github" && !step.complete && (
                   <div className="space-y-2 pt-1">
                     {displayStatus.githubError && !isTransientGitHubWarning(displayStatus.githubError) && (
-                      <p className="text-[12px] text-destructive">{displayStatus.githubError}</p>
+                      <p className="text-body text-destructive">{displayStatus.githubError}</p>
                     )}
-                    <div className="space-y-1.5 text-[12px] text-muted-foreground">
+                    <div className="space-y-1.5 text-body text-muted-foreground">
                       <Step number={1}>
                         Run <InlineCode>gh auth login</InlineCode> on this machine, set <InlineCode>GITHUB_TOKEN</InlineCode>, or add a saved token in <Link href="/settings" className="underline underline-offset-2">settings</Link>.
                       </Step>
@@ -384,7 +384,7 @@ export function OnboardingPanel() {
                 )}
 
                 {step.id === "repo" && !step.complete && (
-                  <div className="pt-1 text-[12px] text-muted-foreground">
+                  <div className="pt-1 text-body text-muted-foreground">
                     The left sidebar is the real entry point. Use <span className="text-foreground">Add</span> for a PR URL or <span className="text-foreground">Watch</span> for an <InlineCode>owner/repo</InlineCode> slug, then choose whether that watched repo should track only your PRs or your whole team.
                   </div>
                 )}
@@ -392,10 +392,10 @@ export function OnboardingPanel() {
                 {step.id === "workflow" && !step.complete && accessibleRepos.length > 0 && (
                   <div className="space-y-2 pt-1">
                     <div className="space-y-2 border border-border bg-muted/40 px-3 py-2">
-                      <p className="text-[12px] text-muted-foreground">
+                      <p className="text-body text-muted-foreground">
                         These are GitHub Actions that run on every PR and post review comments. PatchDeck reads those comments, decides which need code changes, and queues safe fixes. Pick whichever review tool fits your stack.
                       </p>
-                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-label">
                         {REVIEW_PROVIDER_GUIDES.map((provider) => (
                           <a
                             key={provider.href}
@@ -416,11 +416,11 @@ export function OnboardingPanel() {
                             href={`https://github.com/${repoStatus.repo}`}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="block truncate text-[11px] font-medium underline underline-offset-2"
+                            className="block truncate text-label font-medium underline underline-offset-2"
                           >
                             {repoStatus.repo}
                           </a>
-                          <p className="text-[11px] text-muted-foreground">
+                          <p className="text-label text-muted-foreground">
                             No reviewer Action installed on this repo yet.
                           </p>
                         </div>
@@ -435,7 +435,7 @@ export function OnboardingPanel() {
                               type="button"
                               onClick={() => installWorkflowMutation.mutate({ repo: repoStatus.repo, tool })}
                               disabled={installWorkflowMutation.isPending || globalDrainMode}
-                              className="border border-border px-2 py-1 text-[10px] uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-40"
+                              className="border border-border px-2 py-1 text-label uppercase tracking-wider transition-colors hover:bg-foreground hover:text-background disabled:opacity-40"
                             >
                               {globalDrainMode ? "Paused" : isPending ? "Adding…" : `Add ${REVIEW_TOOL_LABELS[tool]} Action`}
                             </button>
@@ -450,10 +450,10 @@ export function OnboardingPanel() {
                 {step.id === "workflow" && step.complete && reposWithReview.length > 0 && (
                   <div className="space-y-2 pt-1">
                     <div className="space-y-2 border border-border bg-muted/40 px-3 py-2">
-                      <p className="text-[12px] text-muted-foreground">
+                      <p className="text-body text-muted-foreground">
                         These are GitHub Actions that run on every PR and post review comments. PatchDeck reads those comments, decides which need code changes, and queues safe fixes. Pick whichever review tool fits your stack.
                       </p>
-                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-[11px]">
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-label">
                         {REVIEW_PROVIDER_GUIDES.map((provider) => (
                           <a
                             key={provider.href}
@@ -475,7 +475,7 @@ export function OnboardingPanel() {
                         return (
                           <span
                             key={repoStatus.repo}
-                            className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+                            className="border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground"
                           >
                             {repoStatus.repo} · {detectedTools}
                           </span>
@@ -490,13 +490,13 @@ export function OnboardingPanel() {
 
           {inaccessibleRepos.length > 0 && !isTransientGitHubWarning(displayStatus.githubError) && (
             <div className="space-y-3 border border-destructive/30 bg-destructive/5 px-3 py-3">
-              <div className="text-[11px] font-medium uppercase tracking-wider text-destructive">
+              <div className="text-label font-medium uppercase tracking-wider text-destructive">
                 Repository access issues
               </div>
               <div className="space-y-2">
                 {inaccessibleRepos.map((repoStatus) => (
                   <div key={repoStatus.repo} className="space-y-1">
-                    <div className="text-[11px] font-medium">
+                    <div className="text-label font-medium">
                       <a
                         href={`https://github.com/${repoStatus.repo}`}
                         target="_blank"
@@ -506,7 +506,7 @@ export function OnboardingPanel() {
                         {repoStatus.repo}
                       </a>
                     </div>
-                    <p className="text-[12px] text-destructive">
+                    <p className="text-body text-destructive">
                       Cannot access this repository: {repoStatus.error ?? "unknown error"}
                     </p>
                   </div>

--- a/client/src/components/QueueStatusBadge.tsx
+++ b/client/src/components/QueueStatusBadge.tsx
@@ -7,7 +7,7 @@ export function QueueStatusBadge({ status }: { status: QueueStatusView | null })
 
   return (
     <span
-      className={`inline-flex items-center gap-1 border px-1.5 py-0 text-[10px] uppercase tracking-wider ${status.className}`}
+      className={`inline-flex items-center gap-1 border px-1.5 py-0 text-label uppercase tracking-wider ${status.className}`}
       data-testid="queue-status-badge"
     >
       <span>{status.label}</span>

--- a/client/src/components/SocialPostGenerator.tsx
+++ b/client/src/components/SocialPostGenerator.tsx
@@ -20,7 +20,7 @@ function CopyChip({ text }: { text: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
     >
       {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
       {copied ? "copied" : "copy"}
@@ -100,7 +100,7 @@ export function SocialPostGenerator({
   return (
     <div className="mt-3 border-t border-border pt-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <div className="flex items-center gap-2 text-label text-muted-foreground">
           <Sparkles className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
           <span className="font-medium uppercase tracking-wider">Social post</span>
         </div>
@@ -109,7 +109,7 @@ export function SocialPostGenerator({
           onClick={handleGenerate}
           disabled={busy}
           data-testid={`${testIdPrefix}-generate-social-post`}
-          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary bg-primary px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary bg-primary px-3 py-1 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Sparkles className="h-3 w-3" />}
           {buttonLabel}
@@ -117,20 +117,20 @@ export function SocialPostGenerator({
       </div>
 
       {startError && (
-        <div className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[11px] text-destructive">
+        <div className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-label text-destructive">
           {startError}
         </div>
       )}
 
       {post?.status === "error" && post.error && (
-        <div className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[11px] text-destructive">
-          <div className="text-[10px] font-medium uppercase tracking-wider">Generation failed</div>
+        <div className="mt-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-label text-destructive">
+          <div className="text-label font-medium uppercase tracking-wider">Generation failed</div>
           <div className="mt-1 whitespace-pre-wrap break-words">{post.error}</div>
         </div>
       )}
 
       {post?.status === "generating" && (
-        <div className="mt-2 text-[11px] text-muted-foreground">
+        <div className="mt-2 text-label text-muted-foreground">
           Automation is composing posts. This can take 30–120 seconds.
         </div>
       )}
@@ -143,12 +143,12 @@ export function SocialPostGenerator({
               data-testid={`${testIdPrefix}-social-twitter`}
             >
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                <span className="text-label font-medium uppercase tracking-wider text-muted-foreground">
                   Twitter / X
                 </span>
                 <CopyChip text={post.twitter} />
               </div>
-              <pre className="whitespace-pre-wrap break-words text-[12px] leading-relaxed text-foreground/85">
+              <pre className="whitespace-pre-wrap break-words text-body leading-relaxed text-foreground/85">
                 {post.twitter}
               </pre>
             </section>
@@ -159,12 +159,12 @@ export function SocialPostGenerator({
               data-testid={`${testIdPrefix}-social-linkedin`}
             >
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                <span className="text-label font-medium uppercase tracking-wider text-muted-foreground">
                   LinkedIn
                 </span>
                 <CopyChip text={post.linkedin} />
               </div>
-              <pre className="whitespace-pre-wrap break-words text-[12px] leading-relaxed text-foreground/85">
+              <pre className="whitespace-pre-wrap break-words text-body leading-relaxed text-foreground/85">
                 {post.linkedin}
               </pre>
             </section>
@@ -172,12 +172,12 @@ export function SocialPostGenerator({
           {!post.twitter && !post.linkedin && post.raw && (
             <section className="rounded-md border border-border bg-muted/20 p-3">
               <div className="mb-2 flex items-center justify-between">
-                <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                <span className="text-label font-medium uppercase tracking-wider text-muted-foreground">
                   Raw output
                 </span>
                 <CopyChip text={post.raw} />
               </div>
-              <pre className="whitespace-pre-wrap break-words text-[12px] leading-relaxed text-foreground/85">
+              <pre className="whitespace-pre-wrap break-words text-body leading-relaxed text-foreground/85">
                 {post.raw}
               </pre>
             </section>

--- a/client/src/components/UpdateBanner.tsx
+++ b/client/src/components/UpdateBanner.tsx
@@ -37,7 +37,7 @@ export function UpdateBanner() {
     <div className="shrink-0 border-b border-warning-border bg-warning-muted">
       <div className="grid gap-2 px-4 py-2 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
         <div className="min-w-0 space-y-1.5">
-          <div className="flex min-w-0 flex-wrap items-center gap-3 text-[12px]">
+          <div className="flex min-w-0 flex-wrap items-center gap-3 text-body">
             <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-warning" />
             <span className="font-medium uppercase tracking-wider text-warning-foreground">
               Update available
@@ -46,7 +46,7 @@ export function UpdateBanner() {
               {`PatchDeck ${formatAppVersionLabel(status.latestVersion)} is available. You're on ${formatAppVersionLabel(status.currentVersion)}.`}
             </span>
           </div>
-          <ol className="list-decimal space-y-1 pl-5 text-[11px] text-foreground/70">
+          <ol className="list-decimal space-y-1 pl-5 text-label text-foreground/70">
             {updateInstructionSteps.map((step) => (
               <li key={`${step.text}:${step.command ?? ""}`} className="pl-0.5">
                 {step.command ? (
@@ -60,7 +60,7 @@ export function UpdateBanner() {
             ))}
           </ol>
         </div>
-        <div className="flex items-center gap-3 text-[11px]">
+        <div className="flex items-center gap-3 text-label">
           <a
             href={status.latestReleaseUrl}
             target="_blank"

--- a/client/src/components/WebLoginGate.tsx
+++ b/client/src/components/WebLoginGate.tsx
@@ -95,7 +95,7 @@ export function WebLoginGate({ children }: WebLoginGateProps) {
   if (!status) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
-        <div className="border border-border px-4 py-3 text-xs uppercase text-muted-foreground">
+        <div className="border border-border px-4 py-3 text-body uppercase text-muted-foreground">
           {error ?? "Loading PatchDeck"}
         </div>
       </div>
@@ -113,30 +113,30 @@ export function WebLoginGate({ children }: WebLoginGateProps) {
         onSubmit={submitLogin}
       >
         <div className="mb-5 space-y-1">
-          <p className="text-[10px] uppercase text-muted-foreground">Remote access</p>
-          <h1 className="text-base font-semibold">Sign in to PatchDeck</h1>
+          <p className="text-label uppercase text-muted-foreground">Remote access</p>
+          <h1 className="text-title font-semibold">Sign in to PatchDeck</h1>
         </div>
 
         {!status.loginConfigured ? (
-          <div className="border border-warning-border bg-warning-muted p-3 text-xs text-warning-foreground">
+          <div className="border border-warning-border bg-warning-muted p-3 text-body text-warning-foreground">
             Remote login is not configured on this server.
           </div>
         ) : (
           <>
-            <label className="mb-3 block text-xs">
+            <label className="mb-3 block text-body">
               <span className="mb-1 block text-muted-foreground">Username</span>
               <input
-                className="w-full border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
+                className="w-full border border-input bg-background px-3 py-2 text-body text-foreground outline-none focus:border-ring"
                 autoComplete="username"
                 value={username}
                 onChange={(event) => setUsername(event.target.value)}
               />
             </label>
 
-            <label className="mb-4 block text-xs">
+            <label className="mb-4 block text-body">
               <span className="mb-1 block text-muted-foreground">Password</span>
               <input
-                className="w-full border border-input bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-ring"
+                className="w-full border border-input bg-background px-3 py-2 text-body text-foreground outline-none focus:border-ring"
                 autoComplete="current-password"
                 type="password"
                 value={password}
@@ -145,13 +145,13 @@ export function WebLoginGate({ children }: WebLoginGateProps) {
             </label>
 
             {error && (
-              <div className="mb-4 border border-destructive bg-background p-3 text-xs text-destructive">
+              <div className="mb-4 border border-destructive bg-background p-3 text-body text-destructive">
                 {error}
               </div>
             )}
 
             <button
-              className="w-full border border-primary bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              className="w-full border border-primary bg-primary px-3 py-2 text-body font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
               disabled={submitting}
               type="submit"
             >

--- a/client/src/components/detail/DetailHeader.tsx
+++ b/client/src/components/detail/DetailHeader.tsx
@@ -32,8 +32,8 @@ export function DetailHeader({
   failed = false,
 }: DetailHeaderProps) {
   const titleClass = titleMultiline
-    ? "line-clamp-2 break-words text-[15px] font-semibold leading-snug tracking-tight"
-    : "line-clamp-2 break-words text-[15px] font-semibold leading-snug tracking-tight sm:block sm:truncate";
+    ? "line-clamp-2 break-words text-title font-semibold leading-snug tracking-tight"
+    : "line-clamp-2 break-words text-title font-semibold leading-snug tracking-tight sm:block sm:truncate";
   const accentClass = accentTone ? ` border-t-2 ${toneHeaderAccentClass(accentTone)}` : "";
   const failedBg = toneFailedBgClass(failed);
 
@@ -52,7 +52,7 @@ export function DetailHeader({
                 href={externalLink.href}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex max-w-full shrink-0 items-center gap-1 font-mono text-[11px] text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                className="inline-flex max-w-full shrink-0 items-center gap-1 font-mono text-label text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
                 <ExternalLink className="h-3 w-3" aria-hidden="true" />
                 <span className="min-w-0 truncate">{externalLink.label}</span>

--- a/client/src/components/detail/DetailPanel.tsx
+++ b/client/src/components/detail/DetailPanel.tsx
@@ -34,7 +34,7 @@ export function DetailPanel({
   return (
     <div className={`mt-3 border ${containerClass}`} data-testid={testId}>
       <div className={`flex flex-wrap items-center justify-between gap-2 border-b px-3 py-2 ${headerStripClass}`}>
-        <div className="text-[10px] uppercase tracking-wider">{title}</div>
+        <div className="text-label uppercase tracking-wider">{title}</div>
         <div className="flex items-center gap-2">
           {chip}
           {action}

--- a/client/src/components/detail/MetaBreadcrumb.tsx
+++ b/client/src/components/detail/MetaBreadcrumb.tsx
@@ -8,7 +8,7 @@ export type MetaItem = {
 export function MetaBreadcrumb({ items }: { items: MetaItem[] }) {
   if (items.length === 0) return null;
   return (
-    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-label text-muted-foreground">
       {items.map((item, idx) => (
         <Fragment key={item.key}>
           {idx > 0 && <span className="hidden text-border sm:inline" aria-hidden="true">·</span>}

--- a/client/src/components/detail/StageProgressBar.tsx
+++ b/client/src/components/detail/StageProgressBar.tsx
@@ -53,7 +53,7 @@ export function StageProgressBar({
           );
         })}
       </div>
-      <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+      <span className="font-mono text-label uppercase tracking-wider text-muted-foreground">
         {doneCount}/{stages.length}
       </span>
     </div>

--- a/client/src/components/detail/StatusChip.tsx
+++ b/client/src/components/detail/StatusChip.tsx
@@ -19,7 +19,7 @@ export function StatusChip({
     <span
       data-testid={testId}
       title={title}
-      className={`inline-flex items-center rounded-md border px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider ${toneChipClass(tone)}${animateClass}`}
+      className={`inline-flex items-center rounded-md border px-1.5 py-0 text-label font-medium uppercase tracking-wider ${toneChipClass(tone)}${animateClass}`}
     >
       {label}
     </span>

--- a/client/src/components/ui/accordion.tsx
+++ b/client/src/components/ui/accordion.tsx
@@ -44,7 +44,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-hidden text-sm transition-opacity data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-hidden text-body transition-opacity data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
     <div className={cn("pb-4 pt-0", className)}>{children}</div>

--- a/client/src/components/ui/alert-dialog.tsx
+++ b/client/src/components/ui/alert-dialog.tsx
@@ -77,7 +77,7 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold", className)}
+    className={cn("text-title font-semibold", className)}
     {...props}
   />
 ))
@@ -89,7 +89,7 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-body text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/alert.tsx
+++ b/client/src/components/ui/alert.tsx
@@ -50,7 +50,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    className={cn("text-body [&_p]:leading-relaxed", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
   // Whitespace-nowrap: Badges should never wrap.
-  "whitespace-nowrap inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2" +
+  "whitespace-nowrap inline-flex items-center rounded-md border px-2.5 py-0.5 text-label font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2" +
   " hover-elevate " ,
   {
     variants: {

--- a/client/src/components/ui/breadcrumb.tsx
+++ b/client/src/components/ui/breadcrumb.tsx
@@ -19,7 +19,7 @@ const BreadcrumbList = React.forwardRef<
   <ol
     ref={ref}
     className={cn(
-      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      "flex flex-wrap items-center gap-1.5 break-words text-body text-muted-foreground sm:gap-2.5",
       className
     )}
     {...props}

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0" +
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-body font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0" +
   " hover-elevate active-elevate-2",
   {
     variants: {
@@ -27,7 +27,7 @@ const buttonVariants = cva(
       // but will expand to fit large amounts of content.
       size: {
         default: "min-h-9 px-4 py-2",
-        sm: "min-h-8 rounded-md px-3 text-xs",
+        sm: "min-h-8 rounded-md px-3 text-body",
         lg: "min-h-10 rounded-lg px-8",
         icon: "h-9 w-9",
       },

--- a/client/src/components/ui/calendar.tsx
+++ b/client/src/components/ui/calendar.tsx
@@ -21,7 +21,7 @@ function Calendar({
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
         caption: "flex justify-center pt-1 relative items-center",
-        caption_label: "text-sm font-medium",
+        caption_label: "text-body font-medium",
         nav: "space-x-1 flex items-center",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),
@@ -32,9 +32,9 @@ function Calendar({
         table: "w-full border-collapse space-y-1",
         head_row: "flex",
         head_cell:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+          "text-muted-foreground rounded-md w-9 font-normal text-body",
         row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell: "h-9 w-9 text-center text-body p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),
           "h-9 w-9 p-0 font-normal aria-selected:opacity-100"

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "text-display font-semibold leading-none tracking-tight",
       className
     )}
     {...props}
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-body text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -52,7 +52,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex aspect-video justify-center text-body [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}
@@ -179,7 +179,7 @@ const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-body shadow-xl",
           className
         )}
       >

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-body outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -71,7 +71,7 @@ const CommandEmpty = React.forwardRef<
 >((props, ref) => (
   <CommandPrimitive.Empty
     ref={ref}
-    className="py-6 text-center text-sm"
+    className="py-6 text-center text-body"
     {...props}
   />
 ))
@@ -85,7 +85,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-body [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
       className
     )}
     {...props}
@@ -113,7 +113,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-body outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     )}
     {...props}
@@ -129,7 +129,7 @@ const CommandShortcut = ({
   return (
     <span
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-body tracking-widest text-muted-foreground",
         className
       )}
       {...props}

--- a/client/src/components/ui/context-menu.tsx
+++ b/client/src/components/ui/context-menu.tsx
@@ -25,7 +25,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
       className
     )}
@@ -78,7 +78,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -94,7 +94,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -118,7 +118,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -142,7 +142,7 @@ const ContextMenuLabel = React.forwardRef<
   <ContextMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      "px-2 py-1.5 text-body font-semibold text-foreground",
       inset && "pl-8",
       className
     )}
@@ -170,7 +170,7 @@ const ContextMenuShortcut = ({
   return (
     <span
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-body tracking-widest text-muted-foreground",
         className
       )}
       {...props}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -88,7 +88,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-title font-semibold leading-none tracking-tight",
       className
     )}
     {...props}
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-body text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/drawer.tsx
+++ b/client/src/components/ui/drawer.tsx
@@ -84,7 +84,7 @@ const DrawerTitle = React.forwardRef<
   <DrawerPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-title font-semibold leading-none tracking-tight",
       className
     )}
     {...props}
@@ -98,7 +98,7 @@ const DrawerDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-body text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/dropdown-menu.tsx
+++ b/client/src/components/ui/dropdown-menu.tsx
@@ -25,7 +25,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -81,7 +81,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-body outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -97,7 +97,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -121,7 +121,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -145,7 +145,7 @@ const DropdownMenuLabel = React.forwardRef<
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
+      "px-2 py-1.5 text-body font-semibold",
       inset && "pl-8",
       className
     )}
@@ -172,7 +172,7 @@ const DropdownMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      className={cn("ml-auto text-body tracking-widest opacity-60", className)}
       {...props}
     />
   )

--- a/client/src/components/ui/form.tsx
+++ b/client/src/components/ui/form.tsx
@@ -135,7 +135,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-body text-muted-foreground", className)}
       {...props}
     />
   )
@@ -157,7 +157,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn("text-sm font-medium text-destructive", className)}
+      className={cn("text-body font-medium text-destructive", className)}
       {...props}
     >
       {body}

--- a/client/src/components/ui/input-otp.tsx
+++ b/client/src/components/ui/input-otp.tsx
@@ -39,7 +39,7 @@ const InputOTPSlot = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-sm transition-colors first:rounded-l-md first:border-l last:rounded-r-md",
+        "relative flex h-10 w-10 items-center justify-center border-y border-r border-input text-body transition-colors first:rounded-l-md first:border-l last:rounded-r-md",
         isActive && "z-10 ring-2 ring-ring ring-offset-background",
         className
       )}

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-title ring-offset-background file:border-0 file:bg-transparent file:text-body file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-body",
           className
         )}
         ref={ref}

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-body font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
 const Label = React.forwardRef<

--- a/client/src/components/ui/menubar.tsx
+++ b/client/src/components/ui/menubar.tsx
@@ -58,7 +58,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-body font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const MenubarSubTrigger = React.forwardRef<
   <MenubarPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
       className
     )}
@@ -136,7 +136,7 @@ const MenubarItem = React.forwardRef<
   <MenubarPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -152,7 +152,7 @@ const MenubarCheckboxItem = React.forwardRef<
   <MenubarPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -175,7 +175,7 @@ const MenubarRadioItem = React.forwardRef<
   <MenubarPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -199,7 +199,7 @@ const MenubarLabel = React.forwardRef<
   <MenubarPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
+      "px-2 py-1.5 text-body font-semibold",
       inset && "pl-8",
       className
     )}
@@ -227,7 +227,7 @@ const MenubarShortcut = ({
   return (
     <span
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-body tracking-widest text-muted-foreground",
         className
       )}
       {...props}

--- a/client/src/components/ui/navigation-menu.tsx
+++ b/client/src/components/ui/navigation-menu.tsx
@@ -41,7 +41,7 @@ NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 const NavigationMenuItem = NavigationMenuPrimitive.Item
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=open]:text-accent-foreground data-[state=open]:bg-accent/50 data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent"
+  "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-body font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=open]:text-accent-foreground data-[state=open]:bg-accent/50 data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent"
 )
 
 const NavigationMenuTrigger = React.forwardRef<

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-body ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -105,7 +105,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn("py-1.5 pl-8 pr-2 text-body font-semibold", className)}
     {...props}
   />
 ))
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-body outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -108,7 +108,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
+    className={cn("text-title font-semibold text-foreground", className)}
     {...props}
   />
 ))
@@ -120,7 +120,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-body text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -406,7 +406,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:h-4 [&>svg]:w-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-body font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:h-4 [&>svg]:w-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className
       )}
@@ -446,7 +446,7 @@ function SidebarGroupContent({
     <div
       data-slot="sidebar-group-content"
       data-sidebar="group-content"
-      className={cn("w-full text-sm", className)}
+      className={cn("w-full text-body", className)}
       {...props}
     />
   )
@@ -475,7 +475,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:w-8! group-data-[collapsible=icon]:h-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-body outline-hidden ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:w-8! group-data-[collapsible=icon]:h-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -484,9 +484,9 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+        default: "h-8 text-body",
+        sm: "h-7 text-body",
+        lg: "h-12 text-body group-data-[collapsible=icon]:p-0!",
       },
     },
     defaultVariants: {
@@ -587,7 +587,7 @@ function SidebarMenuBadge({
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums select-none",
+        "text-sidebar-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-body font-medium tabular-nums select-none",
         "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
@@ -689,8 +689,8 @@ function SidebarMenuSubButton({
       className={cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline outline-2 outline-transparent outline-offset-2 focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
         "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
-        size === "sm" && "text-xs",
-        size === "md" && "text-sm",
+        size === "sm" && "text-body",
+        size === "md" && "text-body",
         "group-data-[collapsible=icon]:hidden",
         className
       )}

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -9,7 +9,7 @@ const Table = React.forwardRef<
   <div className="relative w-full overflow-auto">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn("w-full caption-bottom text-body", className)}
       {...props}
     />
   </div>
@@ -99,7 +99,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    className={cn("mt-4 text-body text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-body font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}

--- a/client/src/components/ui/textarea.tsx
+++ b/client/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-title ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-body",
         className
       )}
       ref={ref}

--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -60,7 +60,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-body font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
       className
     )}
     {...props}
@@ -92,7 +92,7 @@ const ToastTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
-    className={cn("text-sm font-semibold", className)}
+    className={cn("text-body font-semibold", className)}
     {...props}
   />
 ))
@@ -104,7 +104,7 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    className={cn("text-body opacity-90", className)}
     {...props}
   />
 ))

--- a/client/src/components/ui/toggle.tsx
+++ b/client/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
+  "inline-flex items-center justify-center rounded-md text-body font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
   {
     variants: {
       variant: {

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-body text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
       className
     )}
     {...props}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -134,7 +134,7 @@
 
   body {
     @apply font-sans antialiased bg-background text-foreground;
-    font-size: 14px;
+    font-size: 13px;
     line-height: 1.5;
     letter-spacing: -0.011em;
     font-feature-settings: "cv11", "ss01";

--- a/client/src/lib/activityTargetRoute.test.ts
+++ b/client/src/lib/activityTargetRoute.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getActivityTargetRoute } from "./activityTargetRoute";
+
+test("activity routes point to PatchDeck pages instead of external targets", () => {
+  assert.equal(getActivityTargetRoute("babysit_pr"), "/prs");
+  assert.equal(getActivityTargetRoute("answer_pr_question"), "/prs");
+  assert.equal(getActivityTargetRoute("work_issue"), "/issues");
+  assert.equal(getActivityTargetRoute("evaluate_issue"), "/issues");
+  assert.equal(getActivityTargetRoute("verify_issue"), "/issues");
+  assert.equal(getActivityTargetRoute("process_release_run"), "/releases");
+});
+
+test("background-only activities do not render as navigable links", () => {
+  assert.equal(getActivityTargetRoute("sync_watched_repos"), null);
+  assert.equal(getActivityTargetRoute("heal_deployment"), null);
+  assert.equal(getActivityTargetRoute("generate_social_changelog"), null);
+});

--- a/client/src/lib/activityTargetRoute.ts
+++ b/client/src/lib/activityTargetRoute.ts
@@ -1,0 +1,20 @@
+import type { BackgroundJobKind } from "@shared/schema";
+
+export function getActivityTargetRoute(kind: BackgroundJobKind): string | null {
+  switch (kind) {
+    case "babysit_pr":
+    case "answer_pr_question":
+      return "/prs";
+    case "evaluate_issue":
+    case "verify_issue":
+    case "work_issue":
+      return "/issues";
+    case "process_release_run":
+      return "/releases";
+    case "sync_watched_repos":
+    case "heal_deployment":
+    case "generate_social_changelog":
+    default:
+      return null;
+  }
+}

--- a/client/src/lib/prListCache.test.ts
+++ b/client/src/lib/prListCache.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PRSummary } from "@shared/schema";
+import {
+  PR_LIST_CACHE_RETENTION_MS,
+  PR_LIST_STALE_MS,
+  readCachedPRs,
+  writeCachedPRs,
+} from "./prListCache";
+
+class FakeStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+const samplePR: PRSummary = {
+  id: "pr-1",
+  number: 42,
+  title: "Fix PR monitor",
+  body: null,
+  bodyHtml: null,
+  repo: "acme/widgets",
+  branch: "fix/pr-monitor",
+  author: "alice",
+  url: "https://github.com/acme/widgets/pull/42",
+  status: "watching",
+  accepted: 0,
+  rejected: 0,
+  flagged: 0,
+  testsPassed: null,
+  lintPassed: null,
+  mergeableState: null,
+  lastChecked: null,
+  lastSyncAttemptedAt: null,
+  lastSyncSucceededAt: null,
+  lastSyncError: null,
+  watchEnabled: true,
+  addedAt: "2026-05-18T12:00:00.000Z",
+};
+
+test("PR list cache round-trips schema-valid summaries", () => {
+  const storage = new FakeStorage();
+  const now = 1_000_000;
+
+  writeCachedPRs("active", [samplePR], {
+    storage,
+    now: () => now,
+  });
+
+  const cached = readCachedPRs("active", {
+    storage,
+    now: () => now + PR_LIST_STALE_MS + 1,
+  });
+
+  assert.deepEqual(cached, {
+    data: [samplePR],
+    updatedAt: now,
+  });
+});
+
+test("PR list cache drops invalid payloads", () => {
+  const storage = new FakeStorage();
+  storage.setItem("patchdeck:prs-cache:v1:archived", JSON.stringify({
+    data: [{ id: "missing-required-fields" }],
+    updatedAt: 1_000_000,
+  }));
+
+  assert.equal(readCachedPRs("archived", { storage, now: () => 1_000_001 }), null);
+  assert.equal(storage.getItem("patchdeck:prs-cache:v1:archived"), null);
+});
+
+test("PR list cache retains stale data only within the retention window", () => {
+  const storage = new FakeStorage();
+  writeCachedPRs("active", [samplePR], {
+    storage,
+    now: () => 1_000_000,
+  });
+
+  assert.notEqual(
+    readCachedPRs("active", {
+      storage,
+      now: () => 1_000_000 + PR_LIST_CACHE_RETENTION_MS,
+    }),
+    null,
+  );
+  assert.equal(
+    readCachedPRs("active", {
+      storage,
+      now: () => 1_000_000 + PR_LIST_CACHE_RETENTION_MS + 1,
+    }),
+    null,
+  );
+});

--- a/client/src/lib/prListCache.ts
+++ b/client/src/lib/prListCache.ts
@@ -1,0 +1,79 @@
+import { prSummarySchema, type PRSummary } from "@shared/schema";
+
+export type PRListCacheView = "active" | "archived";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export const PR_LIST_STALE_MS = 15 * 60 * 1000;
+export const PR_LIST_CACHE_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+function getStorage(storage?: StorageLike | null): StorageLike | null {
+  if (storage !== undefined) return storage;
+  if (typeof window === "undefined") return null;
+  return window.localStorage;
+}
+
+function cacheKey(view: PRListCacheView): string {
+  return `patchdeck:prs-cache:v1:${view}`;
+}
+
+export function readCachedPRs(
+  view: PRListCacheView,
+  options: {
+    storage?: StorageLike | null;
+    now?: () => number;
+    maxAgeMs?: number;
+  } = {},
+): { data: PRSummary[]; updatedAt: number } | null {
+  const storage = getStorage(options.storage);
+  if (!storage) return null;
+
+  const now = options.now ?? Date.now;
+  const maxAgeMs = options.maxAgeMs ?? PR_LIST_CACHE_RETENTION_MS;
+  try {
+    const raw = storage.getItem(cacheKey(view));
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as { data?: unknown; updatedAt?: unknown };
+    if (!parsed.data || typeof parsed.updatedAt !== "number" || !Number.isFinite(parsed.updatedAt)) {
+      storage.removeItem(cacheKey(view));
+      return null;
+    }
+
+    if (now() - parsed.updatedAt > maxAgeMs) {
+      return null;
+    }
+
+    const normalized = prSummarySchema.array().safeParse(parsed.data);
+    if (!normalized.success) {
+      storage.removeItem(cacheKey(view));
+      return null;
+    }
+
+    return { data: normalized.data, updatedAt: parsed.updatedAt };
+  } catch {
+    storage.removeItem(cacheKey(view));
+    return null;
+  }
+}
+
+export function writeCachedPRs(
+  view: PRListCacheView,
+  data: PRSummary[],
+  options: {
+    storage?: StorageLike | null;
+    now?: () => number;
+  } = {},
+): void {
+  const storage = getStorage(options.storage);
+  if (!storage) return;
+
+  try {
+    storage.setItem(cacheKey(view), JSON.stringify({
+      data,
+      updatedAt: (options.now ?? Date.now)(),
+    }));
+  } catch {
+    // Best-effort cache only.
+  }
+}

--- a/client/src/lib/prReadiness.test.ts
+++ b/client/src/lib/prReadiness.test.ts
@@ -115,3 +115,15 @@ test("buildPRReadinessChecks explains why a PR is not ready", () => {
   ]);
   assert.match(checks.find((check) => check.key === "comments")?.detail ?? "", /1 tracked feedback item/);
 });
+
+test("buildPRReadinessChecks reports queued automation instead of idle", () => {
+  const checks = buildPRReadinessChecks(makePr({ status: "error" }), {
+    label: "up next",
+    detail: "starts in ~5m",
+  });
+
+  const workState = checks.find((check) => check.key === "work-state");
+  assert.equal(workState?.label, "Automation queued");
+  assert.equal(workState?.passed, false);
+  assert.equal(workState?.detail, "starts in ~5m");
+});

--- a/client/src/lib/prReadiness.test.ts
+++ b/client/src/lib/prReadiness.test.ts
@@ -68,8 +68,10 @@ test("isGitHubReadyToMerge only treats GitHub clean state as ready", () => {
   assert.equal(isGitHubReadyToMerge({ mergeableState: null }), false);
 });
 
-test("isPRDetailReadyToMerge requires idle work, checks, lint, resolved comments, and GitHub ready state", () => {
+test("isPRDetailReadyToMerge requires idle work, no known check failures, resolved comments, and GitHub ready state", () => {
   assert.equal(isPRDetailReadyToMerge(makePr()), true);
+  assert.equal(isPRDetailReadyToMerge(makePr({ testsPassed: null })), true);
+  assert.equal(isPRDetailReadyToMerge(makePr({ lintPassed: null })), true);
   assert.equal(isPRDetailReadyToMerge(makePr({ testsPassed: false })), false);
   assert.equal(isPRDetailReadyToMerge(makePr({ lintPassed: false })), false);
   assert.equal(isPRDetailReadyToMerge(makePr({ mergeableState: "blocked" })), false);
@@ -84,8 +86,10 @@ test("isPRSummaryReadyToMerge uses stored checks and GitHub ready state", () => 
 
   assert.equal(isPRSummaryReadyToMerge(base satisfies PRSummary), true);
   assert.equal(isPRSummaryReadyToMerge({ ...base, status: "watching" }), true);
-  assert.equal(isPRSummaryReadyToMerge({ ...base, testsPassed: null }), false);
-  assert.equal(isPRSummaryReadyToMerge({ ...base, lintPassed: null }), false);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, testsPassed: null }), true);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, lintPassed: null }), true);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, testsPassed: false }), false);
+  assert.equal(isPRSummaryReadyToMerge({ ...base, lintPassed: false }), false);
   assert.equal(isPRSummaryReadyToMerge({ ...base, mergeableState: "unstable" }), false);
   assert.equal(isPRSummaryReadyToMerge({ ...base, status: "processing" }), false);
 });
@@ -105,7 +109,7 @@ test("buildPRReadinessChecks explains why a PR is not ready", () => {
   assert.deepEqual(checks.map((check) => [check.key, check.passed]), [
     ["work-state", false],
     ["tests", false],
-    ["lint", false],
+    ["lint", true],
     ["comments", false],
     ["github", false],
   ]);

--- a/client/src/lib/prReadiness.ts
+++ b/client/src/lib/prReadiness.ts
@@ -8,6 +8,11 @@ export type PRReadinessCheck = {
   detail: string;
 };
 
+export type PRReadinessWorkStatus = {
+  label: string;
+  detail: string | null;
+} | null;
+
 export function isGitHubReadyToMerge(pr: Pick<PRSummary, "mergeableState">): boolean {
   return pr.mergeableState === "clean";
 }
@@ -37,18 +42,26 @@ export function isPRDetailReadyToMerge(
 
 export function buildPRReadinessChecks(
   pr: Pick<PR, "status" | "testsPassed" | "lintPassed" | "mergeableState" | "feedbackItems">,
+  workStatus: PRReadinessWorkStatus = null,
 ): PRReadinessCheck[] {
   const feedbackResolved = arePRFeedbackItemsResolved(pr.feedbackItems);
   const unresolvedCount = pr.feedbackItems.filter((item) =>
     item.status !== "resolved" && item.status !== "rejected"
   ).length;
+  const workActive = pr.status === "processing" || workStatus !== null;
 
   return [
     {
       key: "work-state",
-      label: "Automation idle",
-      passed: pr.status !== "processing",
-      detail: pr.status === "processing" ? "A work run is still active." : "No active work run.",
+      label: workStatus?.label === "running"
+        ? "Automation running"
+        : workStatus
+          ? "Automation queued"
+          : "Automation idle",
+      passed: !workActive,
+      detail: workStatus
+        ? workStatus.detail ?? "A work run is queued."
+        : pr.status === "processing" ? "A work run is still active." : "No active work run.",
     },
     {
       key: "tests",

--- a/client/src/lib/prReadiness.ts
+++ b/client/src/lib/prReadiness.ts
@@ -18,8 +18,8 @@ export function isPRSummaryReadyToMerge(
   return pr.status !== "processing"
     && pr.status !== "error"
     && pr.status !== "archived"
-    && pr.testsPassed === true
-    && pr.lintPassed === true
+    && pr.testsPassed !== false
+    && pr.lintPassed !== false
     && isGitHubReadyToMerge(pr);
 }
 
@@ -29,8 +29,8 @@ export function isPRDetailReadyToMerge(
   return pr.status !== "processing"
     && pr.status !== "error"
     && pr.status !== "archived"
-    && pr.testsPassed === true
-    && pr.lintPassed === true
+    && pr.testsPassed !== false
+    && pr.lintPassed !== false
     && isGitHubReadyToMerge(pr)
     && arePRFeedbackItemsResolved(pr.feedbackItems);
 }
@@ -53,22 +53,24 @@ export function buildPRReadinessChecks(
     {
       key: "tests",
       label: "Tests passing",
-      passed: pr.testsPassed === true,
+      passed: pr.testsPassed !== false && isGitHubReadyToMerge(pr),
       detail: pr.testsPassed === true
         ? "Latest test result passed."
         : pr.testsPassed === false
           ? "Latest test result failed."
-          : "No test result synced yet.",
+          : pr.mergeableState === "clean"
+            ? "GitHub reports required checks are passing."
+            : "No test result synced yet.",
     },
     {
       key: "lint",
       label: "Lint passing",
-      passed: pr.lintPassed === true,
+      passed: pr.lintPassed !== false,
       detail: pr.lintPassed === true
         ? "Latest lint result passed."
         : pr.lintPassed === false
           ? "Latest lint result failed."
-          : "No lint result synced yet.",
+          : "No separate lint result synced yet.",
     },
     {
       key: "comments",

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, type KeyboardEvent, type RefObject } from "react";
 import { Link, useLocation } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, ExternalLink, GitPullRequest, ListTodo, Loader2 } from "lucide-react";
-import type { ActivityItem, ActivitySnapshot, BackgroundJobKind, Config, IssueListPage, PR } from "@shared/schema";
+import type { ActivityItem, ActivitySnapshot, Config, IssueListPage, PR } from "@shared/schema";
 import { fetchJson } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ACTIVITY_POLL_INTERVAL_MS } from "@/lib/polling";
 import { getActivityIdleReason } from "@/lib/activityIdle";
 import { formatActivityDetail, formatActivityLabel } from "@/lib/activityDisplay";
+import { getActivityTargetRoute } from "@/lib/activityTargetRoute";
 
 type PRBreakdown = {
   total: number;
@@ -44,25 +45,6 @@ function buildPRBreakdown(prs: PR[]): PRBreakdown {
   return result;
 }
 
-function activityTargetRoute(kind: BackgroundJobKind): string | null {
-  switch (kind) {
-    case "babysit_pr":
-    case "answer_pr_question":
-      return "/prs";
-    case "evaluate_issue":
-    case "verify_issue":
-    case "work_issue":
-      return "/issues";
-    case "process_release_run":
-      return "/releases";
-    case "sync_watched_repos":
-    case "heal_deployment":
-    case "generate_social_changelog":
-    default:
-      return null;
-  }
-}
-
 function ActivityRow({ item, accent, leadingIcon, timeRef }: {
   item: ActivityItem;
   accent?: "destructive" | "warning" | "neutral";
@@ -70,7 +52,7 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
   timeRef?: "queuedAt" | "startedAt" | "updatedAt";
 }) {
   const [, setLocation] = useLocation();
-  const route = activityTargetRoute(item.kind);
+  const route = getActivityTargetRoute(item.kind);
   const timestamp = timeRef === "queuedAt"
     ? item.queuedAt
     : timeRef === "startedAt"
@@ -81,8 +63,8 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
   const detail = formatActivityDetail(item.detail);
 
   const labelClass = accent === "destructive"
-    ? "inline-flex items-center gap-1 truncate text-[12px] font-medium text-destructive"
-    : "inline-flex items-center gap-1 truncate text-[12px] text-foreground";
+    ? "inline-flex items-center gap-1 truncate text-body font-medium text-destructive"
+    : "inline-flex items-center gap-1 truncate text-body text-foreground";
 
   const handleNavigate = () => {
     if (!route) return;
@@ -121,21 +103,21 @@ function ActivityRow({ item, accent, leadingIcon, timeRef }: {
           {leadingIcon}
           {label}
         </span>
-        <span className="font-mono text-[10px] text-muted-foreground">{formatRelative(timestamp)}</span>
+        <span className="font-mono text-label text-muted-foreground">{formatRelative(timestamp)}</span>
       </div>
       {detail && (
-        <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{detail}</div>
+        <div className="mt-0.5 truncate text-label text-muted-foreground">{detail}</div>
       )}
       {errorMessage && (
         <div
           title={errorMessage}
-          className="mt-1 line-clamp-2 break-words text-[11px] leading-snug text-destructive/85"
+          className="mt-1 line-clamp-2 break-words text-label leading-snug text-destructive/85"
         >
           {errorMessage}
         </div>
       )}
       {(route || item.targetUrl) && (
-        <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-label uppercase tracking-wider text-muted-foreground">
           {route && (
             <span className="inline-flex items-center gap-1 text-primary">
               open {route === "/prs" ? "PR" : route === "/issues" ? "issue" : "page"} →
@@ -225,16 +207,16 @@ function KpiCell({
         aria-label="Jump to failed activity"
         className={`${baseClass} text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring`}
       >
-        <div className="text-[10px] font-medium uppercase tracking-wider opacity-80">{label}</div>
-        <div className="font-mono text-xl leading-none">{value}</div>
+        <div className="text-label font-medium uppercase tracking-wider opacity-80">{label}</div>
+        <div className="font-mono text-display leading-none">{value}</div>
       </button>
     );
   }
 
   return (
     <div data-testid={testId} className={baseClass}>
-      <div className="text-[10px] font-medium uppercase tracking-wider opacity-80">{label}</div>
-      <div className="font-mono text-xl leading-none">{value}</div>
+      <div className="text-label font-medium uppercase tracking-wider opacity-80">{label}</div>
+      <div className="font-mono text-display leading-none">{value}</div>
     </div>
   );
 }
@@ -249,7 +231,7 @@ function RepoCard({ stats }: { stats: RepoStats }) {
       chip={(
         <Link
           href={linkHref}
-          className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          className="font-mono text-label uppercase tracking-wider text-muted-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         >
           open →
         </Link>
@@ -257,7 +239,7 @@ function RepoCard({ stats }: { stats: RepoStats }) {
     >
       <div className="space-y-2 px-3 py-2.5">
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span className="inline-flex items-center gap-1 text-label uppercase tracking-wider text-muted-foreground">
             <GitPullRequest className="h-3 w-3" /> PRs
           </span>
           <StatusChip tone="neutral" label={`${prCounts.total} total`} />
@@ -275,7 +257,7 @@ function RepoCard({ stats }: { stats: RepoStats }) {
           )}
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <span className="inline-flex items-center gap-1 text-label uppercase tracking-wider text-muted-foreground">
             <ListTodo className="h-3 w-3" /> Issues
           </span>
           <StatusChip tone="neutral" label={`${issueCount} open`} />
@@ -299,11 +281,11 @@ function DashboardActivityPanel({
           title="Failed"
           tone={activities.failed.length > 0 ? "destructive" : "neutral"}
           testId="dashboard-activity-failed"
-          chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.failed.length}</span>}
+          chip={<span className="font-mono text-label text-muted-foreground">{activities.failed.length}</span>}
         >
           <div className="max-h-72 overflow-y-auto">
             {activities.failed.length === 0 ? (
-              <div className="px-3 py-2 text-[12px] text-muted-foreground">No failures.</div>
+              <div className="px-3 py-2 text-body text-muted-foreground">No failures.</div>
             ) : (
               activities.failed.slice(0, 12).map((item) => (
                 <ActivityRow
@@ -322,11 +304,11 @@ function DashboardActivityPanel({
         title="In progress"
         tone={activities.inProgress.length > 0 ? "warning" : "neutral"}
         testId="dashboard-activity-in-progress"
-        chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.inProgress.length}</span>}
+        chip={<span className="font-mono text-label text-muted-foreground">{activities.inProgress.length}</span>}
       >
         <div className="max-h-48 overflow-y-auto">
           {activities.inProgress.length === 0 ? (
-            <div className="px-3 py-2 text-[12px] text-muted-foreground">{idleReason ?? "No active jobs."}</div>
+            <div className="px-3 py-2 text-body text-muted-foreground">{idleReason ?? "No active jobs."}</div>
           ) : (
             activities.inProgress.slice(0, 8).map((item) => (
               <ActivityRow
@@ -343,11 +325,11 @@ function DashboardActivityPanel({
       <DetailPanel
         title="Queued"
         testId="dashboard-activity-queued"
-        chip={<span className="font-mono text-[10px] text-muted-foreground">{activities.queued.length}</span>}
+        chip={<span className="font-mono text-label text-muted-foreground">{activities.queued.length}</span>}
       >
         <div className="max-h-48 overflow-y-auto">
           {activities.queued.length === 0 ? (
-            <div className="px-3 py-2 text-[12px] text-muted-foreground">{idleReason ? "No work is queued." : "Queue is empty."}</div>
+            <div className="px-3 py-2 text-body text-muted-foreground">{idleReason ? "No work is queued." : "Queue is empty."}</div>
           ) : (
             activities.queued.slice(0, 8).map((item) => (
               <ActivityRow key={item.id} item={item} timeRef="queuedAt" />
@@ -463,7 +445,7 @@ export default function Dashboard() {
 
           <div className="grid gap-4 lg:grid-cols-[1fr_24rem]">
             <section aria-label="Repository overview">
-              <div className="border-b border-border pb-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <div className="border-b border-border pb-2 text-label uppercase tracking-wider text-muted-foreground">
                 Repositories
                 {watchedRepos.length > 0 && (
                   <span className="ml-2 font-mono text-foreground/80">({watchedRepos.length})</span>
@@ -478,13 +460,13 @@ export default function Dashboard() {
               ) : watchedRepos.length === 0 ? (
                 <div
                   data-testid="dashboard-empty-repos"
-                  className="mt-3 flex flex-col items-start gap-2 rounded-md border border-dashed border-border bg-muted/10 px-4 py-6 text-[12px] text-muted-foreground"
+                  className="mt-3 flex flex-col items-start gap-2 rounded-md border border-dashed border-border bg-muted/10 px-4 py-6 text-body text-muted-foreground"
                 >
                   <AlertTriangle className="h-4 w-4 text-warning-foreground" />
                   <div>No repositories are being watched yet.</div>
                   <Link
                     href="/settings"
-                    className="text-[11px] uppercase tracking-wider text-primary underline decoration-border underline-offset-2 hover:text-primary/90"
+                    className="text-label uppercase tracking-wider text-primary underline decoration-border underline-offset-2 hover:text-primary/90"
                   >
                     Add a repo in settings →
                   </Link>
@@ -499,7 +481,7 @@ export default function Dashboard() {
             </section>
 
             <aside aria-label="Activity">
-              <div className="border-b border-border pb-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <div className="border-b border-border pb-2 text-label uppercase tracking-wider text-muted-foreground">
                 Activity
               </div>
               <div className="mt-3">

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -372,7 +372,7 @@ function IssueRow({
           target="_blank"
           rel="noreferrer noopener"
           data-testid="issue-ready-to-merge-list"
-          className={`mt-2 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${toneClass}`}
+          className={`mt-2 inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${toneClass}`}
         >
           <ExternalLink className="h-3 w-3" />
           PR <span className="font-mono">#{issue.workPrNumber}</span>
@@ -390,7 +390,7 @@ function IssueRow({
             target="_blank"
             rel="noreferrer noopener"
             data-testid="issue-external-pr-list"
-            className="mt-2 inline-flex items-center gap-1 rounded-md border border-warning-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="mt-2 inline-flex items-center gap-1 rounded-md border border-warning-border px-2 py-0.5 text-label uppercase tracking-wider text-warning-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           >
             <ExternalLink className="h-3 w-3" />
             PR <span className="font-mono">#{issue.externalWorkPrNumber}</span>
@@ -401,7 +401,7 @@ function IssueRow({
         ? (
           <div
             data-testid="issue-work-in-progress-list"
-            className="mt-2 inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground"
+            className="mt-2 inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground"
           >
             {issue.workStatus === "in_progress" ? <Loader2 className="h-3 w-3 animate-spin" /> : <span className="h-3 w-3" />}
             {formatIssueWorkStage(issue)}
@@ -425,16 +425,16 @@ function IssueRow({
       >
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-medium">{issue.title}</span>
+            <span className="truncate text-body font-medium">{issue.title}</span>
             {showInlineStatusBadge && <IssueStatusBadge issue={issue} />}
           </div>
-          <div className="mt-1 text-[11px] text-muted-foreground">
+          <div className="mt-1 text-label text-muted-foreground">
             {issue.repo} <span className="font-mono text-foreground/70">#{issue.number}</span>
           </div>
-          <div className="mt-0.5 text-[11px] text-muted-foreground">
+          <div className="mt-0.5 text-label text-muted-foreground">
             by {formatGitHubUsername(issue.author)}
           </div>
-          <div className="mt-1 line-clamp-2 text-[12px] leading-5 text-muted-foreground">
+          <div className="mt-1 line-clamp-2 text-body leading-5 text-muted-foreground">
             {formatBodyPreview(issue.body)}
           </div>
           <div className="mt-2 flex flex-wrap gap-1">
@@ -464,18 +464,18 @@ function IssueRow({
               />
             )}
             {visibleLabels.slice(0, 3).map((label) => (
-              <span key={label} className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+              <span key={label} className="border border-border px-1.5 py-0 text-label uppercase tracking-wider text-muted-foreground">
                 {label}
               </span>
             ))}
             {visibleLabels.length > 3 && (
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              <span className="text-label uppercase tracking-wider text-muted-foreground">
                 +{visibleLabels.length - 3}
               </span>
             )}
           </div>
         </div>
-        <span className="shrink-0 text-[11px] text-muted-foreground">
+        <span className="shrink-0 text-label text-muted-foreground">
           {formatDateTime(issue.updatedAt)}
         </span>
       </button>
@@ -492,7 +492,7 @@ function VerifyStateBadge({ state }: { state: VerifyState }) {
     <span
       data-testid="issue-verify-state-badge"
       data-verify-state={state}
-      className={`inline-flex items-center gap-1 border px-1.5 py-0 text-[10px] uppercase tracking-wider ${
+      className={`inline-flex items-center gap-1 border px-1.5 py-0 text-label uppercase tracking-wider ${
         isPending
           ? "border-primary/60 bg-primary/10 text-primary animate-pulse"
           : "border-success-border bg-success-muted text-success-foreground"
@@ -544,7 +544,7 @@ function SubtaskListPanel({ subtasks }: { subtasks: IssueSubtask[] }) {
       title="Subtasks"
       testId="issue-subtasks"
       chip={(
-        <span className="font-mono text-[10px] text-muted-foreground">
+        <span className="font-mono text-label text-muted-foreground">
           {doneCount} / {subtasks.length} done
         </span>
       )}
@@ -562,18 +562,18 @@ function SubtaskListPanel({ subtasks }: { subtasks: IssueSubtask[] }) {
             </span>
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
-                <span className="truncate text-[12px] font-medium text-foreground">{task.title}</span>
-                <span className="border border-border/60 px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+                <span className="truncate text-body font-medium text-foreground">{task.title}</span>
+                <span className="border border-border/60 px-1.5 py-0 text-label uppercase tracking-wider text-muted-foreground">
                   {task.status}
                 </span>
               </div>
               {task.summary && (
-                <div className="mt-0.5 text-[11px] leading-5 text-muted-foreground">
+                <div className="mt-0.5 text-label leading-5 text-muted-foreground">
                   {task.summary}
                 </div>
               )}
               {task.statusReason && (
-                <div className="mt-1 text-[11px] italic leading-5 text-foreground/70">
+                <div className="mt-1 text-label italic leading-5 text-foreground/70">
                   {task.statusReason}
                 </div>
               )}
@@ -592,16 +592,16 @@ function IssueLogRow({ entry }: { entry: LogEntry }) {
     <div className="border-b border-border/60 px-3 py-2 last:border-b-0">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[12px] text-foreground">{entry.message}</div>
-          {entry.phase && <div className="mt-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">{entry.phase}</div>}
+          <div className="text-body text-foreground">{entry.message}</div>
+          {entry.phase && <div className="mt-0.5 text-label uppercase tracking-wider text-muted-foreground">{entry.phase}</div>}
         </div>
-        <span className="shrink-0 text-[10px] text-muted-foreground">{formatDateTime(entry.timestamp)}</span>
+        <span className="shrink-0 text-label text-muted-foreground">{formatDateTime(entry.timestamp)}</span>
       </div>
       {metadataEntries.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {metadataEntries.map((field) => {
             const content = (
-              <span className="inline-flex max-w-full items-center gap-1 border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+              <span className="inline-flex max-w-full items-center gap-1 border border-border/60 px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground">
                 <span className="shrink-0 text-foreground/70">{field.label}:</span>
                 <span className="min-w-0 truncate normal-case tracking-normal text-foreground/85">{field.value}</span>
                 {field.href && <ExternalLink className="h-3 w-3 shrink-0" />}
@@ -680,7 +680,7 @@ function IssueLogPanel({
     <div className="flex max-h-[42dvh] min-h-0 w-full shrink-0 flex-col border-t border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
       <div className="flex shrink-0 items-center border-b border-border">
         <div
-          className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+          className="flex-1 bg-muted px-3 py-2 text-label uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
           data-testid="tab-issue-activity"
         >
           Activity
@@ -699,27 +699,27 @@ function IssueLogPanel({
       <GlobalActivityPanel activities={activities} queueStatusById={queueStatusById} idleReason={idleReason} />
       <div className="flex-1 overflow-y-auto" data-testid="issue-detail-logs">
         {!selected ? (
-          <div className="p-4 text-[12px] text-muted-foreground">
+          <div className="p-4 text-body text-muted-foreground">
             Select an issue to see logs.
           </div>
         ) : logs.length === 0 ? (
-          <div className="p-4 text-[12px] text-muted-foreground">
+          <div className="p-4 text-body text-muted-foreground">
             No workflow logs yet.
           </div>
         ) : viewLogs.length === 0 ? (
-          <div className="p-4 text-[12px] text-muted-foreground">
+          <div className="p-4 text-body text-muted-foreground">
             View cleared. New log entries will appear here.
           </div>
         ) : (
           <>
             <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              <span className="text-label uppercase tracking-wider text-muted-foreground">
                 {viewLogs.length} visible
               </span>
               <button
                 type="button"
                 onClick={() => setClearedLogIds(new Set(logs.map((log) => log.id)))}
-                className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
                 Clear view
               </button>
@@ -754,8 +754,8 @@ class IssuesErrorBoundary extends Component<{ children: ReactNode }, IssuesError
     if (this.state.hasError) {
       return (
         <div className="flex min-h-screen items-center justify-center bg-background p-6">
-          <div className="max-w-2xl border border-destructive/40 bg-destructive/10 p-4 text-[12px] text-destructive">
-            <div className="text-[11px] uppercase tracking-wider text-destructive/80">Issues UI runtime error</div>
+          <div className="max-w-2xl border border-destructive/40 bg-destructive/10 p-4 text-body text-destructive">
+            <div className="text-label uppercase tracking-wider text-destructive/80">Issues UI runtime error</div>
             <pre className="mt-2 whitespace-pre-wrap break-words">{this.state.message || "Unknown render error"}</pre>
           </div>
         </div>
@@ -1415,7 +1415,7 @@ function IssuesPage() {
             </span>
             <span><span className="font-mono text-foreground">{activeIssueCount}</span> active</span>
             {runtime?.drainMode && (
-              <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+              <span className="rounded-md border border-border px-1.5 py-0.5 text-label uppercase tracking-wider text-muted-foreground">
                 paused
               </span>
             )}
@@ -1430,7 +1430,7 @@ function IssuesPage() {
                   setAreErrorsRolledUp(false);
                   scrollToDashboardErrors();
                 }}
-                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-[11px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                 data-testid="issues-error-pill"
               >
                 <AlertTriangle className="h-3 w-3" aria-hidden="true" />
@@ -1444,7 +1444,7 @@ function IssuesPage() {
               disabled={isSyncingRepos || globalDrainMode || isGitHubThrottled}
               title={isGitHubThrottled ? throttledTitle : undefined}
               data-testid="button-sync-issues"
-              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
             >
               {globalDrainMode ? <span className="h-3.5 w-3.5" /> : (isSyncingRepos || isFetching) ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
               {globalDrainMode ? "paused" : "sync"}
@@ -1474,7 +1474,7 @@ function IssuesPage() {
 
       <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
         <div className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-[34rem] xl:w-[36rem] lg:border-b-0 lg:border-r">
-          <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+          <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2 text-label uppercase tracking-wider text-muted-foreground">
             <div>
               Watched issues
               <span className="ml-2 normal-case tracking-normal text-muted-foreground/80">
@@ -1505,7 +1505,7 @@ function IssuesPage() {
                         : `Queue work for ${startableVisibleIssues.length} visible issue${startableVisibleIssues.length === 1 ? "" : "s"}`
                 }
                 data-testid="button-start-visible-issue-work"
-                className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary px-2 py-0.5 text-[10px] uppercase tracking-wider text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary px-2 py-0.5 text-label uppercase tracking-wider text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {startVisibleWorkMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Wrench className="h-3 w-3" />}
                 {startVisibleWorkMutation.isPending ? "queuing safely" : `queue work (${startableVisibleIssues.length})`}
@@ -1516,7 +1516,7 @@ function IssuesPage() {
                 disabled={isSyncingRepos || globalDrainMode || isGitHubThrottled}
                 title={isGitHubThrottled ? throttledTitle : undefined}
                 data-testid="button-full-sweep-issues"
-                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
               >
                 {globalDrainMode ? "paused" : "full sweep"}
               </button>
@@ -1532,7 +1532,7 @@ function IssuesPage() {
               }}
               className="flex flex-wrap items-start gap-2"
             >
-              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="mt-1 w-14 shrink-0 text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Pull
               </span>
               <div className="flex min-w-0 flex-1 flex-wrap gap-1">
@@ -1543,13 +1543,13 @@ function IssuesPage() {
                   onChange={(event) => setManualPullNumber(event.target.value)}
                   placeholder={`# for ${manualPullRepoHint}`}
                   data-testid="input-manual-issue-pr-number"
-                  className="h-7 min-w-[11rem] flex-1 rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  className="h-7 min-w-[11rem] flex-1 rounded-md border border-border bg-background px-2 font-mono text-body text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
                 <button
                   type="submit"
                   disabled={!canManualPull || manualPullIssueMutation.isPending}
                   data-testid="button-pull-issue-number"
-                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-label uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   {manualPullIssueMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
                   Pull issue
@@ -1563,7 +1563,7 @@ function IssuesPage() {
                   }}
                   disabled={!canManualPull || manualPullPrMutation.isPending}
                   data-testid="button-pull-pr-number"
-                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                  className="inline-flex h-7 items-center gap-1 rounded-md border border-border px-2 text-label uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   {manualPullPrMutation.isPending && <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />}
                   Pull PR
@@ -1571,7 +1571,7 @@ function IssuesPage() {
               </div>
             </form>
             <div className="flex flex-wrap items-start gap-2">
-              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="mt-1 w-14 shrink-0 text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Search
               </span>
               <label htmlFor="issue-number-search" className="sr-only">Search issue number</label>
@@ -1581,18 +1581,18 @@ function IssuesPage() {
                 onChange={(event) => setIssueNumberSearch(event.target.value)}
                 placeholder="Search #"
                 data-testid="issue-number-search"
-                className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 font-mono text-body text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
             <div className="flex flex-wrap items-start gap-2">
-              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="mt-1 w-14 shrink-0 text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Repo
               </span>
               <div className="flex min-w-0 flex-1 flex-wrap gap-1">
                 <button
                   type="button"
                   onClick={() => setSelectedRepo("all")}
-                  className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+                  className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                     selectedRepo === "all"
                       ? "border-primary bg-primary/10 text-primary"
                       : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1605,7 +1605,7 @@ function IssuesPage() {
                     key={repo}
                     type="button"
                     onClick={() => setSelectedRepo(repo)}
-                    className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+                    className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                       selectedRepo === repo
                         ? "border-primary bg-primary/10 text-primary"
                         : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1617,14 +1617,14 @@ function IssuesPage() {
               </div>
             </div>
             <div className="flex flex-wrap items-start gap-2">
-              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="mt-1 w-14 shrink-0 text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Status
               </span>
               <div className="flex min-w-0 flex-1 flex-wrap gap-1">
             <button
               type="button"
               onClick={() => setSelectedWorkFilter("ready")}
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "ready"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1636,7 +1636,7 @@ function IssuesPage() {
               type="button"
               onClick={() => setSelectedWorkFilter("worked")}
               data-testid="issue-worked-filter"
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "worked"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1648,7 +1648,7 @@ function IssuesPage() {
               type="button"
               onClick={() => setSelectedWorkFilter("auto")}
               data-testid="issue-auto-eligible-filter"
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "auto"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1660,7 +1660,7 @@ function IssuesPage() {
               type="button"
               onClick={() => setSelectedWorkFilter("needs_eval")}
               data-testid="issue-needs-evaluation-filter"
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "needs_eval"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1672,7 +1672,7 @@ function IssuesPage() {
               type="button"
               onClick={() => setSelectedWorkFilter("review")}
               data-testid="issue-review-filter"
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "review"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1684,7 +1684,7 @@ function IssuesPage() {
               type="button"
               onClick={() => setSelectedWorkFilter("failed")}
               data-testid="issue-failed-filter"
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "failed"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1696,7 +1696,7 @@ function IssuesPage() {
               type="button"
               onClick={() => setSelectedWorkFilter("stale")}
               data-testid="issue-stale-filter"
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "stale"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1707,7 +1707,7 @@ function IssuesPage() {
             <button
               type="button"
               onClick={() => setSelectedWorkFilter("all")}
-              className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+              className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                 selectedWorkFilter === "all"
                   ? "border-primary bg-primary/10 text-primary"
                   : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -1727,7 +1727,7 @@ function IssuesPage() {
                   ))}
                 </div>
               ) : visibleIssues.length === 0 ? (
-                <div className="p-4 text-[12px] text-muted-foreground">
+                <div className="p-4 text-body text-muted-foreground">
                   {normalizedIssueNumberSearch
                     ? `No issues match #${normalizedIssueNumberSearch}.`
                     : "No open issues found in watched repositories."}
@@ -1736,7 +1736,7 @@ function IssuesPage() {
                 <>
                   {repoGroups.map((group) => (
                     <div key={group.repo} className="border-b border-border/60 last:border-b-0">
-                      <div className="sticky top-0 z-10 border-b border-border bg-background px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                      <div className="sticky top-0 z-10 border-b border-border bg-background px-4 py-2 text-label font-medium uppercase tracking-wider text-muted-foreground">
                         {group.repo} <span className="font-mono text-foreground/70">({group.issues.length})</span>
                       </div>
                       {group.issues.map((issue) => (
@@ -1760,7 +1760,7 @@ function IssuesPage() {
                   {canLoadMore ? (
                     <div ref={loadMoreSentinelRef} className="border-t border-border/60 px-4 py-3" data-testid="issues-load-more-sentinel">
                       <div className="flex items-center justify-between gap-3">
-                        <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                        <span className="text-label uppercase tracking-wider text-muted-foreground">
                           Loaded <span className="font-mono text-foreground">{loadedScopeCount}</span>
                           {" "}of <span className="font-mono text-foreground">{totalScopeCount}</span>
                         </span>
@@ -1769,7 +1769,7 @@ function IssuesPage() {
                           onClick={() => { void loadMoreIssues(); }}
                           disabled={isLoadingMore || globalDrainMode}
                           data-testid="button-load-more-issues"
-                          className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+                          className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1 text-label uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           {isLoadingMore && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
                           Load more
@@ -1777,7 +1777,7 @@ function IssuesPage() {
                       </div>
                     </div>
                   ) : totalIssueCount > loadedIssueCount ? (
-                    <div className="border-t border-border/60 px-4 py-3 text-[11px] uppercase tracking-wider text-muted-foreground" data-testid="issues-loaded-count">
+                    <div className="border-t border-border/60 px-4 py-3 text-label uppercase tracking-wider text-muted-foreground" data-testid="issues-loaded-count">
                       Loaded <span className="font-mono text-foreground">{loadedScopeCount}</span>
                       {" "}of <span className="font-mono text-foreground">{totalScopeCount}</span>
                     </div>
@@ -1856,7 +1856,7 @@ function IssuesPage() {
                       disabled={syncIssueMutation.isPending || Boolean(runtime?.drainMode)}
                       title={runtime?.drainMode ? "Issue sync is paused by drain mode" : "Sync issue from GitHub now"}
                       data-testid="button-sync-issue"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {syncIssueMutation.isPending ? (
                         <>
@@ -1876,7 +1876,7 @@ function IssuesPage() {
                       disabled={evaluateMutation.isPending || Boolean(runtime?.drainMode)}
                       title={runtime?.drainMode ? "Issue evaluation is paused by drain mode" : "Evaluate this issue for auto work"}
                       data-testid="button-evaluate-issue"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {evaluateMutation.isPending ? (
                         <>
@@ -1902,7 +1902,7 @@ function IssuesPage() {
                             : "Queue this issue for work"
                       }
                       data-testid="button-work-issue"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {workMutation.isPending ? (
                         <>
@@ -1935,7 +1935,7 @@ function IssuesPage() {
                             : "Check the work PR diff against this issue's subtasks"
                       }
                       data-testid="button-verify-issue"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {isVerifying ? (
                         <>
@@ -1961,7 +1961,7 @@ function IssuesPage() {
               <div className="px-4 py-3">
                 <div data-testid="issue-label-editor" className="flex flex-wrap items-center gap-1">
                   {selectedIssue.labels.length > 0 ? selectedIssue.labels.map((label) => (
-                    <span key={label} className="inline-flex max-w-full items-center gap-1 border border-border pl-1.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                    <span key={label} className="inline-flex max-w-full items-center gap-1 border border-border pl-1.5 text-label uppercase tracking-wider text-muted-foreground">
                       <span className="min-w-0 truncate">{label}</span>
                       <button
                         type="button"
@@ -1975,7 +1975,7 @@ function IssuesPage() {
                       </button>
                     </span>
                   )) : (
-                    <span className="text-[11px] text-muted-foreground">No labels</span>
+                    <span className="text-label text-muted-foreground">No labels</span>
                   )}
                   <form
                     className="ml-1 inline-flex items-center gap-1"
@@ -1993,7 +1993,7 @@ function IssuesPage() {
                       onChange={(event) => setLabelInput(event.target.value)}
                       placeholder="add label"
                       data-testid="issue-label-input"
-                      className="h-6 w-44 border border-border bg-background px-2 text-[11px] text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      className="h-6 w-44 border border-border bg-background px-2 text-label text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     />
                     <button
                       type="submit"
@@ -2020,13 +2020,13 @@ function IssuesPage() {
                       target="_blank"
                       rel="noreferrer noopener"
                       data-testid="issue-ready-to-merge"
-                      className={`mt-3 flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-[11px] transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${toneClass}`}
+                      className={`mt-3 flex items-center justify-between gap-3 rounded-md border px-3 py-2 text-label transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${toneClass}`}
                     >
                       <span className="min-w-0">
-                        <span className="block text-[10px] uppercase tracking-wider opacity-70">
+                        <span className="block text-label uppercase tracking-wider opacity-70">
                           {readiness.label}
                         </span>
-                        <span className="block truncate text-[12px] leading-5">
+                        <span className="block truncate text-body leading-5">
                           {readiness.detail}
                         </span>
                       </span>
@@ -2040,13 +2040,13 @@ function IssuesPage() {
                     target="_blank"
                     rel="noreferrer noopener"
                     data-testid="issue-external-pr"
-                    className="mt-3 flex items-center justify-between gap-3 rounded-md border border-warning-border bg-warning-muted px-3 py-2 text-[11px] text-warning-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                    className="mt-3 flex items-center justify-between gap-3 rounded-md border border-warning-border bg-warning-muted px-3 py-2 text-label text-warning-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                   >
                     <span className="min-w-0">
-                      <span className="block text-[10px] uppercase tracking-wider opacity-70">
+                      <span className="block text-label uppercase tracking-wider opacity-70">
                         Linked external PR
                       </span>
-                      <span className="block truncate text-[12px] leading-5">
+                      <span className="block truncate text-body leading-5">
                         {selectedIssue.externalWorkPrRepo ?? selectedIssue.repo} #{selectedIssue.externalWorkPrNumber}
                       </span>
                     </span>
@@ -2065,7 +2065,7 @@ function IssuesPage() {
                         disabled={clearFailuresMutation.isPending}
                         title="Clear failed issue work attempts"
                         data-testid="button-clear-issue-failures"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-destructive/50 bg-background/40 px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-destructive/50 bg-background/40 px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         {clearFailuresMutation.isPending ? (
                           <>
@@ -2081,7 +2081,7 @@ function IssuesPage() {
                       </button>
                     )}
                   >
-                    <div className="max-h-80 overflow-auto whitespace-pre-wrap px-3 py-2 text-[11px] leading-5 text-destructive">
+                    <div className="max-h-80 overflow-auto whitespace-pre-wrap px-3 py-2 text-label leading-5 text-destructive">
                       {selectedIssue.lastError}
                     </div>
                   </DetailPanel>
@@ -2101,20 +2101,20 @@ function IssuesPage() {
                     )}
                   >
                     <div className="px-3 py-2">
-                      <div className="text-[12px] leading-5 text-foreground/85">
+                      <div className="text-body leading-5 text-foreground/85">
                         {selectedIssue.evaluationSummary ?? selectedIssue.autoWorkBlockedReason ?? "Evaluate this issue before auto-mode can work it."}
                       </div>
                       <div className="mt-2 flex flex-wrap gap-1.5">
-                        <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                        <span className="border border-border/60 px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground">
                           auto: {selectedIssue.autoWorkEligible ? "enabled" : "blocked"}
                         </span>
                         {typeof selectedIssue.evaluationConfidence === "number" && (
-                          <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <span className="border border-border/60 px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground">
                             confidence: {formatEvaluationConfidence(selectedIssue.evaluationConfidence)}
                           </span>
                         )}
                         {selectedIssue.evaluationUpdatedAt && (
-                          <span className="border border-border/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <span className="border border-border/60 px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground">
                             evaluated: {formatDateTime(selectedIssue.evaluationUpdatedAt)}
                           </span>
                         )}
@@ -2122,7 +2122,7 @@ function IssuesPage() {
                       {selectedIssue.evaluationSafetyFlags && selectedIssue.evaluationSafetyFlags.length > 0 && (
                         <div className="mt-2 flex flex-wrap gap-1.5">
                           {selectedIssue.evaluationSafetyFlags.map((flag) => (
-                            <span key={flag} className="border border-destructive/40 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive">
+                            <span key={flag} className="border border-destructive/40 px-2 py-0.5 text-label uppercase tracking-wider text-destructive">
                               {flag}
                             </span>
                           ))}
@@ -2131,7 +2131,7 @@ function IssuesPage() {
                     </div>
                   </DetailPanel>
                 )}
-                <div className="mt-3 text-[11px] uppercase tracking-wider text-muted-foreground">
+                <div className="mt-3 text-label uppercase tracking-wider text-muted-foreground">
                   Issue body
                 </div>
                 {selectedIssue.bodyHtml ? (
@@ -2141,7 +2141,7 @@ function IssuesPage() {
                     dangerouslySetInnerHTML={{ __html: selectedIssue.bodyHtml }}
                   />
                 ) : (
-                  <pre className="mt-2 whitespace-pre-wrap break-words border border-border/60 bg-background p-4 text-[12px] leading-6 text-muted-foreground">
+                  <pre className="mt-2 whitespace-pre-wrap break-words border border-border/60 bg-background p-4 text-body leading-6 text-muted-foreground">
                     {selectedIssue.body?.trim() || "No body provided."}
                   </pre>
                 )}
@@ -2149,7 +2149,7 @@ function IssuesPage() {
               </div>
             </>
           ) : (
-            <div className="flex flex-1 items-center justify-center text-[12px] text-muted-foreground">
+            <div className="flex flex-1 items-center justify-center text-body text-muted-foreground">
               Select an issue from the left panel.
             </div>
           )}

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -245,7 +245,7 @@ export default function Logs() {
       <UpdateBanner />
       <AppHeader active="logs" />
 
-      <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-2 text-[11px]">
+      <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border px-4 py-2 text-label">
         <label htmlFor="logs-level" className="uppercase tracking-wider text-muted-foreground">level</label>
         <select
           id="logs-level"
@@ -319,28 +319,28 @@ export default function Logs() {
       </div>
 
       {error && (
-        <div className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-1 text-[11px] text-destructive">
+        <div className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-1 text-label text-destructive">
           {error}
         </div>
       )}
 
-      <div ref={containerRef} className="flex-1 overflow-y-auto p-3 font-mono text-[11px] leading-relaxed">
+      <div ref={containerRef} className="flex-1 overflow-y-auto p-3 font-mono text-label leading-relaxed">
         <div className="mb-3 border border-border/60">
-          <div className="border-b border-border/60 px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+          <div className="border-b border-border/60 px-2 py-1 text-label uppercase tracking-wider text-muted-foreground">
             Activity
           </div>
           <div className="max-h-56 overflow-y-auto">
             {activityItems.length === 0 ? (
-              <div className="px-2 py-2 text-[10px] text-muted-foreground">No automation running or queued.</div>
+              <div className="px-2 py-2 text-label text-muted-foreground">No automation running or queued.</div>
             ) : (
               activityItems.map((item) => (
                 <div key={item.id} className="border-b border-border/40 px-2 py-1.5 last:border-b-0">
-                  <div className="flex items-center justify-between gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  <div className="flex items-center justify-between gap-2 text-label uppercase tracking-wider text-muted-foreground">
                     <span>{item.kind.replace("_", " ")}</span>
                     <span>{item.status.replace("_", " ")}</span>
                   </div>
-                  <div className="mt-0.5 text-[11px] text-foreground/85">{item.label}</div>
-                  {item.detail && <div className="text-[10px] text-muted-foreground">{item.detail}</div>}
+                  <div className="mt-0.5 text-label text-foreground/85">{item.label}</div>
+                  {item.detail && <div className="text-label text-muted-foreground">{item.detail}</div>}
                 </div>
               ))
             )}

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -14,13 +14,13 @@ export default function NotFound() {
           <div className="flex items-start gap-3">
             <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-warning-foreground" aria-hidden="true" />
             <div className="min-w-0">
-              <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <div className="text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Not found
               </div>
-              <h1 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+              <h1 className="mt-1 text-title font-semibold tracking-tight text-foreground">
                 Page not found
               </h1>
-              <p className="mt-2 text-[12px] leading-5 text-muted-foreground">
+              <p className="mt-2 text-body leading-5 text-muted-foreground">
                 This route is not available in PatchDeck.
               </p>
             </div>
@@ -28,7 +28,7 @@ export default function NotFound() {
 
           <Link
             href="/"
-            className="mt-4 inline-flex cursor-pointer items-center gap-1 rounded-md border border-border px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="mt-4 inline-flex cursor-pointer items-center gap-1 rounded-md border border-border px-2.5 py-1 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           >
             <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
             Dashboard

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -121,7 +121,7 @@ function FilterChip({
       type="button"
       onClick={onClick}
       data-testid={testId}
-      className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+      className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
         active
           ? "border-primary bg-primary/10 text-primary"
           : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -205,7 +205,7 @@ const HEALING_TONE_CLASSES: Record<"neutral" | "info" | "warning" | "success" | 
 function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
   const cls = getFeedbackStatusBadgeClass(status);
   return (
-    <span className={`inline-block border px-1.5 py-0 text-[11px] uppercase tracking-wide ${cls}`}>
+    <span className={`inline-block border px-1.5 py-0 text-label uppercase tracking-wide ${cls}`}>
       {formatFeedbackStatusLabel(status)}
     </span>
   );
@@ -213,7 +213,7 @@ function FeedbackStatusTag({ status }: { status: FeedbackItem["status"] }) {
 
 function WatchPausedIndicator() {
   return (
-    <span className="border border-border px-1.5 py-0 text-[10px] uppercase tracking-wider text-muted-foreground">
+    <span className="border border-border px-1.5 py-0 text-label uppercase tracking-wider text-muted-foreground">
       watch paused
     </span>
   );
@@ -226,12 +226,12 @@ function DashboardDrainBanner({ runtimeState }: { runtimeState: RuntimeState | u
 
   return (
     <div
-      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-[12px]"
+      className="shrink-0 border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-body"
       data-testid="dashboard-drain-banner"
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0">
-          <div className="text-[10px] font-medium uppercase tracking-wider text-destructive">
+          <div className="text-label font-medium uppercase tracking-wider text-destructive">
             {DRAIN_PAUSED_TITLE}
           </div>
           {runtimeState.drainReason ? (
@@ -242,13 +242,13 @@ function DashboardDrainBanner({ runtimeState }: { runtimeState: RuntimeState | u
               {runtimeState.drainReason}
             </div>
           ) : null}
-          <div className="mt-1 text-[11px] text-muted-foreground">
+          <div className="mt-1 text-label text-muted-foreground">
             {MANUAL_RUNS_BLOCKED_COPY}
           </div>
         </div>
         <Link
           href="/settings"
-          className="shrink-0 border border-destructive/50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+          className="shrink-0 border border-destructive/50 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         >
           Settings
         </Link>
@@ -271,7 +271,7 @@ function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
         {warnings.map((warning) => (
           <div key={warning.id} data-testid={`operator-warning-${warning.id}`}>
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-[12px] font-medium uppercase tracking-wider text-yellow-600">
+              <div className="text-body font-medium uppercase tracking-wider text-yellow-600">
                 {warning.title}
               </div>
               {warning.targetUrl && (
@@ -279,14 +279,14 @@ function OperatorWarningsBanner({ warnings }: { warnings: OperatorWarning[] }) {
                   href={warning.targetUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="border border-yellow-600/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-yellow-600 transition-colors hover:bg-yellow-600 hover:text-background"
+                  className="border border-yellow-600/60 px-2 py-0.5 text-label uppercase tracking-wider text-yellow-600 transition-colors hover:bg-yellow-600 hover:text-background"
                 >
                   Open PR
                 </a>
               )}
             </div>
-            <div className="mt-1 text-[12px] text-foreground/80">{warning.message}</div>
-            <ol className="mt-2 list-decimal space-y-1 pl-4 text-[11px] text-muted-foreground">
+            <div className="mt-1 text-body text-foreground/80">{warning.message}</div>
+            <ol className="mt-2 list-decimal space-y-1 pl-4 text-label text-muted-foreground">
               {warning.fixSteps.map((step) => (
                 <li key={step}>{step}</li>
               ))}
@@ -342,7 +342,7 @@ function MergeReadinessChecklist({
 }) {
   return (
     <div
-      className={`mt-2 rounded-md border px-3 py-2 text-[11px] ${
+      className={`mt-2 rounded-md border px-3 py-2 text-label ${
         ready
           ? "border-success-border bg-success-muted text-success-foreground"
           : "border-warning-border bg-warning-muted text-warning-foreground"
@@ -350,10 +350,10 @@ function MergeReadinessChecklist({
       data-testid="pr-merge-readiness-checklist"
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="text-[10px] font-medium uppercase tracking-wider">
+        <div className="text-label font-medium uppercase tracking-wider">
           Merge readiness
         </div>
-        <div className="rounded-md border border-current/40 px-1.5 py-0 text-[10px] uppercase tracking-wider">
+        <div className="rounded-md border border-current/40 px-1.5 py-0 text-label uppercase tracking-wider">
           {ready ? "ready" : "not ready"}
         </div>
       </div>
@@ -366,8 +366,8 @@ function MergeReadinessChecklist({
               <CircleDashed className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
             )}
             <span className="min-w-0">
-              <span className="block text-[11px] font-medium text-foreground">{check.label}</span>
-              <span className="block truncate text-[10px] opacity-80" title={check.detail}>
+              <span className="block text-label font-medium text-foreground">{check.label}</span>
+              <span className="block truncate text-label opacity-80" title={check.detail}>
                 {check.detail}
               </span>
             </span>
@@ -389,14 +389,14 @@ function AgentIndicator({ pr }: { pr: PRSummary }) {
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          className="inline-flex shrink-0 cursor-default items-center gap-1 text-[12px] text-primary"
+          className="inline-flex shrink-0 cursor-default items-center gap-1 text-body text-primary"
           data-testid={`agent-indicator-${pr.id}`}
         >
           <Bot className="h-3.5 w-3.5 animate-pulse" aria-hidden="true" />
         </span>
       </TooltipTrigger>
       <TooltipContent side="top">
-        <p className="text-xs">Agent run active on this PR</p>
+        <p className="text-body">Agent run active on this PR</p>
       </TooltipContent>
     </Tooltip>
   );
@@ -465,13 +465,13 @@ const PRRow = memo(function PRRow({
       <div className="flex items-start gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-3">
-            <span className="w-12 shrink-0 font-mono text-[12px] text-muted-foreground">#{pr.number}</span>
+            <span className="w-12 shrink-0 font-mono text-body text-muted-foreground">#{pr.number}</span>
             <span className="truncate">{pr.title}</span>
             <AgentIndicator pr={pr} />
             {issueLink && (
               <span
                 data-testid="pr-on-issues-badge"
-                className="shrink-0 rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 text-[10px] uppercase tracking-wider text-primary"
+                className="shrink-0 rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 text-label uppercase tracking-wider text-primary"
                 title={`Linked from issue #${issueLink.number}`}
               >
                 issue <span className="font-mono">#{issueLink.number}</span>
@@ -479,12 +479,12 @@ const PRRow = memo(function PRRow({
             )}
           </div>
           {pr.status === "error" && failureMessage && (
-            <div className="mt-2 ml-[3.75rem] border border-destructive/40 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
+            <div className="mt-2 ml-[3.75rem] border border-destructive/40 bg-destructive/10 px-2 py-1 text-label leading-4 text-destructive">
               <span className="font-medium uppercase tracking-wider">Error:</span>{" "}
               <span className="break-words">{failureMessage}</span>
             </div>
           )}
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-[11px] text-muted-foreground">
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 pl-[3.75rem] text-label text-muted-foreground">
             <a
               href={pr.url}
               target="_blank"
@@ -572,7 +572,7 @@ function FeedbackRow({
               <span className="font-medium">{item.author}</span>
               {trusted && (
                 <span
-                  className="rounded-md border border-success-border bg-success-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider text-success-foreground"
+                  className="rounded-md border border-success-border bg-success-muted px-1.5 py-0 text-label font-medium uppercase tracking-wider text-success-foreground"
                   title={`@${item.author} is in Trusted reviewers — feedback is auto-accepted, agent evaluation skipped.`}
                   data-testid={`feedback-trusted-${item.id}`}
                 >
@@ -580,15 +580,15 @@ function FeedbackRow({
                 </span>
               )}
               {item.file && (
-                <span className="font-mono text-[11px] text-muted-foreground">
+                <span className="font-mono text-label text-muted-foreground">
                   {item.file}{item.line ? `:${item.line}` : ""}
                 </span>
               )}
-              <span className="text-[11px] text-muted-foreground">{item.type.replace("_", " ")}</span>
-              {createdAt && <span className="text-[11px] text-muted-foreground">{createdAt}</span>}
+              <span className="text-label text-muted-foreground">{item.type.replace("_", " ")}</span>
+              {createdAt && <span className="text-label text-muted-foreground">{createdAt}</span>}
             </div>
             {prominentStatusReason && (
-              <div className="mt-1 whitespace-pre-wrap break-words border border-destructive/30 bg-destructive/10 px-2 py-1 text-[11px] leading-4 text-destructive">
+              <div className="mt-1 whitespace-pre-wrap break-words border border-destructive/30 bg-destructive/10 px-2 py-1 text-label leading-4 text-destructive">
                 <span className="font-medium uppercase tracking-wider">Failure reason:</span>{" "}
                 {prominentStatusReason}
               </div>
@@ -603,7 +603,7 @@ function FeedbackRow({
                 data-testid={`retry-${item.id}`}
                 aria-label={`Retry feedback from ${item.author}`}
                 title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Retry feedback item"}
-                className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
+                className="border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
               >
                 {globalDrainMode ? DRAIN_PAUSED_LABEL : "Retry"}
               </button>
@@ -614,7 +614,7 @@ function FeedbackRow({
                 data-testid={`toggle-${item.id}`}
                 aria-label={`${collapsedByDefault ? "Show" : "Hide"} feedback details from ${item.author}`}
                 title="Toggle feedback details"
-                className="border border-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                className="border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
                 Details
               </button>
@@ -635,7 +635,7 @@ function FeedbackRow({
                   data-testid={`override-${decision}-${item.id}`}
                   aria-label={`${decision} feedback from ${item.author}`}
                   aria-pressed={selected}
-                  className={`cursor-pointer rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
+                  className={`cursor-pointer rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background ${
                     selected ? selectedClass : "border-border text-muted-foreground hover:bg-muted hover:text-foreground"
                   }`}
                 >
@@ -650,20 +650,20 @@ function FeedbackRow({
         <div className="px-4 pb-3">
           {item.bodyHtml ? (
             <div
-              className="feedback-markdown text-[12px] leading-relaxed"
+              className="feedback-markdown text-body leading-relaxed"
               dangerouslySetInnerHTML={{ __html: item.bodyHtml }}
             />
           ) : (
-            <p className="whitespace-pre-wrap text-[12px] leading-relaxed text-foreground/80">{item.body}</p>
+            <p className="whitespace-pre-wrap text-body leading-relaxed text-foreground/80">{item.body}</p>
           )}
           {item.statusReason && !prominentStatusReason && (
-            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+            <p className="mt-2 whitespace-pre-wrap break-words text-label text-muted-foreground">
               <span className="font-medium uppercase tracking-wider text-foreground/70">Status reason:</span>{" "}
               {item.statusReason}
             </p>
           )}
           {item.decisionReason && (
-            <p className="mt-2 whitespace-pre-wrap break-words text-[11px] text-muted-foreground">
+            <p className="mt-2 whitespace-pre-wrap break-words text-label text-muted-foreground">
               <span className="font-medium uppercase tracking-wider text-foreground/70">Decision reason:</span>{" "}
               {item.decisionReason}
             </p>
@@ -715,29 +715,29 @@ function LogPanel({ prId }: { prId: string | null }) {
     <div className="flex h-full flex-col">
       <div ref={scrollerRef} className="flex-1 overflow-y-auto" data-testid="pr-detail-logs">
         {!prId ? (
-          <div className="p-4 text-[12px] text-muted-foreground">Select a PR to see logs.</div>
+          <div className="p-4 text-body text-muted-foreground">Select a PR to see logs.</div>
         ) : logs.length === 0 ? (
-          <div className="p-4 text-[12px] text-muted-foreground">No workflow logs yet.</div>
+          <div className="p-4 text-body text-muted-foreground">No workflow logs yet.</div>
         ) : viewLogs.length === 0 ? (
-          <div className="p-4 text-[12px] text-muted-foreground">
+          <div className="p-4 text-body text-muted-foreground">
             View cleared. New log entries will appear here.
           </div>
         ) : (
           <>
             <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              <span className="text-label uppercase tracking-wider text-muted-foreground">
                 {viewLogs.length} visible
               </span>
               <button
                 type="button"
                 onClick={() => setClearedLogIds(new Set(logs.map((log) => log.id)))}
-                className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
                 Clear view
               </button>
             </div>
             {hiddenLogCount > 0 && (
-              <div className="border-b border-border/60 px-3 py-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+              <div className="border-b border-border/60 px-3 py-2 text-label uppercase tracking-wider text-muted-foreground">
                 Showing latest {MAX_VISIBLE_LOGS} entries.
               </div>
             )}
@@ -748,7 +748,7 @@ function LogPanel({ prId }: { prId: string | null }) {
 
               return (
                 <div key={log.id} className="border-b border-border/60 px-3 py-2 last:border-b-0" data-testid={`log-${log.id}`}>
-                  <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  <div className="flex flex-wrap items-center gap-2 text-label uppercase tracking-wider text-muted-foreground">
                     <span className={
                       log.level === "error" ? "text-destructive" :
                       log.level === "warn" ? "text-warning-foreground" :
@@ -761,11 +761,11 @@ function LogPanel({ prId }: { prId: string | null }) {
                     {log.runId && <span className="normal-case text-foreground/45">run {log.runId.slice(0, 8)}</span>}
                     <span>{formatClock(log.timestamp)}</span>
                   </div>
-                  <div className={`mt-1 break-words text-[12px] ${log.level === "error" ? "text-destructive" : "text-foreground/75"}`}>
+                  <div className={`mt-1 break-words text-body ${log.level === "error" ? "text-destructive" : "text-foreground/75"}`}>
                     {log.message}
                   </div>
                   {metadataText && (
-                    <pre className="mt-1 whitespace-pre-wrap break-all text-[10px] text-muted-foreground">
+                    <pre className="mt-1 whitespace-pre-wrap break-all text-label text-muted-foreground">
                       {metadataText}
                     </pre>
                   )}
@@ -799,17 +799,17 @@ function HealingPanel({
     >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">CI healing</div>
+          <div className="text-label font-medium uppercase tracking-wider text-muted-foreground">CI healing</div>
           <div className="mt-1 flex flex-wrap items-center gap-2">
             {view ? (
               <>
-                <span className={`inline-flex rounded-md border px-1.5 py-0.5 text-[11px] font-medium uppercase tracking-wider ${toneClass}`}>
+                <span className={`inline-flex rounded-md border px-1.5 py-0.5 text-label font-medium uppercase tracking-wider ${toneClass}`}>
                   {view.stateLabel}
                 </span>
-                <span className="text-[11px] text-muted-foreground">{view.attemptSummary}</span>
+                <span className="text-label text-muted-foreground">{view.attemptSummary}</span>
               </>
             ) : (
-              <span className="text-[11px] text-muted-foreground">
+              <span className="text-label text-muted-foreground">
                 {config?.autoHealCI === false
                   ? "Automatic CI healing is disabled in settings."
                   : "No healing session yet for this PR."}
@@ -818,7 +818,7 @@ function HealingPanel({
           </div>
         </div>
         {session && (
-          <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          <span className="shrink-0 font-mono text-label text-muted-foreground">
             head {session.currentHeadSha.slice(0, 7)}
           </span>
         )}
@@ -826,21 +826,21 @@ function HealingPanel({
 
       {view ? (
         <>
-          <div className="mt-2 grid gap-1 text-[11px]">
+          <div className="mt-2 grid gap-1 text-label">
             {view.reasonSummary && (
               <div>
-                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Reason</span>
+                <span className="text-label uppercase tracking-wider text-muted-foreground">Reason</span>
                 <span className="ml-2 text-foreground/80">{view.reasonSummary}</span>
               </div>
             )}
             <div className="text-muted-foreground">{view.statusHint}</div>
             <div>
-              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Attempts</span>
+              <span className="text-label uppercase tracking-wider text-muted-foreground">Attempts</span>
               <span className="ml-2 font-mono text-foreground/80">{view.attemptSummary}</span>
               {session?.latestFingerprint && (
                 <>
                   <span className="mx-1.5 text-border" aria-hidden="true">·</span>
-                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">fingerprint</span>
+                  <span className="text-label uppercase tracking-wider text-muted-foreground">fingerprint</span>
                   <span className="ml-1.5 font-mono text-foreground/80">{session.latestFingerprint}</span>
                 </>
               )}
@@ -855,7 +855,7 @@ function HealingPanel({
                     type="button"
                     disabled
                     title={action.hint}
-                    className={`rounded-md border px-2 py-0.5 text-[10px] uppercase tracking-wider transition-colors ${
+                    className={`rounded-md border px-2 py-0.5 text-label uppercase tracking-wider transition-colors ${
                       action.available
                         ? "border-border text-foreground/70 hover:bg-muted"
                         : "border-border text-muted-foreground/60"
@@ -865,7 +865,7 @@ function HealingPanel({
                   </button>
                 ))}
               </div>
-              <div className="mt-1 text-[10px] text-muted-foreground">
+              <div className="mt-1 text-label text-muted-foreground">
                 Operator controls are read-only until healing action endpoints are added.
               </div>
             </>
@@ -873,7 +873,7 @@ function HealingPanel({
         </>
       ) : (
         config?.autoHealCI !== false && (
-          <div className="mt-2 text-[11px] text-muted-foreground">
+          <div className="mt-2 text-label text-muted-foreground">
             The watcher will create a healing session when a failing check is classified as healable.
           </div>
         )
@@ -893,7 +893,7 @@ function PRDescriptionPanel({ pr }: { pr: PR }) {
         aria-expanded={isOpen}
         className="flex w-full items-center justify-between gap-2 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
-        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Description</div>
+        <div className="text-label font-medium uppercase tracking-wider text-muted-foreground">Description</div>
         {isOpen ? <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" /> : <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />}
       </button>
       {isOpen && (
@@ -904,7 +904,7 @@ function PRDescriptionPanel({ pr }: { pr: PR }) {
             dangerouslySetInnerHTML={{ __html: pr.bodyHtml }}
           />
         ) : (
-          <pre className="mt-2 whitespace-pre-wrap break-words border border-border/60 bg-background p-4 text-[12px] leading-6 text-muted-foreground">
+          <pre className="mt-2 whitespace-pre-wrap break-words border border-border/60 bg-background p-4 text-body leading-6 text-muted-foreground">
             {pr.body?.trim() || "No description provided."}
           </pre>
         )
@@ -949,7 +949,7 @@ function RightPanel({
     <div className="flex max-h-[42dvh] min-h-0 w-full shrink-0 flex-col border-t border-border lg:max-h-none lg:min-h-0 lg:w-80 lg:border-l lg:border-t-0">
       <div className="flex shrink-0 items-center border-b border-border">
         <div
-          className="flex-1 bg-muted px-3 py-2 text-[11px] uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
+          className="flex-1 bg-muted px-3 py-2 text-label uppercase tracking-wider text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
           data-testid="tab-activity"
         >
           Activity
@@ -1001,12 +1001,12 @@ function QAPanel({ prId, globalDrainMode }: { prId: string; globalDrainMode: boo
 
   return (
     <div className="flex h-full flex-col">
-      <div className="border-b border-border px-4 py-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+      <div className="border-b border-border px-4 py-2 text-label uppercase tracking-wider text-muted-foreground">
         Ask Agent
       </div>
       <div ref={scrollRef} className="flex-1 overflow-y-auto p-4 space-y-3">
         {questions.length === 0 ? (
-          <span className="text-[12px] text-muted-foreground">
+          <span className="text-body text-muted-foreground">
             {globalDrainMode
               ? ASK_DRAIN_COPY
               : "Ask questions about this PR — the agent will read activity logs, feedback, and status to answer."}
@@ -1014,24 +1014,24 @@ function QAPanel({ prId, globalDrainMode }: { prId: string; globalDrainMode: boo
         ) : (
           questions.map((q) => (
             <div key={q.id} className="space-y-1.5" data-testid={`question-${q.id}`}>
-              <div className="text-[12px]">
+              <div className="text-body">
                 <span className="font-medium text-foreground/90">Q: </span>
                 <span className="text-foreground/80">{q.question}</span>
               </div>
               {q.status === "pending" || q.status === "answering" ? (
-                <div className="text-[11px] text-muted-foreground animate-pulse">
+                <div className="text-label text-muted-foreground animate-pulse">
                   Agent is thinking...
                 </div>
               ) : q.status === "error" ? (
-                <div className="text-[11px] text-destructive">
+                <div className="text-label text-destructive">
                   Error: {q.error || "Unknown error"}
                 </div>
               ) : (
-                <div className="text-[12px] leading-relaxed text-foreground/85 whitespace-pre-wrap border-l-2 border-primary/40 pl-3">
+                <div className="text-body leading-relaxed text-foreground/85 whitespace-pre-wrap border-l-2 border-primary/40 pl-3">
                   {q.answer}
                 </div>
               )}
-              <div className="text-[10px] text-muted-foreground">
+              <div className="text-label text-muted-foreground">
                 {formatClock(q.createdAt)}
                 {q.answeredAt && ` — answered ${formatClock(q.answeredAt)}`}
               </div>
@@ -1055,20 +1055,20 @@ function QAPanel({ prId, globalDrainMode }: { prId: string; globalDrainMode: boo
             aria-label="Question for selected pull request"
             disabled={globalDrainMode}
             data-testid="input-question"
-            className="flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="flex-1 border border-border bg-transparent px-2 py-1 text-body placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
           />
           <button
             type="submit"
             disabled={askDisabled}
             title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Ask agent"}
             data-testid="button-ask"
-            className="cursor-pointer border border-primary bg-primary px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+            className="cursor-pointer border border-primary bg-primary px-3 py-1 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
           >
             {globalDrainMode ? DRAIN_PAUSED_LABEL : askMutation.isPending ? "..." : "Ask"}
           </button>
         </div>
         {askMutation.isError && (
-          <div className="mt-1 text-[11px] text-destructive">
+          <div className="mt-1 text-label text-destructive">
             {getErrorMessage(askMutation.error)}
           </div>
         )}
@@ -1408,7 +1408,7 @@ export default function Dashboard() {
         )}
         actions={(
           <>
-            <label htmlFor="dashboard-coding-agent" className="text-[11px] uppercase tracking-wider text-muted-foreground">Agent</label>
+            <label htmlFor="dashboard-coding-agent" className="text-label uppercase tracking-wider text-muted-foreground">Agent</label>
             <select
               id="dashboard-coding-agent"
               value={config?.codingAgent ?? "codex"}
@@ -1420,7 +1420,7 @@ export default function Dashboard() {
               }}
               disabled={updateConfigMutation.isPending}
               data-testid="select-coding-agent"
-              className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-1 text-[11px] transition-colors focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+              className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-1 text-label transition-colors focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
             >
               <option value="codex">codex</option>
               <option value="claude">claude</option>
@@ -1433,7 +1433,7 @@ export default function Dashboard() {
                   scrollToDashboardErrors();
                 }}
                 data-testid="dashboard-error-pill"
-                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 px-2 py-0.5 text-[11px] uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                className="inline-flex items-center gap-1 rounded-md border border-destructive/50 bg-destructive/10 px-2 py-0.5 text-label uppercase tracking-wider text-destructive transition-colors hover:bg-destructive hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
                 <AlertTriangle className="h-3 w-3" aria-hidden="true" />
                 errors
@@ -1446,7 +1446,7 @@ export default function Dashboard() {
               disabled={isRefreshing || globalDrainMode || isGitHubThrottled}
               title={isGitHubThrottled ? throttledTitle : undefined}
               data-testid="button-sync-dashboard"
-              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-label uppercase tracking-wider text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
             >
               {isRefreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
               sync
@@ -1484,7 +1484,7 @@ export default function Dashboard() {
               type="button"
               onClick={() => setViewMode("active")}
               data-testid="tab-active"
-              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
                 viewMode === "active"
                   ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
                   : "text-muted-foreground hover:text-foreground"
@@ -1496,7 +1496,7 @@ export default function Dashboard() {
               type="button"
               onClick={() => setViewMode("issues")}
               data-testid="tab-on-issues"
-              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
                 viewMode === "issues"
                   ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
                   : "text-muted-foreground hover:text-foreground"
@@ -1508,7 +1508,7 @@ export default function Dashboard() {
               type="button"
               onClick={() => setViewMode("archived")}
               data-testid="tab-archived"
-              className={`flex-1 whitespace-nowrap px-2 py-2 text-[11px] uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
+              className={`flex-1 whitespace-nowrap px-2 py-2 text-label uppercase tracking-wider transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset ${
                 viewMode === "archived"
                   ? "bg-muted text-foreground shadow-[inset_0_-2px_0_0_hsl(var(--primary))]"
                   : "text-muted-foreground hover:text-foreground"
@@ -1526,11 +1526,11 @@ export default function Dashboard() {
                 onChange={(event) => setPrNumberSearch(event.target.value)}
                 placeholder="Search #"
                 data-testid="pr-number-search"
-                className="h-7 w-full rounded-md border border-border bg-background px-2 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="h-7 w-full rounded-md border border-border bg-background px-2 font-mono text-body text-foreground placeholder:font-sans placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
             <div className="flex flex-wrap items-start gap-2">
-              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="mt-1 w-14 shrink-0 text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Repo
               </span>
               <div className="flex min-w-0 flex-1 flex-wrap gap-1">
@@ -1549,7 +1549,7 @@ export default function Dashboard() {
               </div>
             </div>
             <div className="flex flex-wrap items-start gap-2">
-              <span className="mt-1 w-14 shrink-0 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="mt-1 w-14 shrink-0 text-label font-medium uppercase tracking-wider text-muted-foreground">
                 Status
               </span>
               <div className="flex min-w-0 flex-1 flex-wrap gap-1">
@@ -1580,7 +1580,7 @@ export default function Dashboard() {
                 ))}
               </div>
             ) : displayedPRs.length === 0 ? (
-              <div className="p-4 text-[12px] text-muted-foreground">
+              <div className="p-4 text-body text-muted-foreground">
                 {normalizedPrNumberSearch
                   ? `No PRs match #${normalizedPrNumberSearch}.`
                   : isArchived
@@ -1672,7 +1672,7 @@ export default function Dashboard() {
                             : "Sync GitHub feedback now"
                       }
                       data-testid="button-sync-pr"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {syncPrMutation.isPending ? (
                         <><Loader2 className="h-3.5 w-3.5 animate-spin" />Syncing</>
@@ -1686,7 +1686,7 @@ export default function Dashboard() {
                       disabled={watchMutation.isPending}
                       data-testid="button-toggle-watch"
                       title={selectedPRWatchEnabled ? "Pause background watch for this PR" : "Resume background watch for this PR"}
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {selectedPRWatchEnabled ? (
                         <><Pause className="h-3.5 w-3.5" />Pause watch</>
@@ -1706,7 +1706,7 @@ export default function Dashboard() {
                             : "Queue PR work safely"
                       }
                       data-testid="button-apply"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-primary bg-primary px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {applyMutation.isPending || selectedPR.status === "processing" || selectedPRQueueStatus ? (
                         <>
@@ -1736,21 +1736,21 @@ export default function Dashboard() {
                         testId="detail-ready-to-merge"
                         label="GitHub ready to merge"
                         hint="Open PR on GitHub →"
-                        className="mt-2 gap-2 px-3 py-1.5 text-[12px] tracking-wider"
+                        className="mt-2 gap-2 px-3 py-1.5 text-body tracking-wider"
                         dotClassName="h-2 w-2"
-                        hintClassName="text-[11px] normal-case tracking-normal text-success-foreground/75"
+                        hintClassName="text-label normal-case tracking-normal text-success-foreground/75"
                       />
                     )}
                     {selectedPRErrorMessage && (
                       <div
-                        className="mt-2 border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] leading-5 text-destructive"
+                        className="mt-2 border border-destructive/40 bg-destructive/10 px-3 py-2 text-body leading-5 text-destructive"
                         data-testid="selected-pr-error"
                       >
-                        <div className="text-[10px] font-medium uppercase tracking-wider">Automation error</div>
+                        <div className="text-label font-medium uppercase tracking-wider">Automation error</div>
                         <div className="mt-1 whitespace-pre-wrap break-words">{selectedPRErrorMessage}</div>
                       </div>
                     )}
-                    <div className="mt-2 text-[11px] text-muted-foreground">
+                    <div className="mt-2 text-label text-muted-foreground">
                       {globalDrainMode
                         ? GLOBAL_DRAIN_PR_COPY
                         : selectedPRWatchEnabled
@@ -1768,7 +1768,7 @@ export default function Dashboard() {
 
           <div className="flex-1 overflow-y-auto">
                 {selectedPR.feedbackItems.length === 0 ? (
-                  <div className="p-4 text-[12px] text-muted-foreground">
+                  <div className="p-4 text-body text-muted-foreground">
                     {selectedPRWatchEnabled
                       ? "No feedback yet. The watcher will sync GitHub comments automatically."
                       : "No feedback yet. Background watch is paused for this PR."}
@@ -1787,7 +1787,7 @@ export default function Dashboard() {
               </div>
             </>
           ) : (
-            <div className="flex flex-1 items-center justify-center text-[12px] text-muted-foreground">
+            <div className="flex flex-1 items-center justify-center text-body text-muted-foreground">
               Select a PR from the left panel.
             </div>
           )}
@@ -1808,7 +1808,7 @@ export default function Dashboard() {
             {selectedPRId ? (
               <QAPanel prId={selectedPRId} globalDrainMode={globalDrainMode} />
             ) : (
-              <div className="flex h-full items-center justify-center p-4 text-[12px] text-muted-foreground">
+              <div className="flex h-full items-center justify-center p-4 text-body text-muted-foreground">
                 Select a PR to ask questions.
               </div>
             )}

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -1270,7 +1270,7 @@ export default function Dashboard() {
   const selectedPRWatchEnabled = selectedPRSummary ? isPRWatchEnabled(selectedPRSummary) : true;
   const selectedFailedActivity = selectedPRSummary ? latestActivityForTarget(activities.failed, selectedPRSummary.id) : undefined;
   const selectedPRQueueStatus = selectedPRSummary ? queueStatusById.get(selectedPRSummary.id) ?? null : null;
-  const selectedPRErrorMessage = selectedPRSummary?.status === "error"
+  const selectedPRErrorMessage = selectedPRSummary?.status === "error" && !selectedPRQueueStatus
     ? selectedFailedActivity?.lastError ?? getPRFeedbackFailureReason(selectedPR) ?? "Automation stopped on this PR. Check the activity log for the full failure context."
     : null;
   const activeErrorCount = activities.failed.length + activities.warnings.length;
@@ -1291,7 +1291,7 @@ export default function Dashboard() {
     eligibleCount: eligiblePRCount,
     trackedLabel: "PR",
   });
-  const selectedPRReadinessChecks = selectedPR ? buildPRReadinessChecks(selectedPR) : [];
+  const selectedPRReadinessChecks = selectedPR ? buildPRReadinessChecks(selectedPR, selectedPRQueueStatus) : [];
 
   const applyMutation = useMutation({
     mutationFn: async (id: string) => {
@@ -1599,7 +1599,7 @@ export default function Dashboard() {
                   queueStatus={queueStatusById.get(pr.id) ?? null}
                   issueLink={issueLinkedPRByKey.get(prIssueLinkKey(pr.repo, pr.number)) ?? null}
                   failureMessage={
-                    pr.status === "error"
+                    pr.status === "error" && !queueStatusById.get(pr.id)
                       ? latestActivityForTarget(activities.failed, pr.id)?.lastError ?? getPRFeedbackFailureReason(pr)
                       : null
                   }
@@ -1613,6 +1613,7 @@ export default function Dashboard() {
           {selectedPR ? (
             <>
               {(() => {
+                const selectedPRFailed = selectedPR.status === "error" && !selectedPRQueueStatus;
                 const metaItems: MetaItem[] = [
                   { key: "status", content: <span>work: <span className="text-foreground">{formatPRWorkState(selectedPR.status, selectedPR.prStage)}</span></span> },
                   { key: "author", content: <span>author: <span className="text-foreground/80">{formatGitHubUsername(selectedPR.author)}</span></span> },
@@ -1647,7 +1648,7 @@ export default function Dashboard() {
               <DetailHeader
                 title={selectedPR.title}
                 accentTone="primary"
-                failed={selectedPR.status === "error"}
+                failed={selectedPRFailed}
                 stageBar={<StageProgressBar stages={buildPRStages(selectedPR)} testId="pr-stage-progress" />}
                 titleSuffix={(
                   <>

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -41,6 +41,7 @@ import { prStatusTone, toneRailClass } from "@/lib/statusTones";
 import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
 import { getActivityIdleReason } from "@/lib/activityIdle";
 import { formatPRWorkState } from "@/lib/statusCopy";
+import { PR_LIST_STALE_MS, readCachedPRs, writeCachedPRs } from "@/lib/prListCache";
 
 type GitHubRateLimitState = {
   limited: boolean;
@@ -1143,16 +1144,38 @@ export default function Dashboard() {
     refetchInterval: 5000,
   });
   const uiPollIntervalMs = getUiPollIntervalMs(config);
+  const cachedActivePRs = useMemo(() => readCachedPRs("active"), []);
+  const cachedArchivedPRs = useMemo(() => readCachedPRs("archived"), []);
 
-  const { data: prs = [], isLoading } = useQuery<PRSummary[]>({
+  const activePRsQuery = useQuery<PRSummary[]>({
     queryKey: ["/api/prs"],
+    initialData: cachedActivePRs?.data,
+    initialDataUpdatedAt: cachedActivePRs?.updatedAt,
+    staleTime: PR_LIST_STALE_MS,
     refetchInterval: 3000,
   });
 
-  const { data: archivedPRs = [], isLoading: isLoadingArchived } = useQuery<PRSummary[]>({
+  const archivedPRsQuery = useQuery<PRSummary[]>({
     queryKey: ["/api/prs/archived"],
+    initialData: cachedArchivedPRs?.data,
+    initialDataUpdatedAt: cachedArchivedPRs?.updatedAt,
+    staleTime: PR_LIST_STALE_MS,
     refetchInterval: 10000,
   });
+  const { data: prs = [], isLoading } = activePRsQuery;
+  const { data: archivedPRs = [], isLoading: isLoadingArchived } = archivedPRsQuery;
+
+  useEffect(() => {
+    if (activePRsQuery.status === "success") {
+      writeCachedPRs("active", activePRsQuery.data);
+    }
+  }, [activePRsQuery.status, activePRsQuery.data]);
+
+  useEffect(() => {
+    if (archivedPRsQuery.status === "success") {
+      writeCachedPRs("archived", archivedPRsQuery.data);
+    }
+  }, [archivedPRsQuery.status, archivedPRsQuery.data]);
 
   const { data: runtimeState } = useQuery<RuntimeState>({
     queryKey: ["/api/runtime"],

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -56,7 +56,7 @@ function StatusBadge({ status }: { status: ReleaseRunStatus }) {
           : "border-border text-muted-foreground";
 
   return (
-    <span className={`rounded-md border px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider ${cls}`}>
+    <span className={`rounded-md border px-1.5 py-0 text-label font-medium uppercase tracking-wider ${cls}`}>
       {status}
     </span>
   );
@@ -80,7 +80,7 @@ function CopyButton({ text }: { text: string }) {
     <button
       type="button"
       onClick={handleCopy}
-      className="cursor-pointer rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      className="cursor-pointer rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
     >
       {copied ? "copied" : "copy"}
     </button>
@@ -123,21 +123,21 @@ function ReleaseRunCard({
       >
         <div className="flex min-w-0 items-center gap-3">
           <StatusBadge status={run.status} />
-          <span className="truncate text-sm font-medium">{run.repo}</span>
-          <span className="font-mono text-[11px] text-muted-foreground">#{run.triggerPrNumber}</span>
+          <span className="truncate text-body font-medium">{run.repo}</span>
+          <span className="font-mono text-label text-muted-foreground">#{run.triggerPrNumber}</span>
           {run.proposedVersion && (
-            <span className="rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 font-mono text-[10px] font-medium uppercase tracking-wider text-primary">
+            <span className="rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 font-mono text-label font-medium uppercase tracking-wider text-primary">
               {run.proposedVersion}
             </span>
           )}
           {!run.proposedVersion && run.recommendedBump && (
-            <span className="text-[11px] text-muted-foreground">
+            <span className="text-label text-muted-foreground">
               bump {run.recommendedBump}
             </span>
           )}
           {githubRelease && (
             <span
-              className="inline-flex items-center gap-1 rounded-md border border-success-border bg-success-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider text-success-foreground"
+              className="inline-flex items-center gap-1 rounded-md border border-success-border bg-success-muted px-1.5 py-0 text-label font-medium uppercase tracking-wider text-success-foreground"
               title={`Linked to GitHub release ${githubRelease.tagName}`}
               data-testid={`github-link-${run.id}`}
             >
@@ -146,7 +146,7 @@ function ReleaseRunCard({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <div className="flex items-center gap-3 text-label text-muted-foreground">
           <span>{formatDateTime(run.createdAt)}</span>
           <span>{expanded ? "Hide" : "Show"}</span>
         </div>
@@ -154,7 +154,7 @@ function ReleaseRunCard({
 
       {expanded && (
         <div id={detailsId} className="border-t border-border px-4 pb-4 pt-3">
-          <div className="mb-3 text-[12px] text-muted-foreground">
+          <div className="mb-3 text-body text-muted-foreground">
             Trigger PR:{" "}
             <a href={run.triggerPrUrl} target="_blank" rel="noreferrer noopener" className="underline underline-offset-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background">
               #{run.triggerPrNumber} {run.triggerPrTitle}
@@ -162,17 +162,17 @@ function ReleaseRunCard({
           </div>
 
           {run.decisionReason && (
-            <p className="mb-3 text-[12px] leading-relaxed">{run.decisionReason}</p>
+            <p className="mb-3 text-body leading-relaxed">{run.decisionReason}</p>
           )}
 
           {run.releaseTitle && (
-            <p className="mb-3 text-[12px]">
+            <p className="mb-3 text-body">
               <span className="text-muted-foreground">Release title:</span>{" "}
               <span>{run.releaseTitle}</span>
             </p>
           )}
 
-          <div className="mb-3 grid grid-cols-1 gap-2 text-[12px] text-muted-foreground md:grid-cols-2">
+          <div className="mb-3 grid grid-cols-1 gap-2 text-body text-muted-foreground md:grid-cols-2">
             <div>Base branch: {run.baseBranch || "n/a"}</div>
             <div>Trigger SHA: {shortSha(run.triggerMergeSha)}</div>
             <div>Merged at: {formatDateTime(run.triggerMergedAt)}</div>
@@ -181,10 +181,10 @@ function ReleaseRunCard({
 
           {run.includedPrs.length > 0 && (
             <div className="mb-3">
-              <div className="mb-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <div className="mb-1.5 text-label uppercase tracking-wider text-muted-foreground">
                 Included PRs ({run.includedPrs.length})
               </div>
-              <div className="space-y-1 border border-border p-3 text-[12px]">
+              <div className="space-y-1 border border-border p-3 text-body">
                 {run.includedPrs.map((pr) => (
                   <div key={`${pr.mergeSha}-${pr.number}`} className="flex items-center justify-between gap-3">
                     <span className="truncate">
@@ -202,29 +202,29 @@ function ReleaseRunCard({
           {run.releaseNotes && (
             <div className="mb-3">
               <div className="mb-1.5 flex items-center justify-between">
-                <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Release Notes</span>
+                <span className="text-label uppercase tracking-wider text-muted-foreground">Release Notes</span>
                 <CopyButton text={run.releaseNotes} />
               </div>
-              <pre className="whitespace-pre-wrap border border-border bg-background p-3 text-[12px] leading-relaxed font-mono">
+              <pre className="whitespace-pre-wrap border border-border bg-background p-3 text-body leading-relaxed font-mono">
                 {run.releaseNotes}
               </pre>
             </div>
           )}
 
           {run.error && (
-            <div className="mb-3 border border-destructive/40 bg-destructive/5 p-3 text-[12px] text-destructive">
+            <div className="mb-3 border border-destructive/40 bg-destructive/5 p-3 text-body text-destructive">
               {run.error}
             </div>
           )}
 
           {githubRelease && (
-            <div className="mb-3 rounded-md border border-success-border bg-success-muted/40 px-3 py-2 text-[12px]">
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
-                <span className="text-[10px] font-medium uppercase tracking-wider text-success-foreground">
+            <div className="mb-3 rounded-md border border-success-border bg-success-muted/40 px-3 py-2 text-body">
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-label">
+                <span className="text-label font-medium uppercase tracking-wider text-success-foreground">
                   Linked GitHub release
                 </span>
                 <span className="text-border" aria-hidden="true">·</span>
-                <span className="rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 font-mono text-[10px] font-medium uppercase tracking-wider text-primary">
+                <span className="rounded-md border border-primary/40 bg-primary/10 px-1.5 py-0 font-mono text-label font-medium uppercase tracking-wider text-primary">
                   {githubRelease.tagName}
                 </span>
                 {githubRelease.publishedAt && (
@@ -237,7 +237,7 @@ function ReleaseRunCard({
                 )}
               </div>
               {githubRelease.name && (
-                <div className="mt-1 truncate text-[12px] font-medium">{githubRelease.name}</div>
+                <div className="mt-1 truncate text-body font-medium">{githubRelease.name}</div>
               )}
             </div>
           )}
@@ -248,7 +248,7 @@ function ReleaseRunCard({
                 href={githubRelease?.htmlUrl ?? run.githubReleaseUrl ?? "#"}
                 target="_blank"
                 rel="noreferrer noopener"
-                className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-transparent px-2.5 py-0.5 text-label font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:border-primary/40 hover:bg-muted hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
               >
                 <ExternalLink className="h-3 w-3" />
                 Open on GitHub
@@ -259,7 +259,7 @@ function ReleaseRunCard({
                 type="button"
                 onClick={() => onRetry(run.id)}
                 disabled={retryPending}
-                className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
               >
                 retry
               </button>
@@ -267,7 +267,7 @@ function ReleaseRunCard({
           </div>
 
           {shouldShowEmptyDetails && (
-            <p className="mt-2 text-[12px] text-muted-foreground">No details available yet.</p>
+            <p className="mt-2 text-body text-muted-foreground">No details available yet.</p>
           )}
 
           <SocialPostGenerator
@@ -302,8 +302,8 @@ function RepoListButton({
           : "border-l-transparent hover:bg-muted/30"
       }`}
     >
-      <span className="min-w-0 truncate text-[12px] text-foreground">{repo}</span>
-      <span className={`shrink-0 font-mono text-[11px] ${selected ? "text-primary" : "text-muted-foreground"}`}>
+      <span className="min-w-0 truncate text-body text-foreground">{repo}</span>
+      <span className={`shrink-0 font-mono text-label ${selected ? "text-primary" : "text-muted-foreground"}`}>
         {count}
       </span>
     </button>
@@ -450,7 +450,7 @@ export default function Releases() {
         {/* Sidebar: repo list */}
         <aside className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-72 lg:border-b-0 lg:border-r">
           <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
-            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            <span className="text-label font-medium uppercase tracking-wider text-muted-foreground">
               Watched repositories
             </span>
             <button
@@ -471,9 +471,9 @@ export default function Releases() {
           </div>
           <div className="flex-1 overflow-y-auto">
             {isLoading && repoList.length === 0 ? (
-              <div className="p-4 text-[12px] text-muted-foreground">Loading…</div>
+              <div className="p-4 text-body text-muted-foreground">Loading…</div>
             ) : repoList.length === 0 ? (
-              <div className="p-4 text-[12px] text-muted-foreground">
+              <div className="p-4 text-body text-muted-foreground">
                 No watched repositories. Add some from Settings.
               </div>
             ) : (
@@ -493,8 +493,8 @@ export default function Releases() {
         {/* Content: selected repo's releases */}
         <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           {githubError && (
-            <div className="mx-6 mt-6 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] text-destructive">
-              <div className="text-[10px] font-medium uppercase tracking-wider">GitHub sync error</div>
+            <div className="mx-6 mt-6 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-body text-destructive">
+              <div className="text-label font-medium uppercase tracking-wider">GitHub sync error</div>
               <div className="mt-1 whitespace-pre-wrap break-words">
                 {githubError instanceof Error ? githubError.message : String(githubError)}
               </div>
@@ -502,22 +502,22 @@ export default function Releases() {
           )}
 
           {!selectedRepo ? (
-            <div className="flex flex-1 items-center justify-center p-6 text-[12px] text-muted-foreground">
+            <div className="flex flex-1 items-center justify-center p-6 text-body text-muted-foreground">
               {isLoading ? "Loading…" : "Select a repository from the left to see its releases."}
             </div>
           ) : (
             <div className="p-6">
               <div className="mb-4 flex items-baseline justify-between">
-                <h2 className="text-[15px] font-semibold tracking-tight">{selectedRepo}</h2>
-                <span className="font-mono text-[11px] text-muted-foreground">
+                <h2 className="text-title font-semibold tracking-tight">{selectedRepo}</h2>
+                <span className="font-mono text-label text-muted-foreground">
                   {selectedRuns.length} pipeline · {selectedOrphans.length} external
                 </span>
               </div>
 
               {selectedRuns.length === 0 && selectedOrphans.length === 0 ? (
                 <div className="rounded-md border border-border px-4 py-8 text-center">
-                  <p className="text-sm text-muted-foreground">No release activity yet.</p>
-                  <p className="mt-1 text-[12px] text-muted-foreground">
+                  <p className="text-body text-muted-foreground">No release activity yet.</p>
+                  <p className="mt-1 text-body text-muted-foreground">
                     Pipeline runs appear after merged PRs are evaluated. GitHub releases appear when you sync from GitHub.
                   </p>
                 </div>
@@ -526,10 +526,10 @@ export default function Releases() {
                   {selectedRuns.length > 0 && (
                     <section>
                       <div className="mb-2 flex items-baseline justify-between">
-                        <h3 className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                        <h3 className="text-label font-medium uppercase tracking-wider text-muted-foreground">
                           Pipeline runs
                         </h3>
-                        <span className="font-mono text-[11px] text-muted-foreground">
+                        <span className="font-mono text-label text-muted-foreground">
                           {selectedRuns.length}
                         </span>
                       </div>
@@ -555,14 +555,14 @@ export default function Releases() {
                   {selectedOrphans.length > 0 && (
                     <section>
                       <div className="mb-2 flex items-baseline justify-between">
-                        <h3 className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                        <h3 className="text-label font-medium uppercase tracking-wider text-muted-foreground">
                           Published outside the pipeline
                         </h3>
-                        <span className="font-mono text-[11px] text-muted-foreground">
+                        <span className="font-mono text-label text-muted-foreground">
                           {selectedOrphans.length}
                         </span>
                       </div>
-                      <p className="mb-3 text-[11px] text-muted-foreground">
+                      <p className="mb-3 text-label text-muted-foreground">
                         GitHub releases with no matching internal run. Created manually or before this tool started watching.
                       </p>
                       <div className="flex flex-col gap-2">

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -209,7 +209,7 @@ function SegmentControl<T extends string>({
           <label
             key={option.value}
             data-testid={`${testIdPrefix}-${option.value}`}
-            className={`cursor-pointer rounded-md border px-2 py-1 text-[11px] font-medium transition-colors focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background ${
+            className={`cursor-pointer rounded-md border px-2 py-1 text-label font-medium transition-colors focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-background ${
               active
                 ? "border-primary bg-primary/10 text-primary"
                 : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary"
@@ -299,8 +299,8 @@ function scrollToSettingsSection(id: string) {
 function SettingsTOC() {
   return (
     <aside className="hidden w-48 shrink-0 lg:block">
-      <nav className="sticky top-6 text-[12px]" aria-label="Settings sections">
-        <div className="mb-3 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+      <nav className="sticky top-6 text-body" aria-label="Settings sections">
+        <div className="mb-3 text-label font-medium uppercase tracking-wider text-muted-foreground">
           On this page
         </div>
         <ul className="space-y-0.5">
@@ -346,9 +346,9 @@ function SettingsGroup({
   return (
     <section id={id} className="scroll-mt-6">
       <header className="mb-5 border-b border-border pb-3">
-        <h2 className="text-base font-semibold text-foreground">{title}</h2>
+        <h2 className="text-title font-semibold text-foreground">{title}</h2>
         {description ? (
-          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+          <p className="mt-1 text-body text-muted-foreground">{description}</p>
         ) : null}
       </header>
       <div className="space-y-6">{children}</div>
@@ -373,9 +373,9 @@ function SettingsSubsection({
     <div id={id} className="scroll-mt-6">
       <div className="mb-2 flex flex-wrap items-baseline justify-between gap-3">
         <div>
-          <h3 className="text-sm font-medium text-foreground">{title}</h3>
+          <h3 className="text-body font-medium text-foreground">{title}</h3>
           {description ? (
-            <p className="mt-0.5 text-[11px] text-muted-foreground">{description}</p>
+            <p className="mt-0.5 text-label text-muted-foreground">{description}</p>
           ) : null}
         </div>
         {action}
@@ -647,8 +647,8 @@ export default function Settings() {
         <div className="mx-auto max-w-6xl">
           <div className="mb-8 flex flex-wrap items-end justify-between gap-3 border-b border-border pb-4">
             <div>
-              <h1 className="text-xl font-semibold tracking-tight text-foreground">Settings</h1>
-              <p className="mt-1 text-xs text-muted-foreground">
+              <h1 className="text-display font-semibold tracking-tight text-foreground">Settings</h1>
+              <p className="mt-1 text-body text-muted-foreground">
                 Configure what PatchDeck watches, how the agent behaves, and how releases ship.
               </p>
             </div>
@@ -666,7 +666,7 @@ export default function Settings() {
                 }}
                 className="rounded-md border border-border p-4"
               >
-                <label htmlFor="settings-add-pr" className="text-sm">Pull request</label>
+                <label htmlFor="settings-add-pr" className="text-body">Pull request</label>
                 <div className="mt-2 flex gap-2">
                   <input
                     id="settings-add-pr"
@@ -676,13 +676,13 @@ export default function Settings() {
                     placeholder="github.com/owner/repo/pull/123"
                     aria-label="GitHub pull request URL"
                     data-testid="input-add-pr"
-                    className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                    className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-body placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                   />
                   <button
                     type="submit"
                     disabled={addMutation.isPending || !addUrl.trim()}
                     data-testid="button-add-pr"
-                    className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                    className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     Add
                   </button>
@@ -698,7 +698,7 @@ export default function Settings() {
                 }}
                 className="rounded-md border border-border p-4"
               >
-                <label htmlFor="settings-add-repo" className="text-sm">Repository</label>
+                <label htmlFor="settings-add-repo" className="text-body">Repository</label>
                 <div className="mt-2 flex gap-2">
                   <input
                     id="settings-add-repo"
@@ -708,19 +708,19 @@ export default function Settings() {
                     placeholder="owner/repo"
                     aria-label="Repository owner and name"
                     data-testid="input-add-repo"
-                    className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-[12px] placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                    className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-body placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                   />
                   <button
                     type="submit"
                     disabled={addRepoMutation.isPending || !addRepo.trim()}
                     data-testid="button-add-repo"
-                    className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                    className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-label font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                   >
                     Watch
                   </button>
                 </div>
                 <div className="mt-3">
-                  <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                  <div className="text-label uppercase tracking-wider text-muted-foreground">
                     Track automatically
                   </div>
                   <WatchScopeControl
@@ -746,14 +746,14 @@ export default function Settings() {
                       disabled={syncReposMutation.isPending || globalDrainMode}
                       title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Sync watched repos from GitHub"}
                       data-testid="button-sync-repos"
-                      className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-xs font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                      className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-body font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                     >
                       {globalDrainMode ? DRAIN_PAUSED_LABEL : syncReposMutation.isPending ? "Syncing..." : "Sync"}
                     </button>
                   }
                 >
             {repos.length === 0 ? (
-              <div className="rounded-md border border-border p-4 text-[12px] text-muted-foreground">
+              <div className="rounded-md border border-border p-4 text-body text-muted-foreground">
                 No repositories being watched yet.
               </div>
             ) : (
@@ -780,14 +780,14 @@ export default function Settings() {
                             href={getRepoHref(repo.repo)}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="break-all text-sm text-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                            className="break-all text-body text-foreground underline decoration-border underline-offset-2 transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                           >
                             {repo.repo}
                           </a>
-                          <div className="mt-1 text-[11px] text-muted-foreground">
+                          <div className="mt-1 text-label text-muted-foreground">
                             {repo.ownPrsOnly === false ? "Tracking team PRs" : "Tracking your PRs"} · PR monitoring {repo.prAutoMonitor === false ? "manual" : "auto"} · issue evaluate {repo.issueAutoEvaluate ? "auto" : "manual"} · issue work {repo.issueAutoWork ? "auto" : "manual"}
                           </div>
-                          <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider">
+                          <div className="mt-2 flex flex-wrap items-center gap-2 text-label uppercase tracking-wider">
                             <span
                               className={`inline-flex items-center border px-2 py-0.5 ${
                                 repoFullyAuto
@@ -823,7 +823,7 @@ export default function Settings() {
                           disabled={manualReleaseMutation.isPending || globalDrainMode}
                           title={globalDrainMode ? DRAIN_PAUSED_TITLE : "Queue manual release"}
                           data-testid={`tracked-repo-manual-release-${repo.repo.replace("/", "-")}`}
-                          className="shrink-0 border border-border px-2 py-1 text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
+                          className="shrink-0 border border-border px-2 py-1 text-body uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
                         >
                           {globalDrainMode ? DRAIN_PAUSED_LABEL : manualReleasePending ? "Releasing..." : "Release"}
                         </button>
@@ -837,7 +837,7 @@ export default function Settings() {
                           disabled={removeRepoMutation.isPending}
                           title="Stop watching this repository and keep tracked PR history"
                           data-testid={`tracked-repo-soft-remove-${repo.repo.replace("/", "-")}`}
-                          className="shrink-0 border border-border px-2 py-1 text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
+                          className="shrink-0 border border-border px-2 py-1 text-body uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
                         >
                           Unwatch
                         </button>
@@ -851,7 +851,7 @@ export default function Settings() {
                           disabled={removeRepoMutation.isPending}
                           title="Stop watching this repository and remove tracked PRs"
                           data-testid={`tracked-repo-hard-remove-${repo.repo.replace("/", "-")}`}
-                          className="shrink-0 border border-destructive/60 px-2 py-1 text-xs uppercase tracking-wider text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
+                          className="shrink-0 border border-destructive/60 px-2 py-1 text-body uppercase tracking-wider text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-30"
                         >
                           Remove data
                         </button>
@@ -859,7 +859,7 @@ export default function Settings() {
                       {shouldShowRepoAutoAlert && (
                         <div
                           data-testid={`tracked-repo-auto-alert-${repo.repo.replace("/", "-")}`}
-                          className="mt-3 flex flex-wrap items-center justify-between gap-2 border border-warning-border bg-warning-muted px-3 py-2 text-[11px] text-warning-foreground"
+                          className="mt-3 flex flex-wrap items-center justify-between gap-2 border border-warning-border bg-warning-muted px-3 py-2 text-label text-warning-foreground"
                         >
                           <span>
                             Global auto is on, but this repo is not fully automated yet.
@@ -876,7 +876,7 @@ export default function Settings() {
                             }
                             disabled={updateRepoSettingsMutation.isPending}
                             data-testid={`tracked-repo-enable-auto-${repo.repo.replace("/", "-")}`}
-                            className="shrink-0 border border-warning-border bg-background px-2 py-1 text-[10px] uppercase tracking-wider text-warning-foreground transition-colors hover:bg-warning-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-40"
+                            className="shrink-0 border border-warning-border bg-background px-2 py-1 text-label uppercase tracking-wider text-warning-foreground transition-colors hover:bg-warning-muted/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-40"
                           >
                             Enable auto for repo
                           </button>
@@ -885,14 +885,14 @@ export default function Settings() {
                       {config?.autoIssues === false && (
                         <div
                           data-testid={`tracked-repo-global-issues-off-${repo.repo.replace("/", "-")}`}
-                          className="mt-3 border border-warning-border bg-warning-muted px-3 py-2 text-[11px] text-warning-foreground"
+                          className="mt-3 border border-warning-border bg-warning-muted px-3 py-2 text-label text-warning-foreground"
                         >
                           Global Issues auto is off — these per-repo issue controls are paused. Re-enable from the AUTO MODE menu.
                         </div>
                       )}
                       <div className="mt-4 grid gap-4 md:grid-cols-3">
                         <div>
-                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <div className="text-label uppercase tracking-wider text-muted-foreground">
                             Track automatically
                           </div>
                           <WatchScopeControl
@@ -909,7 +909,7 @@ export default function Settings() {
                           />
                         </div>
                         <div>
-                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <div className="text-label uppercase tracking-wider text-muted-foreground">
                             PR monitoring
                           </div>
                           <IssueWorkModeControl
@@ -924,12 +924,12 @@ export default function Settings() {
                             name={`tracked-repo-pr-monitor-${repo.repo}`}
                             testIdPrefix={`tracked-repo-pr-monitor-${repo.repo.replace("/", "-")}`}
                           />
-                          <div className="mt-1 text-[10px] text-muted-foreground">
+                          <div className="mt-1 text-label text-muted-foreground">
                             Manual still syncs PR status; skips automatic PR work.
                           </div>
                         </div>
                         <div>
-                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <div className="text-label uppercase tracking-wider text-muted-foreground">
                             Issue auto-evaluate
                           </div>
                           <IssueWorkModeControl
@@ -946,7 +946,7 @@ export default function Settings() {
                           />
                         </div>
                         <div>
-                          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <div className="text-label uppercase tracking-wider text-muted-foreground">
                             Issue work mode
                           </div>
                           <IssueWorkModeControl
@@ -961,11 +961,11 @@ export default function Settings() {
                             name={`tracked-repo-issue-work-mode-${repo.repo}`}
                             testIdPrefix={`tracked-repo-issue-work-mode-${repo.repo.replace("/", "-")}`}
                           />
-                          <div className="mt-1 text-[10px] text-muted-foreground">
+                          <div className="mt-1 text-label text-muted-foreground">
                             Auto-work also enables auto-evaluate.
                           </div>
                         </div>
-                        <label className="flex items-end gap-2 text-[11px] uppercase tracking-wider text-muted-foreground">
+                        <label className="flex items-end gap-2 text-label uppercase tracking-wider text-muted-foreground">
                           <input
                             type="checkbox"
                             checked={repo.autoCreateReleases}
@@ -984,7 +984,7 @@ export default function Settings() {
                       </div>
                       <div className="mt-4 grid gap-3 border-t border-border pt-4 md:grid-cols-5">
                         <div className="grid gap-2">
-                          <label htmlFor={`tracked-repo-agent-${id}`} className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <label htmlFor={`tracked-repo-agent-${id}`} className="text-label uppercase tracking-wider text-muted-foreground">
                             Agent
                           </label>
                           <select
@@ -999,7 +999,7 @@ export default function Settings() {
                               })
                             }
                             disabled={updateRepoSettingsMutation.isPending}
-                            className="border border-border bg-transparent px-2 py-1 text-xs focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             {REPO_AGENT_OPTIONS.map((option) => (
                               <option key={option.value} value={option.value}>{option.label}</option>
@@ -1007,7 +1007,7 @@ export default function Settings() {
                           </select>
                         </div>
                         <div className="grid gap-2">
-                          <label htmlFor={`tracked-repo-codex-model-${id}`} className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <label htmlFor={`tracked-repo-codex-model-${id}`} className="text-label uppercase tracking-wider text-muted-foreground">
                             Codex model
                           </label>
                           <select
@@ -1020,7 +1020,7 @@ export default function Settings() {
                               })
                             }
                             disabled={updateRepoSettingsMutation.isPending}
-                            className="border border-border bg-transparent px-2 py-1 text-xs focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             <option value="">Global</option>
                             {CODEX_MODEL_OPTIONS.filter((option) => option.value !== "").map((option) => (
@@ -1029,7 +1029,7 @@ export default function Settings() {
                           </select>
                         </div>
                         <div className="grid gap-2">
-                          <label htmlFor={`tracked-repo-codex-reasoning-${id}`} className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <label htmlFor={`tracked-repo-codex-reasoning-${id}`} className="text-label uppercase tracking-wider text-muted-foreground">
                             Codex thinking
                           </label>
                           <select
@@ -1044,7 +1044,7 @@ export default function Settings() {
                               })
                             }
                             disabled={updateRepoSettingsMutation.isPending}
-                            className="border border-border bg-transparent px-2 py-1 text-xs focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             <option value="">Global</option>
                             {CODEX_REASONING_OPTIONS.map((option) => (
@@ -1053,7 +1053,7 @@ export default function Settings() {
                           </select>
                         </div>
                         <div className="grid gap-2">
-                          <label htmlFor={`tracked-repo-claude-model-${id}`} className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <label htmlFor={`tracked-repo-claude-model-${id}`} className="text-label uppercase tracking-wider text-muted-foreground">
                             Claude model
                           </label>
                           <select
@@ -1066,7 +1066,7 @@ export default function Settings() {
                               })
                             }
                             disabled={updateRepoSettingsMutation.isPending}
-                            className="border border-border bg-transparent px-2 py-1 text-xs focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             <option value="">Global</option>
                             {CLAUDE_MODEL_OPTIONS.filter((option) => option.value !== "").map((option) => (
@@ -1075,7 +1075,7 @@ export default function Settings() {
                           </select>
                         </div>
                         <div className="grid gap-2">
-                          <label htmlFor={`tracked-repo-claude-effort-${id}`} className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <label htmlFor={`tracked-repo-claude-effort-${id}`} className="text-label uppercase tracking-wider text-muted-foreground">
                             Claude thinking
                           </label>
                           <select
@@ -1090,7 +1090,7 @@ export default function Settings() {
                               })
                             }
                             disabled={updateRepoSettingsMutation.isPending}
-                            className="border border-border bg-transparent px-2 py-1 text-xs focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             <option value="">Global</option>
                             {CLAUDE_EFFORT_OPTIONS.map((option) => (
@@ -1112,8 +1112,8 @@ export default function Settings() {
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <label htmlFor="settings-coding-agent" className="text-sm">Coding Agent</label>
-                  <div className="text-[11px] text-muted-foreground">
+                  <label htmlFor="settings-coding-agent" className="text-body">Coding Agent</label>
+                  <div className="text-label text-muted-foreground">
                     CLI agent used to apply fixes
                   </div>
                 </div>
@@ -1125,7 +1125,7 @@ export default function Settings() {
                     updateConfigMutation.mutate({ codingAgent: newAgent });
                   }}
                   disabled={updateConfigMutation.isPending}
-                  className="border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                  className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                 >
                   {AGENT_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>{option.label}</option>
@@ -1134,7 +1134,7 @@ export default function Settings() {
               </div>
               <div className="grid gap-3 md:grid-cols-2">
                 <div className="grid gap-2">
-                  <label htmlFor="settings-codex-model" className="text-xs uppercase tracking-wider text-muted-foreground">
+                  <label htmlFor="settings-codex-model" className="text-body uppercase tracking-wider text-muted-foreground">
                     Codex model
                   </label>
                   <select
@@ -1142,7 +1142,7 @@ export default function Settings() {
                     value={config?.codexModel ?? ""}
                     onChange={(e) => updateConfigMutation.mutate({ codexModel: e.target.value })}
                     disabled={updateConfigMutation.isPending}
-                    className="border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                    className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                   >
                     {CODEX_MODEL_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
@@ -1150,7 +1150,7 @@ export default function Settings() {
                   </select>
                 </div>
                 <div className="grid gap-2">
-                  <label htmlFor="settings-codex-reasoning" className="text-xs uppercase tracking-wider text-muted-foreground">
+                  <label htmlFor="settings-codex-reasoning" className="text-body uppercase tracking-wider text-muted-foreground">
                     Codex thinking
                   </label>
                   <select
@@ -1158,7 +1158,7 @@ export default function Settings() {
                     value={config?.codexReasoningEffort ?? "default"}
                     onChange={(e) => updateConfigMutation.mutate({ codexReasoningEffort: e.target.value as Config["codexReasoningEffort"] })}
                     disabled={updateConfigMutation.isPending}
-                    className="border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                    className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                   >
                     {CODEX_REASONING_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
@@ -1166,7 +1166,7 @@ export default function Settings() {
                   </select>
                 </div>
                 <div className="grid gap-2">
-                  <label htmlFor="settings-claude-model" className="text-xs uppercase tracking-wider text-muted-foreground">
+                  <label htmlFor="settings-claude-model" className="text-body uppercase tracking-wider text-muted-foreground">
                     Claude model
                   </label>
                   <select
@@ -1174,7 +1174,7 @@ export default function Settings() {
                     value={config?.claudeModel ?? "opus"}
                     onChange={(e) => updateConfigMutation.mutate({ claudeModel: e.target.value })}
                     disabled={updateConfigMutation.isPending}
-                    className="border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                    className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                   >
                     {CLAUDE_MODEL_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
@@ -1182,7 +1182,7 @@ export default function Settings() {
                   </select>
                 </div>
                 <div className="grid gap-2">
-                  <label htmlFor="settings-claude-effort" className="text-xs uppercase tracking-wider text-muted-foreground">
+                  <label htmlFor="settings-claude-effort" className="text-body uppercase tracking-wider text-muted-foreground">
                     Claude thinking
                   </label>
                   <select
@@ -1190,7 +1190,7 @@ export default function Settings() {
                     value={config?.claudeEffort ?? "default"}
                     onChange={(e) => updateConfigMutation.mutate({ claudeEffort: e.target.value as Config["claudeEffort"] })}
                     disabled={updateConfigMutation.isPending}
-                    className="border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                    className="border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                   >
                     {CLAUDE_EFFORT_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>{option.label}</option>
@@ -1200,8 +1200,8 @@ export default function Settings() {
               </div>
               <label className="flex items-start justify-between gap-3">
                 <div>
-                  <div className="text-sm">Fallback to next coding agent</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Fallback to next coding agent</div>
+                  <div className="text-label text-muted-foreground">
                     If the configured agent cannot start or authenticate, retry the automation run with the other local agent.
                   </div>
                 </div>
@@ -1225,8 +1225,8 @@ export default function Settings() {
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
               <label className="flex items-center justify-between gap-3 cursor-pointer">
                 <div>
-                  <div className="text-sm">Auto-fix conflicts</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Auto-fix conflicts</div>
+                  <div className="text-label text-muted-foreground">
                     Ask the agent to fix merge conflicts when tracked PRs are not mergeable.
                   </div>
                 </div>
@@ -1245,8 +1245,8 @@ export default function Settings() {
               </label>
               <label className="flex items-center justify-between gap-3 cursor-pointer">
                 <div>
-                  <div className="text-sm">Auto-update docs</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Auto-update docs</div>
+                  <div className="text-label text-muted-foreground">
                     Automatically assess whether tracked PRs need documentation updates.
                   </div>
                 </div>
@@ -1315,8 +1315,8 @@ export default function Settings() {
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-sm">Automatic CI healing</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Automatic CI healing</div>
+                  <div className="text-label text-muted-foreground">
                     Classify healable CI failures and run bounded repair attempts in isolated worktrees.
                   </div>
                 </div>
@@ -1398,8 +1398,8 @@ export default function Settings() {
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
               <label className="flex items-start justify-between gap-3">
                 <div>
-                  <div className="text-sm">Automatic release creation</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Automatic release creation</div>
+                  <div className="text-label text-muted-foreground">
                     Evaluate merged PRs and publish GitHub releases automatically when the agent decides they are release-worthy.
                   </div>
                 </div>
@@ -1422,25 +1422,25 @@ export default function Settings() {
                 data-testid="github-auth-status"
               >
                 <div className="min-w-0">
-                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground">Active account</div>
-                  <div className="truncate font-mono text-sm">
+                  <div className="text-label uppercase tracking-wider text-muted-foreground">Active account</div>
+                  <div className="truncate font-mono text-body">
                     {githubAuthStatus?.connected && githubAuthStatus.login
                       ? `@${githubAuthStatus.login}`
                       : "not connected"}
                   </div>
                   {githubAuthStatus?.error ? (
-                    <div className="mt-1 text-[11px] text-destructive">{githubAuthStatus.error}</div>
+                    <div className="mt-1 text-label text-destructive">{githubAuthStatus.error}</div>
                   ) : null}
                 </div>
-                <div className="shrink-0 text-[11px] text-muted-foreground">
+                <div className="shrink-0 text-label text-muted-foreground">
                   source: <span className="font-mono text-foreground">{GITHUB_AUTH_SOURCE_LABEL[githubAuthStatus?.source ?? "none"]}</span>
                 </div>
               </div>
               <div className="flex flex-col gap-3">
                 <div className="flex items-center justify-between gap-3">
                   <div>
-                    <div className="text-sm">Tokens</div>
-                    <div className="text-[11px] text-muted-foreground">
+                    <div className="text-body">Tokens</div>
+                    <div className="text-label text-muted-foreground">
                       Tried in order before GITHUB_TOKEN and gh auth. For fine-grained PATs, give the watched repos
                       Metadata: read, Contents: read/write if you push, Issues: read/write, Pull requests: read/write,
                       and Checks: read. Tokens from the same GitHub account share the same rate-limit bucket.
@@ -1450,7 +1450,7 @@ export default function Settings() {
                     <button
                       type="button"
                       onClick={() => setShowTokenInput(true)}
-                      className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                      className="border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                     >
                       add
                     </button>
@@ -1464,8 +1464,8 @@ export default function Settings() {
                         className="flex items-center justify-between gap-3 border border-border px-2 py-1.5"
                       >
                         <div className="min-w-0">
-                          <div className="truncate font-mono text-xs">{token}</div>
-                          <div className="text-[10px] text-muted-foreground">
+                          <div className="truncate font-mono text-body">{token}</div>
+                          <div className="text-label text-muted-foreground">
                             priority {index + 1}
                           </div>
                         </div>
@@ -1474,7 +1474,7 @@ export default function Settings() {
                             type="button"
                             onClick={() => moveGithubToken(index, index - 1)}
                             disabled={index === 0 || updateConfigMutation.isPending}
-                            className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             up
                           </button>
@@ -1482,7 +1482,7 @@ export default function Settings() {
                             type="button"
                             onClick={() => moveGithubToken(index, index + 1)}
                             disabled={index === githubTokens.length - 1 || updateConfigMutation.isPending}
-                            className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             down
                           </button>
@@ -1490,7 +1490,7 @@ export default function Settings() {
                             type="button"
                             onClick={() => removeGithubToken(index)}
                             disabled={updateConfigMutation.isPending}
-                            className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                            className="border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                           >
                             remove
                           </button>
@@ -1499,7 +1499,7 @@ export default function Settings() {
                     ))}
                   </div>
                 ) : (
-                  <div className="text-[11px] text-muted-foreground">none configured</div>
+                  <div className="text-label text-muted-foreground">none configured</div>
                 )}
                 {showTokenInput ? (
                   <div className="flex items-center gap-2">
@@ -1509,7 +1509,7 @@ export default function Settings() {
                       onChange={(e) => setNewGithubToken(e.target.value)}
                       placeholder="ghp_..."
                       aria-label="GitHub token"
-                      className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                      className="min-w-0 flex-1 border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                     />
                     <button
                       type="button"
@@ -1522,7 +1522,7 @@ export default function Settings() {
                         }
                       }}
                       disabled={!newGithubToken.trim() || updateConfigMutation.isPending}
-                      className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                      className="border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                     >
                       add
                     </button>
@@ -1532,7 +1532,7 @@ export default function Settings() {
                         setShowTokenInput(false);
                         setNewGithubToken("");
                       }}
-                      className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                      className="px-2 py-1 text-body text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                     >
                       cancel
                     </button>
@@ -1541,7 +1541,7 @@ export default function Settings() {
 
                 <div className="mt-1 flex flex-col gap-2">
                   <div className="flex items-center justify-between gap-3">
-                    <div className="text-[11px] text-muted-foreground">
+                    <div className="text-label text-muted-foreground">
                       Run a direct GitHub auth and rate-limit check for each configured token.
                     </div>
                     <div className="flex items-center gap-2">
@@ -1550,7 +1550,7 @@ export default function Settings() {
                           type="button"
                           onClick={() => setTokenTestLogs([])}
                           data-testid="button-clear-github-token-tests"
-                          className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                          className="px-2 py-1 text-body text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                         >
                           clear
                         </button>
@@ -1560,7 +1560,7 @@ export default function Settings() {
                         onClick={() => testGitHubTokensMutation.mutate()}
                         disabled={testGitHubTokensMutation.isPending}
                         data-testid="button-test-github-tokens"
-                        className="border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                        className="border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                       >
                         {testGitHubTokensMutation.isPending
                           ? `testing ${githubTokens.length} key${githubTokens.length === 1 ? "" : "s"}…`
@@ -1568,7 +1568,7 @@ export default function Settings() {
                       </button>
                     </div>
                   </div>
-                  <div className="min-h-[8rem] max-h-52 overflow-y-auto border border-border/80 bg-background/40 p-2 text-[11px] leading-relaxed">
+                  <div className="min-h-[8rem] max-h-52 overflow-y-auto border border-border/80 bg-background/40 p-2 text-label leading-relaxed">
                     {tokenTestLogs.length === 0 ? (
                       <div className="text-muted-foreground">No key tests run yet.</div>
                     ) : (
@@ -1577,7 +1577,7 @@ export default function Settings() {
                           key={`${log.timestamp}-${logIndex}`}
                           className="mb-3 last:mb-0 border-b border-border/40 pb-2 last:border-b-0 last:pb-0"
                         >
-                          <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          <div className="mb-1 text-label uppercase tracking-wider text-muted-foreground">
                             {new Date(log.timestamp).toLocaleTimeString("en-US")}
                             {log.tokensTested > 0
                               ? ` · ${log.tokensTested} key${log.tokensTested === 1 ? "" : "s"}`
@@ -1597,7 +1597,7 @@ export default function Settings() {
                                     <div className="flex flex-wrap items-center gap-2 font-mono">
                                       <span className="text-muted-foreground">#{data.index}</span>
                                       <span
-                                        className={`inline-flex items-center rounded-sm border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider ${TOKEN_TEST_STATUS_CLASS[data.status]}`}
+                                        className={`inline-flex items-center rounded-sm border px-1.5 py-0.5 text-label font-semibold uppercase tracking-wider ${TOKEN_TEST_STATUS_CLASS[data.status]}`}
                                       >
                                         {data.status}
                                       </span>
@@ -1616,7 +1616,7 @@ export default function Settings() {
                               if (item.kind === "error") {
                                 return (
                                   <div key={key} className="flex flex-wrap items-center gap-2 font-mono">
-                                    <span className="inline-flex items-center rounded-sm border border-destructive/40 bg-destructive/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-destructive">
+                                    <span className="inline-flex items-center rounded-sm border border-destructive/40 bg-destructive/10 px-1.5 py-0.5 text-label font-semibold uppercase tracking-wider text-destructive">
                                       error
                                     </span>
                                     <span className="break-words text-destructive">{item.message}</span>
@@ -1636,10 +1636,10 @@ export default function Settings() {
               </div>
 
               <div className="flex flex-col gap-2">
-                <label htmlFor="settings-github-comment-app-name" className="text-sm">
+                <label htmlFor="settings-github-comment-app-name" className="text-body">
                   GitHub reply signature
                 </label>
-                <div className="text-[11px] text-muted-foreground">
+                <div className="text-label text-muted-foreground">
                   Replace the app name shown in public GitHub replies. Leave blank to remove it.
                 </div>
                 <input
@@ -1660,14 +1660,14 @@ export default function Settings() {
                     }
                   }}
                   disabled={updateConfigMutation.isPending}
-                  className="w-full border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                  className="w-full border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                 />
               </div>
 
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-sm">Repository links in PR comments</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Repository links in PR comments</div>
+                  <div className="text-label text-muted-foreground">
                     Link the reply signature back to the project repository in agent-authored GitHub PR comments and footers.
                   </div>
                 </div>
@@ -1687,8 +1687,8 @@ export default function Settings() {
 
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-sm">GitHub progress replies</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">GitHub progress replies</div>
+                  <div className="text-label text-muted-foreground">
                     Post public Accepted/In progress/Verifying status replies while automation works on review comments.
                   </div>
                 </div>
@@ -1741,7 +1741,7 @@ export default function Settings() {
             <div className="flex flex-col gap-4 rounded-md border border-border p-4">
               {(githubRateLimit?.limited || githubRateLimit?.recentlyLimited) ? (
                 <div
-                  className="border-l-2 border-warning bg-warning-muted/40 px-3 py-2 text-[11px] text-warning-foreground"
+                  className="border-l-2 border-warning bg-warning-muted/40 px-3 py-2 text-label text-warning-foreground"
                   data-testid="runtime-github-rate-limit"
                 >
                   {githubRateLimit?.limited && githubRateLimit.resetAt
@@ -1751,12 +1751,12 @@ export default function Settings() {
               ) : null}
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
-                  <div className="text-sm">Automation</div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-body">Automation</div>
+                  <div className="text-label text-muted-foreground">
                     Drain mode blocks new agent runs. In-flight runs continue until they finish.
                   </div>
                   <div
-                    className="mt-2 text-[11px]"
+                    className="mt-2 text-label"
                     aria-live="polite"
                     data-testid="text-drain-status"
                   >
@@ -1774,13 +1774,13 @@ export default function Settings() {
                   }
                   disabled={!runtimeState || drainMutation.isPending}
                   data-testid="button-toggle-drain"
-                  className="shrink-0 border border-border px-2 py-1 text-xs hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+                  className="shrink-0 border border-border px-2 py-1 text-body hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
                 >
                   {getDrainActionLabel(runtimeState)}
                 </button>
               </div>
               {runtimeState?.drainMode && (runtimeState.drainReason || runtimeState.drainRequestedAt) ? (
-                <div className="border-l-2 border-destructive bg-muted/30 px-3 py-2 text-[11px]">
+                <div className="border-l-2 border-destructive bg-muted/30 px-3 py-2 text-label">
                   {runtimeState.drainReason ? (
                     <div className="text-foreground">{runtimeState.drainReason}</div>
                   ) : null}
@@ -1798,7 +1798,7 @@ export default function Settings() {
             <div className="rounded-md border border-border p-4">
               <div className="grid gap-3 md:grid-cols-[1fr_1fr_auto] md:items-end">
                 <div>
-                  <label htmlFor="settings-web-username" className="text-sm">Username</label>
+                  <label htmlFor="settings-web-username" className="text-body">Username</label>
                   <input
                     id="settings-web-username"
                     type="text"
@@ -1807,11 +1807,11 @@ export default function Settings() {
                     placeholder="operator"
                     aria-label="Remote access username"
                     data-testid="input-remote-access-username"
-                    className="mt-2 w-full rounded-md border border-border bg-transparent px-2 py-1 text-sm placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                    className="mt-2 w-full rounded-md border border-border bg-transparent px-2 py-1 text-body placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                   />
                 </div>
                 <div>
-                  <label htmlFor="settings-web-password" className="text-sm">Password</label>
+                  <label htmlFor="settings-web-password" className="text-body">Password</label>
                   <input
                     id="settings-web-password"
                     type="password"
@@ -1820,7 +1820,7 @@ export default function Settings() {
                     placeholder="not configured"
                     aria-label="Remote access password"
                     data-testid="input-remote-access-password"
-                    className="mt-2 w-full rounded-md border border-border bg-transparent px-2 py-1 text-sm placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                    className="mt-2 w-full rounded-md border border-border bg-transparent px-2 py-1 text-body placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
                   />
                 </div>
                 <button
@@ -1833,12 +1833,12 @@ export default function Settings() {
                   }
                   disabled={updateConfigMutation.isPending}
                   data-testid="button-save-remote-access"
-                  className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-xs font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
+                  className="cursor-pointer rounded-md border border-primary bg-primary px-3 py-1 text-body font-medium uppercase tracking-wider text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   Save
                 </button>
               </div>
-              <p className="mt-3 text-[11px] text-muted-foreground">
+              <p className="mt-3 text-label text-muted-foreground">
                 Remote network users must sign in with these credentials. Local loopback access remains open.
               </p>
             </div>
@@ -1890,8 +1890,8 @@ function StringListRow({
     <div className="flex flex-col gap-2">
       <div className="flex items-end gap-2">
         <label htmlFor={inputId} className="min-w-0 flex-1 cursor-pointer">
-          <span className="block text-sm">{label}</span>
-          <span id={descriptionId} className="block text-[11px] text-muted-foreground">{description}</span>
+          <span className="block text-body">{label}</span>
+          <span id={descriptionId} className="block text-label text-muted-foreground">{description}</span>
           <input
             id={inputId}
             type="text"
@@ -1906,14 +1906,14 @@ function StringListRow({
             placeholder={placeholder}
             disabled={disabled}
             aria-describedby={descriptionId}
-            className="mt-2 w-full min-w-0 border border-border bg-transparent px-2 py-1 text-sm focus:border-primary focus:outline-none disabled:opacity-50"
+            className="mt-2 w-full min-w-0 border border-border bg-transparent px-2 py-1 text-body focus:border-primary focus:outline-none disabled:opacity-50"
           />
         </label>
         <button
           type="button"
           onClick={addValue}
           disabled={!draft.trim() || disabled}
-          className="border border-border px-2 py-1 text-xs transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+          className="border border-border px-2 py-1 text-body transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
         >
           add
         </button>
@@ -1923,7 +1923,7 @@ function StringListRow({
           {values.map((value, index) => (
             <span
               key={value}
-              className="inline-flex items-center gap-1.5 border border-border px-2 py-0.5 font-mono text-xs"
+              className="inline-flex items-center gap-1.5 border border-border px-2 py-0.5 font-mono text-body"
             >
               {value}
               <button
@@ -1939,7 +1939,7 @@ function StringListRow({
           ))}
         </div>
       ) : (
-        <div className="text-[11px] text-muted-foreground">none configured</div>
+        <div className="text-label text-muted-foreground">none configured</div>
       )}
     </div>
   );
@@ -1967,8 +1967,8 @@ function SettingRow({
   return (
     <div className="flex items-center justify-between gap-3">
       <div>
-        <label htmlFor={inputId} className="text-sm">{label}</label>
-        <div id={descriptionId} className="text-[11px] text-muted-foreground">{description}</div>
+        <label htmlFor={inputId} className="text-body">{label}</label>
+        <div id={descriptionId} className="text-label text-muted-foreground">{description}</div>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         {canReset && (
@@ -1977,7 +1977,7 @@ function SettingRow({
             onClick={() => onChange(defaultValue)}
             disabled={disabled}
             aria-label={`Reset ${label} to default`}
-            className="rounded-md border border-border px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+            className="rounded-md border border-border px-2 py-1 text-label uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
           >
             Default
           </button>
@@ -1992,7 +1992,7 @@ function SettingRow({
           }}
           disabled={disabled}
           aria-describedby={descriptionId}
-          className="w-28 border border-border bg-transparent px-2 py-1 text-right text-sm focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
+          className="w-28 border border-border bg-transparent px-2 py-1 text-right text-body focus:border-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:opacity-50"
         />
       </div>
     </div>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -85,6 +85,21 @@ type GitHubRateLimitState = {
   resetAt: string | null;
   recentlyLimited: boolean;
   lastLimitedAt: string | null;
+  resources?: {
+    core?: GitHubRateLimitResourceState;
+    graphql?: GitHubRateLimitResourceState;
+    search?: GitHubRateLimitResourceState;
+  };
+};
+
+type GitHubRateLimitResourceState = {
+  limited: boolean;
+  resetAt: string | null;
+  recentlyLimited: boolean;
+  lastLimitedAt: string | null;
+  budget: { remaining: number; limit: number; percentRemaining: number; resetAt: string | null } | null;
+  belowReserve: boolean;
+  belowFloor: boolean;
 };
 
 type GitHubAuthStatus = {
@@ -436,6 +451,10 @@ export default function Settings() {
     queryKey: ["/api/github-rate-limit"],
     refetchInterval: uiPollIntervalMs,
   });
+  const githubBudgetRows = (["core", "graphql", "search"] as const).map((resource) => ({
+    resource,
+    state: githubRateLimit?.resources?.[resource],
+  }));
   const { data: githubAuthStatus } = useQuery<GitHubAuthStatus>({
     queryKey: ["/api/github-auth/status"],
     refetchInterval: uiPollIntervalMs,
@@ -1749,6 +1768,33 @@ export default function Settings() {
                     : "GitHub rate limit was hit recently. Sync may be delayed."}
                 </div>
               ) : null}
+              <div className="grid gap-3 text-label sm:grid-cols-3" data-testid="runtime-github-budget">
+                {githubBudgetRows.map(({ resource, state }) => {
+                  const budget = state?.budget ?? null;
+                  const tone = state?.belowFloor
+                    ? "border-destructive text-destructive"
+                    : state?.belowReserve
+                      ? "border-warning-border text-warning-foreground"
+                      : "border-border text-muted-foreground";
+                  return (
+                    <div key={resource} className={`border-l-2 pl-2 ${tone}`}>
+                      <div className="uppercase tracking-wider">{resource}</div>
+                      <div className="mt-1 text-body text-foreground">
+                        {budget ? `${budget.remaining}/${budget.limit}` : "unknown"}
+                      </div>
+                      <div className="mt-0.5 uppercase tracking-wider">
+                        {state?.belowFloor
+                          ? "floor"
+                          : state?.belowReserve
+                            ? "reserve"
+                            : budget
+                              ? `${budget.percentRemaining}% left`
+                              : "not observed"}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <div className="text-body">Automation</div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,14 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["dist/**", "build/**", "dogfood-output/**", "node_modules/**"],
+    ignores: [
+      "dist/**",
+      "build/**",
+      "dogfood-output/**",
+      "node_modules/**",
+      ".worktrees/**",
+      "src-tauri/target/**",
+    ],
   },
   {
     files: ["**/*.js"],
@@ -45,6 +52,21 @@ export default tseslint.config(
       globals: {
         ...globals.browser,
       },
+    },
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "Literal[value=/text-\\[[0-9]/]",
+          message:
+            "Use the named font-size tokens (text-label/text-body/text-title/text-display) instead of arbitrary text-[…] sizes.",
+        },
+        {
+          selector: "TemplateElement[value.raw=/text-\\[[0-9]/]",
+          message:
+            "Use the named font-size tokens (text-label/text-body/text-title/text-display) instead of arbitrary text-[…] sizes.",
+        },
+      ],
     },
   },
   {

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -140,6 +140,32 @@ test("runtime queueBabysit records durable PR work intent", async () => {
   assert.ok(logs.some((log) => log.message === "Queued PR work resumed this PR after a failed run"));
 });
 
+test("runtime activity preserves monitor follow-up labels", async () => {
+  const storage = new MemStorage();
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+  });
+  const pr = await seedPR(storage);
+  await storage.enqueueBackgroundJob({
+    kind: "babysit_pr",
+    targetId: pr.id,
+    dedupeKey: `babysit_pr:${pr.id}:monitor:test`,
+    payload: {
+      monitorFollowUp: true,
+      activityLabel: "Monitoring PR #42",
+      activityDetail: "acme/widgets - feat: add widget",
+      activityTargetUrl: pr.url,
+    },
+  });
+
+  const activities = await runtime.listActivities();
+
+  assert.equal(activities.queued[0]?.label, "Monitoring PR #42");
+  assert.equal(activities.queued[0]?.detail, "acme/widgets - feat: add widget");
+});
+
 test("runtime queueBabysit uses repo agent override when configured", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -973,9 +973,88 @@ test("syncRepos syncs issues and persists the new etag when the issue list chang
   );
 });
 
+test("listIssues stays cached-only when issue automation is off", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoIssues: false, watchedRepos: ["owner/repo"] });
+  await storage.upsertSyncedIssues("owner/repo", [{
+    number: 7,
+    title: "Cached issue",
+    body: "cached body",
+    bodyHtml: null,
+    url: "https://github.com/owner/repo/issues/7",
+    repoFullName: "owner/repo",
+    repoCloneUrl: "https://github.com/owner/repo.git",
+    author: "alice",
+    labels: ["needs-triage"],
+    assignees: [],
+    comments: 0,
+    createdAt: "2026-05-03T17:00:00.000Z",
+    updatedAt: "2026-05-03T18:00:00.000Z",
+  }], "2026-05-03T18:00:00.000Z");
+
+  let buildOctokitCalls = 0;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    buildOctokitFn: async () => {
+      buildOctokitCalls += 1;
+      return {
+        paginate: async () => {
+          throw new Error("issue timeline should not be fetched when issue automation is off");
+        },
+      } as never;
+    },
+  });
+
+  const page = await runtime.listIssues({ limit: 50, offset: 0 });
+
+  assert.equal(page.items.length, 1);
+  assert.equal(page.items[0]?.title, "Cached issue");
+  assert.equal(page.items[0]?.externalWorkPrNumber, null);
+  assert.equal(buildOctokitCalls, 0, "disabled issue automation must not enrich list rows through GitHub");
+});
+
+test("getIssue stays cached-only when issue automation is off", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoIssues: false, watchedRepos: ["owner/repo"] });
+  await storage.upsertSyncedIssues("owner/repo", [{
+    number: 7,
+    title: "Cached issue",
+    body: "cached body",
+    bodyHtml: null,
+    url: "https://github.com/owner/repo/issues/7",
+    repoFullName: "owner/repo",
+    repoCloneUrl: "https://github.com/owner/repo.git",
+    author: "alice",
+    labels: ["needs-triage"],
+    assignees: [],
+    comments: 0,
+    createdAt: "2026-05-03T17:00:00.000Z",
+    updatedAt: "2026-05-03T18:00:00.000Z",
+  }], "2026-05-03T18:00:00.000Z");
+
+  let buildOctokitCalls = 0;
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+    buildOctokitFn: async () => {
+      buildOctokitCalls += 1;
+      throw new Error("issue detail should not fetch GitHub when issue automation is off");
+    },
+  });
+
+  const issue = await runtime.getIssue("owner/repo", 7);
+
+  assert.equal(issue.title, "Cached issue");
+  assert.equal(issue.externalWorkPrNumber, null);
+  assert.equal(buildOctokitCalls, 0, "disabled issue automation must keep issue detail cached-only");
+});
+
 test("syncIssue refreshes worked issue metadata from GitHub", async () => {
   const storage = new MemStorage();
-  await storage.updateConfig({ watchedRepos: ["owner/repo"] });
+  await storage.updateConfig({ autoIssues: false, watchedRepos: ["owner/repo"] });
   await storage.upsertSyncedIssues("owner/repo", [{
     number: 7,
     title: "Old title",

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -108,6 +108,38 @@ test("runtime queueBabysit enqueues a babysit job using the configured agent", a
   assert.equal(jobs[0]?.payload.activityTargetUrl, pr.url);
 });
 
+test("runtime queueBabysit records durable PR work intent", async () => {
+  const storage = new MemStorage();
+  const runtime = createAppRuntime({
+    storage,
+    startBackgroundServices: false,
+    startWatcher: false,
+  });
+  const pr = await seedPR(storage, {
+    status: "error",
+    watchEnabled: false,
+  });
+
+  const updated = await runtime.queueBabysit(pr.id);
+
+  assert.equal(updated.status, "watching");
+  assert.equal(updated.watchEnabled, true);
+
+  const config = await storage.getConfig();
+  assert.deepEqual(config.watchedRepos, ["acme/widgets"]);
+
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    status: "queued",
+  });
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0]?.targetId, pr.id);
+
+  const logs = await storage.getLogs(pr.id);
+  assert.ok(logs.some((log) => log.message === "Background watch resumed by queued PR work"));
+  assert.ok(logs.some((log) => log.message === "Queued PR work resumed this PR after a failed run"));
+});
+
 test("runtime queueBabysit uses repo agent override when configured", async () => {
   const storage = new MemStorage();
   const runtime = createAppRuntime({

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -2014,6 +2014,37 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     );
   };
 
+  const activatePRWorkIntent = async (pr: PR, config: Config): Promise<{ pr: PR; config: Config }> => {
+    let nextConfig = config;
+    if (!nextConfig.watchedRepos.includes(pr.repo)) {
+      nextConfig = await storage.updateConfig({
+        watchedRepos: [...nextConfig.watchedRepos, pr.repo].sort((a, b) => a.localeCompare(b)),
+      });
+      await storage.addLog(pr.id, "info", `Repository ${pr.repo} added to automatic PR work watch list`);
+    }
+
+    const updates: Partial<PR> = {};
+    if (pr.watchEnabled === false) {
+      updates.watchEnabled = true;
+    }
+    if (pr.status === "error") {
+      updates.status = "watching";
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return { pr, config: nextConfig };
+    }
+
+    const updated = assertFound(await storage.updatePR(pr.id, updates), "PR not found");
+    if (updates.watchEnabled === true) {
+      await storage.addLog(pr.id, "info", "Background watch resumed by queued PR work");
+    }
+    if (updates.status === "watching") {
+      await storage.addLog(pr.id, "info", "Queued PR work resumed this PR after a failed run");
+    }
+    return { pr: updated, config: nextConfig };
+  };
+
   const queueBabysitForRepo = async (pr: PR, config: Config) => {
     const repoSettings = await storage.getRepoSettings(pr.repo);
     await queueBabysitWithAgent(pr, resolveRepoCodingAgent(config, repoSettings));
@@ -2406,10 +2437,15 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       const repoSlug = `${parsed.owner}/${parsed.repo}`;
       const existing = await storage.getPRByRepoAndNumber(repoSlug, parsed.number);
       if (existing) {
-        return existing;
+        const config = await storage.getConfig();
+        const activated = await activatePRWorkIntent(existing, config);
+        await storage.addLog(activated.pr.id, "info", "PR already tracked; queued PR work and monitoring");
+        await queueBabysitForRepo(activated.pr, activated.config);
+        notifyChange();
+        return activated.pr;
       }
 
-      const config = await storage.getConfig();
+      let config = await storage.getConfig();
       const octokit = await buildOctokit(config);
       const summary = await fetchPullSummary(octokit, parsed);
 
@@ -2437,7 +2473,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       await storage.addLog(pr.id, "info", `Repository ${repoSlug} added to automatic PR work watch list`);
 
       if (!config.watchedRepos.includes(repoSlug)) {
-        await storage.updateConfig({
+        config = await storage.updateConfig({
           watchedRepos: [...config.watchedRepos, repoSlug].sort((a, b) => a.localeCompare(b)),
         });
       }
@@ -2560,13 +2596,13 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         });
       }
 
-      const config = await storage.getConfig();
-      const repoSettings = await storage.getRepoSettings(pr.repo);
+      const { pr: activatedPr, config } = await activatePRWorkIntent(pr, await storage.getConfig());
+      const repoSettings = await storage.getRepoSettings(activatedPr.repo);
       const selectedAgent = resolveRepoCodingAgent(config, repoSettings);
-      await storage.addLog(pr.id, "info", `Queued manual PR work using ${selectedAgent}`);
-      await queueBabysitForRepo(pr, config);
+      await storage.addLog(activatedPr.id, "info", `Queued manual PR work using ${selectedAgent}`);
+      await queueBabysitForRepo(activatedPr, config);
 
-      const updated = await storage.getPR(pr.id);
+      const updated = await storage.getPR(activatedPr.id);
       notifyChange();
       return assertFound(updated, "PR disappeared after apply run");
     },
@@ -2581,13 +2617,13 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         });
       }
 
-      const config = await storage.getConfig();
-      const repoSettings = await storage.getRepoSettings(pr.repo);
+      const { pr: activatedPr, config } = await activatePRWorkIntent(pr, await storage.getConfig());
+      const repoSettings = await storage.getRepoSettings(activatedPr.repo);
       const selectedAgent = resolveRepoCodingAgent(config, repoSettings);
-      await storage.addLog(pr.id, "info", `Queued manual PR work using ${selectedAgent}`);
-      await queueBabysitForRepo(pr, config);
+      await storage.addLog(activatedPr.id, "info", `Queued manual PR work using ${selectedAgent}`);
+      await queueBabysitForRepo(activatedPr, config);
 
-      const updated = await storage.getPR(pr.id);
+      const updated = await storage.getPR(activatedPr.id);
       notifyChange();
       return assertFound(updated, "PR disappeared after babysit run");
     },

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -1297,6 +1297,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     issue: Awaited<ReturnType<typeof fetchIssueSummary>>,
     options: {
       includePrMergeability?: boolean;
+      includeExternalPrLinks?: boolean;
       issueJobs?: BackgroundJob[];
       octokit?: Awaited<ReturnType<typeof buildOctokit>>;
       isWorked?: boolean;
@@ -1322,7 +1323,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }, evaluation);
     let externalPr: { number: number; url: string; repoFullName: string } | null = null;
     const parsedIssueRepo = parseRepoSlug(issue.repoFullName);
-    const linkedOpenPrs = options.octokit && parsedIssueRepo
+    const linkedOpenPrs = options.includeExternalPrLinks !== false && options.octokit && parsedIssueRepo
       ? await listOpenLinkedPullRequestsForIssue(options.octokit, parsedIssueRepo, issue.number)
       : [];
     if (linkedOpenPrs.length > 0) {
@@ -1492,7 +1493,8 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
     const synced = await storage.listSyncedIssues({ repos: config.watchedRepos, limit, offset, includeWorked: true });
     const counts = await storage.listSyncedIssueCounts({ repos: config.watchedRepos, includeWorked: true });
-    const octokit = await buildOctokit(config);
+    const issueAutomationEnabled = config.autoIssues !== false;
+    const octokit = issueAutomationEnabled ? await buildOctokit(config) : null;
     const workJobs = await storage.listBackgroundJobs({ kind: "work_issue" });
     const workJobsByTarget = new Map<string, BackgroundJob[]>();
 
@@ -1509,8 +1511,9 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       markIssueSyncSuccess(targetId, attemptedAt);
       return applyIssueWorkState(issue, {
         issueJobs: workJobsByTarget.get(targetId) ?? [],
-        includePrMergeability: record.isWorked,
-        octokit,
+        includePrMergeability: issueAutomationEnabled && record.isWorked,
+        includeExternalPrLinks: issueAutomationEnabled,
+        octokit: octokit ?? undefined,
         isWorked: record.isWorked,
       });
     }));
@@ -1545,8 +1548,20 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       throw new AppRuntimeError(404, `Repository ${canonical} is not being watched`);
     }
 
-    const octokit = await buildOctokitImpl(config);
     const targetId = formatIssueTargetId(canonical, number);
+    if (config.autoIssues === false) {
+      const cached = await storage.getSyncedIssue(canonical, number);
+      if (!cached) {
+        throw new AppRuntimeError(404, `Issue ${canonical}#${number} has not been synced yet`);
+      }
+      return applyIssueWorkState(cached.payload, {
+        includePrMergeability: false,
+        includeExternalPrLinks: false,
+        isWorked: cached.isWorked,
+      });
+    }
+
+    const octokit = await buildOctokitImpl(config);
     const attemptedAt = markIssueSyncAttempt(targetId);
     try {
       const issue = await fetchIssueSummary(octokit, { ...parsedRepo, number });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -1842,6 +1842,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
 
     if (job.kind === "babysit_pr") {
+      if (job.payload.monitorFollowUp === true && payloadDescription) {
+        return normalizeActivityDescription(payloadDescription);
+      }
+
       const pr = context.prsById.get(job.targetId);
       if (pr) {
         return {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -1148,6 +1148,17 @@ test("syncAndBabysitTrackedRepos enqueues no babysit_pr jobs while the core budg
     await babysitter.syncAndBabysitTrackedRepos();
     const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
     assert.equal(jobs.length, 0, "no new babysit jobs are enqueued while the budget is tight");
+    const deferredSweeps = await storage.listBackgroundJobs({ kind: "sync_watched_repos", status: "queued" });
+    assert.equal(deferredSweeps.length, 1, "budget pressure schedules a later backfill");
+    assert.equal(deferredSweeps[0]?.payload.deferredReason, "core budget reserve");
+    assert.equal(
+      deferredSweeps[0]?.payload.activityDetail,
+      "Waiting for GitHub core budget before refilling PR work queue",
+    );
+    assert.ok(
+      new Date(deferredSweeps[0]?.availableAt ?? 0).getTime() - Date.now() > 50_000,
+      "budget backfill should use a longer cooldown than normal batch pacing",
+    );
   } finally {
     clearRateLimitStateForTests();
   }

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -40,6 +40,8 @@ function makePullSummary(pr: { url: string }, overrides?: Record<string, unknown
   return {
     number: 106,
     title: "Verbose PR",
+    body: null,
+    bodyHtml: null,
     branch: "feature/verbose",
     author: "octocat",
     url: pr.url,
@@ -53,6 +55,10 @@ function makePullSummary(pr: { url: string }, overrides?: Record<string, unknown
     baseSha: "base123",
     mergeable: true as boolean | null,
     mergeableState: "clean" as string | null,
+    merged: false,
+    mergedAt: null,
+    closedAt: null,
+    mergeCommitSha: null,
     ...overrides,
   };
 }
@@ -5735,6 +5741,92 @@ test("babysitPR logs metadata when skipping a duplicate in-progress run", async 
   assert.equal(typeof skipLog?.metadata?.activeRunId, "string");
   assert.equal(typeof skipLog?.metadata?.activeStartedAt, "string");
   assert.equal(typeof skipLog?.metadata?.activeAgeMs, "number");
+});
+
+test("runQueuedBabysitPR archives merged PRs instead of running or rescheduling work", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const queue = new BackgroundJobQueue(storage);
+  const existingItem = makeFeedbackItem();
+  const mergedAt = "2026-05-18T18:36:32.000Z";
+  const pr = await storage.addPR({
+    number: 6300,
+    title: "Merged PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/merged",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/6300",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    mergeableState: "blocked",
+    lastChecked: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      fetchFeedbackItemsForPR: async () => {
+        throw new Error("feedback sync should not run for an already merged PR");
+      },
+      fetchPullSummary: async () => makePullSummary(pr, {
+        number: 6300,
+        title: "Merged PR",
+        branch: "feature/merged",
+        headRef: "feature/merged",
+        headSha: "merged-head",
+        mergeable: false,
+        mergeableState: "blocked",
+        merged: true,
+        mergedAt,
+        closedAt: mergedAt,
+        mergeCommitSha: "merge123",
+      }),
+      listFailingStatuses: async () => {
+        throw new Error("CI status checks should not run for an already merged PR");
+      },
+    }),
+    {
+      checkAgentHealth: async () => {
+        throw new Error("agent health should not be checked for an already merged PR");
+      },
+      resolveAgent: async () => {
+        throw new Error("agent should not resolve for an already merged PR");
+      },
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => {
+        throw new Error("agent should not evaluate an already merged PR");
+      },
+      applyFixesWithAgent: async () => {
+        throw new Error("agent should not apply fixes to an already merged PR");
+      },
+      runCommand: makeGitRunCommand(),
+    },
+    undefined,
+    (kind, targetId, dedupeKey, payload, options) => queue.enqueue(kind, targetId, dedupeKey, payload, options),
+  );
+
+  await babysitter.runQueuedBabysitPR(pr.id, "claude");
+
+  const updated = await storage.getPR(pr.id);
+  assert.equal(updated?.status, "archived");
+  assert.equal(updated?.prStage, "done");
+  assert.equal(updated?.mergeableState, "blocked");
+
+  const [run] = await storage.listAgentRuns({ prId: pr.id });
+  assert.equal(run?.status, "completed");
+  assert.equal(run?.phase, "run.pr_merged");
+  assert.equal(run?.initialHeadSha, "merged-head");
+
+  const queuedJobs = await storage.listBackgroundJobs({ kind: "babysit_pr" });
+  assert.equal(queuedJobs.length, 0);
+
+  const logs = await storage.getLogs(pr.id);
+  assert.ok(logs.some((log) => log.message.includes("was merged on GitHub — archived")));
 });
 
 test("runQueuedBabysitPR rejects when evaluation auth fails after recording the run failure", async () => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -8,6 +8,7 @@ import { APP_COMMENT_FOOTER, PRBabysitter } from "./babysitter";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
 import { clearRateLimitStateForTests, recordResourceBudget } from "./rateLimitState";
+import { SqliteStorage } from "./sqliteStorage";
 
 function makeFeedbackItem(overrides: Partial<FeedbackItem> = {}): FeedbackItem {
   return {
@@ -897,6 +898,68 @@ function makeOctocatPull(n: number) {
     baseSha: "base",
   };
 }
+
+test("syncAndBabysitTrackedRepos reactivates archived PRs instead of inserting duplicates", async () => {
+  clearRateLimitStateForTests();
+  const root = await mkdtemp(path.join(os.tmpdir(), "patchdeck-babysitter-sqlite-"));
+  const storage = new SqliteStorage(root);
+  await storage.updateConfig({
+    watchedRepos: ["octo/example"],
+    maxConcurrentBabysitRuns: 50,
+    autoUpdateDocs: false,
+  });
+  const archived = await storage.addPR({
+    number: 106,
+    title: "Archived PR",
+    repo: "octo/example",
+    branch: "old-branch",
+    author: "octocat",
+    url: "https://github.com/octo/example/pull/106",
+    status: "archived",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      listOpenPullsForRepo: async () => [makeOctocatPull(106)],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+  babysitter.babysitPR = async () => {
+    throw new Error("watcher should enqueue, not babysit directly");
+  };
+
+  await babysitter.syncAndBabysitTrackedRepos({ fullSweep: true });
+
+  const reactivated = await storage.getPR(archived.id);
+  const lookup = await storage.getPRByRepoAndNumber("octo/example", 106);
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: archived.id,
+    status: "queued",
+  });
+
+  assert.equal(lookup?.id, archived.id);
+  assert.equal(reactivated?.status, "watching");
+  assert.equal(reactivated?.title, "PR 106");
+  assert.equal(reactivated?.branch, "feature/106");
+  assert.equal(jobs.length, 1);
+});
 
 test("syncAndBabysitTrackedRepos caps babysit_pr enqueues per repo per sweep", async () => {
   clearRateLimitStateForTests();
@@ -5888,6 +5951,7 @@ test("runQueuedBabysitPR launches code-owner fallback after the default run fail
   });
   const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
   process.env.CODEFACTORY_HOME = worktreeRoot;
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
   const applyCalls: Array<{
     agent: string;
     cwd?: string;
@@ -5899,7 +5963,7 @@ test("runQueuedBabysitPR launches code-owner fallback after the default run fail
     const babysitter = new PRBabysitter(
       storage,
       makeWatcherGitHubService({
-        fetchPullSummary: async () => makePullSummary(pr),
+        fetchPullSummary: async () => makePullSummary(pr, { mergeableState: "blocked" }),
         listFailingStatuses: async () => [{
           context: "build",
           description: "TypeScript compilation failed",
@@ -5926,6 +5990,8 @@ test("runQueuedBabysitPR launches code-owner fallback after the default run fail
           remoteHeadSha: "def456",
         }),
       },
+      undefined,
+      async (...args) => backgroundJobQueue.enqueue(...args),
     );
 
     await babysitter.runQueuedBabysitPR(pr.id, "claude");
@@ -5960,6 +6026,11 @@ test("runQueuedBabysitPR launches code-owner fallback after the default run fail
   assert.equal(typeof fallbackMetadata?.startedAt, "string");
   assert.equal(typeof fallbackMetadata?.completedAt, "string");
   assert.ok(logs.some((log) => log.phase === "code-owner-fallback" && log.message.includes("Launching claude code-owner fallback")));
+  const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0]?.targetId, pr.id);
+  assert.equal(jobs[0]?.payload.monitorFollowUp, true);
+  assert.equal(jobs[0]?.payload.monitorReason, "GitHub mergeable state is blocked");
 });
 
 test("runQueuedBabysitPR records code-owner fallback failure phase", async () => {
@@ -6158,6 +6229,139 @@ test("babysitPR resolves lingering review threads without reposting an existing 
   assert.equal(updatedItem?.status, "resolved");
   assert.deepEqual(postedFollowUps, []);
   assert.deepEqual(resolvedThreads, ["PRRT_kwDO_example"]);
+});
+
+test("babysitPR does not count agent command comments as feedback audit trails", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const existingItem = makeFeedbackItem({
+    id: "gh-issue-comment-risk-report",
+    author: "github-actions[bot]",
+    body: "## PR Risk Report\n\nReview this PR before merge.",
+    bodyHtml: "<h2>PR Risk Report</h2><p>Review this PR before merge.</p>",
+    replyKind: "general_comment",
+    sourceId: "100",
+    sourceNodeId: "IC_kwDO_risk",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#issuecomment-100",
+    threadId: null,
+    threadResolved: null,
+    auditToken: "codefactory-feedback:gh-issue-comment-risk-report",
+    file: null,
+    line: null,
+    type: "general_comment",
+    decision: "accept",
+    decisionReason: "Auto-accepted: trusted reviewer @github-actions[bot]",
+    action: "Review this PR before merge.",
+    status: "in_progress",
+  });
+  const commandComment = makeFeedbackItem({
+    id: "gh-issue-comment-command",
+    author: "octocat",
+    body: `<!-- codefactory-agent-command -->\n\nDispatched agent with ${existingItem.auditToken}`,
+    bodyHtml: `<p>Dispatched agent with ${existingItem.auditToken}</p>`,
+    replyKind: "general_comment",
+    sourceId: "101",
+    sourceNodeId: "IC_kwDO_command",
+    sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#issuecomment-101",
+    threadId: null,
+    threadResolved: null,
+    auditToken: "codefactory-feedback:gh-issue-comment-command",
+    file: null,
+    line: null,
+    type: "general_comment",
+    decision: "reject",
+    decisionReason: "PatchDeck agent command comment",
+    action: null,
+    status: "rejected",
+    statusReason: "PatchDeck agent command comment",
+  });
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem, commandComment],
+    accepted: 1,
+    rejected: 1,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  let feedbackFetchCount = 0;
+  let postedBody = "";
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => {
+        feedbackFetchCount += 1;
+        if (feedbackFetchCount === 1) {
+          return [existingItem, commandComment];
+        }
+
+        return [
+          existingItem,
+          commandComment,
+          makeFeedbackItem({
+            id: "gh-issue-comment-followup",
+            author: "octocat",
+            body: postedBody,
+            bodyHtml: `<p>${postedBody}</p>`,
+            replyKind: "general_comment",
+            sourceId: "102",
+            sourceNodeId: "IC_kwDO_followup",
+            sourceUrl: "https://github.com/alex-morgan-o/lolodex/pull/106#issuecomment-102",
+            threadId: null,
+            threadResolved: null,
+            auditToken: "codefactory-feedback:gh-issue-comment-followup",
+            file: null,
+            line: null,
+            type: "general_comment",
+            createdAt: new Date().toISOString(),
+            decision: null,
+            action: null,
+            status: "pending",
+          }),
+        ];
+      },
+      fetchPullSummary: async () => makePullSummary(pr),
+      listFailingStatuses: async () => [],
+      checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async (_octokit, _parsed, _item, body) => {
+        postedBody = body;
+      },
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => {
+        throw new Error("in-progress feedback should not be re-evaluated");
+      },
+      applyFixesWithAgent: async () => {
+        throw new Error("in-progress feedback recovery should only post the missing follow-up");
+      },
+      runCommand: makeGitRunCommand(),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const updatedItem = updated?.feedbackItems.find((item) => item.id === existingItem.id);
+
+  assert.match(postedBody, new RegExp(existingItem.auditToken));
+  assert.equal(updatedItem?.status, "resolved");
 });
 
 test("babysitPR reposts GitHub follow-up when an earlier audit trail used the wrong thread", async () => {
@@ -7094,6 +7298,108 @@ test("syncAndBabysitTrackedRepos auto-registers only the authenticated user's PR
   assert.deepEqual(queuedTargets, [prs[0]!.id]);
 });
 
+test("syncAndBabysitTrackedRepos caches the authenticated GitHub login across sweeps", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["alex-morgan-o/lolodex"],
+    autoUpdateDocs: false,
+  });
+
+  let loginCalls = 0;
+  const babysitter = new PRBabysitter(
+    storage,
+    makeWatcherGitHubService({
+      getAuthenticatedLogin: async () => {
+        loginCalls += 1;
+        return "OctoCat";
+      },
+      listOpenPullsForRepo: async () => [
+        {
+          number: 106,
+          title: "My PR",
+          branch: "feature/mine",
+          author: "octocat",
+          url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+        },
+      ],
+    }),
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async () => ({} as never),
+  );
+
+  await babysitter.syncAndBabysitTrackedRepos();
+  await babysitter.syncAndBabysitTrackedRepos();
+
+  const prs = await storage.getPRs();
+  assert.equal(prs.length, 1);
+  assert.equal(prs[0]?.number, 106);
+  assert.equal(loginCalls, 1, "the watcher should reuse the authenticated login instead of calling GET /user every sweep");
+});
+
+test("syncAndBabysitTrackedRepos times out authenticated login lookup and cools down", async () => {
+  const previousTimeout = process.env.PATCHDECK_AUTH_LOGIN_TIMEOUT_MS;
+  process.env.PATCHDECK_AUTH_LOGIN_TIMEOUT_MS = "5";
+
+  try {
+    const storage = new MemStorage();
+    await storage.updateConfig({
+      watchedRepos: ["alex-morgan-o/lolodex"],
+      autoUpdateDocs: false,
+    });
+
+    let loginCalls = 0;
+    const babysitter = new PRBabysitter(
+      storage,
+      makeWatcherGitHubService({
+        getAuthenticatedLogin: async () => {
+          loginCalls += 1;
+          return new Promise<string | null>(() => {});
+        },
+        listOpenPullsForRepo: async () => [
+          {
+            number: 106,
+            title: "My PR",
+            branch: "feature/mine",
+            author: "octocat",
+            url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+          },
+        ],
+      }),
+      {
+        resolveAgent: async () => "codex",
+        evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+        applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+        runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+      },
+      undefined,
+      async () => ({} as never),
+    );
+
+    const startedAt = Date.now();
+    await babysitter.syncAndBabysitTrackedRepos();
+    const elapsedMs = Date.now() - startedAt;
+
+    assert.ok(elapsedMs < 500, `watcher should fail closed quickly, took ${elapsedMs}ms`);
+    assert.equal(loginCalls, 2, "the watcher should retry the timed-out lookup once");
+    assert.equal((await storage.getPRs()).length, 0, "own-only filtering should fail closed without an authenticated login");
+
+    await babysitter.syncAndBabysitTrackedRepos();
+    assert.equal(loginCalls, 2, "the failure cooldown should skip immediate repeated GET /user attempts");
+  } finally {
+    if (previousTimeout === undefined) {
+      delete process.env.PATCHDECK_AUTH_LOGIN_TIMEOUT_MS;
+    } else {
+      process.env.PATCHDECK_AUTH_LOGIN_TIMEOUT_MS = previousTimeout;
+    }
+  }
+});
+
 test("syncAndBabysitTrackedRepos can include teammate PRs when repo setting disables own-only filtering", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({
@@ -7307,6 +7613,66 @@ test("babysitPR blocks external CI failures without launching the healing agent"
   assert.equal(healingAgentCalled, false);
 });
 
+test("babysitPR clears a blocked CI healing session when the same head becomes healthy", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoHealCI: true, autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 42,
+    title: "Recovered CI",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/recovered-ci",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/42",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+  const session = await storage.createHealingSession({
+    prId: pr.id,
+    repo: pr.repo,
+    prNumber: pr.number,
+    initialHeadSha: "blocked123",
+    currentHeadSha: "blocked123",
+    state: "blocked",
+    endedAt: "2026-04-29T03:46:32.083Z",
+    blockedReason: "External CI failure likely not fixable in-branch: triage: Check run cancelled",
+    escalationReason: null,
+    latestFingerprint: "github-check-run:cancelled:triage",
+    attemptCount: 0,
+    lastImprovementScore: null,
+  });
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      ...makeWatcherGitHubService(),
+      fetchPullSummary: async () => makePullSummary(pr, { headSha: "blocked123", headRef: pr.branch, branch: pr.branch }),
+      fetchCheckSnapshotsForRef: async () => [],
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCIHealingRepairAttempt: async () => {
+        throw new Error("healing agent should not run after CI turns healthy");
+      },
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updatedSession = await storage.getHealingSession(session.id);
+  assert.equal(updatedSession?.state, "healed");
+  assert.equal(updatedSession?.blockedReason, null);
+  assert.equal(updatedSession?.latestFingerprint, null);
+});
+
 test("babysitPR does not reopen terminal healing sessions for the same head SHA", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ autoHealCI: true, autoUpdateDocs: false });
@@ -7374,6 +7740,268 @@ test("babysitPR does not reopen terminal healing sessions for the same head SHA"
   assert.equal(updatedSession?.state, "escalated");
   assert.equal(healingAgentCalled, false);
   assert.ok(!logs.some((log) => log.message.includes("Illegal healing session transition")));
+});
+
+test("babysitPR falls back to status-task fixes after CI healing escalates", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoHealCI: true, autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 48,
+    title: "Escalated CI still red",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/escalated-status",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/48",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const session = await storage.createHealingSession({
+    prId: pr.id,
+    repo: pr.repo,
+    prNumber: pr.number,
+    initialHeadSha: "same-head",
+    currentHeadSha: "same-head",
+    state: "escalated",
+    endedAt: "2026-04-29T03:46:32.083Z",
+    blockedReason: null,
+    escalationReason: "agent exited with code 124",
+    latestFingerprint: "github-check-run:tests:build",
+    attemptCount: 1,
+    lastImprovementScore: null,
+  });
+
+  const evaluatedPrompts: string[] = [];
+  const appliedPrompts: string[] = [];
+  let healingAgentCalled = false;
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+
+  try {
+    const babysitter = new PRBabysitter(
+      storage,
+      {
+        ...makeWatcherGitHubService(),
+        fetchPullSummary: async () => makePullSummary(pr, { headSha: "same-head", headRef: pr.branch, branch: pr.branch }),
+        fetchCheckSnapshotsForRef: async (_octokit: unknown, _repo: unknown, prId: string, headSha: string) => [
+          makeCheckSnapshot({
+            prId,
+            sha: headSha,
+            description: "Failed steps: Run unit tests",
+          }),
+        ],
+        listFailingStatuses: async (_octokit: unknown, _repo: unknown, sha: string) => (
+          sha === "same-head"
+            ? [{
+                context: "build",
+                description: "Check run failure",
+                targetUrl: "https://github.com/octo/example/actions/runs/1",
+              }]
+            : []
+        ),
+        checkCISettled: async () => true,
+      },
+      {
+        ciPollIntervalMs: 0,
+        resolveAgent: async () => "codex",
+        evaluateFixNecessityWithAgent: async ({ prompt }) => {
+          evaluatedPrompts.push(prompt);
+          return { needsFix: true, reason: "Unit test failure needs a code change" };
+        },
+        applyFixesWithAgent: async ({ prompt }) => {
+          appliedPrompts.push(prompt);
+          return { code: 0, stdout: "", stderr: "" };
+        },
+        runCommand: makeGitRunCommand({
+          localHeadSha: "repaired123",
+          remoteHeadSha: "repaired123",
+        }),
+        runCIHealingRepairAttempt: async () => {
+          healingAgentCalled = true;
+          throw new Error("terminal healing session must not launch the dedicated healing agent");
+        },
+      },
+    );
+
+    await babysitter.babysitPR(pr.id, "codex");
+  } finally {
+    delete process.env.CODEFACTORY_HOME;
+  }
+
+  const updatedSession = await storage.getHealingSession(session.id);
+  const updatedPr = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(healingAgentCalled, false);
+  assert.equal(updatedSession?.state, "escalated");
+  assert.equal(updatedPr?.testsPassed, true);
+  assert.equal(evaluatedPrompts.length, 1);
+  assert.match(evaluatedPrompts[0] ?? "", /Failed steps: Run unit tests/);
+  assert.equal(appliedPrompts.length, 1);
+  assert.match(appliedPrompts[0] ?? "", /Approved status-check tasks/);
+  assert.match(appliedPrompts[0] ?? "", /build: Failed steps: Run unit tests/);
+  assert.ok(logs.some((log) => log.phase === "evaluate.status" && log.message.includes("Evaluating 1 failing status check")));
+  assert.ok(!logs.some((log) => log.phase === "evaluate.status" && log.message.includes("Skipping legacy status-task evaluation")));
+});
+
+test("babysitPR reruns cancelled GitHub Actions checks and queues monitoring", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 50,
+    title: "Cancelled build",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/cancelled-build",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/50",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: false,
+    lintPassed: null,
+    mergeableState: "blocked",
+    lastChecked: null,
+  });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const rerunCalls: Array<{ runId: number; contexts: string[] }> = [];
+  let statusEvaluationCalls = 0;
+  const now = new Date("2026-05-18T11:00:00.000Z");
+  const cancelledSnapshot = makeCheckSnapshot({
+    prId: pr.id,
+    sha: "cancelled-head",
+    conclusion: "cancelled",
+    description: "Check run cancelled",
+    targetUrl: "https://github.com/alex-morgan-o/lolodex/actions/runs/12345/job/67890",
+  });
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      ...makeWatcherGitHubService(),
+      fetchPullSummary: async () => makePullSummary(pr, {
+        headSha: "cancelled-head",
+        headRef: pr.branch,
+        branch: pr.branch,
+        mergeableState: "blocked",
+      }),
+      fetchCheckSnapshotsForRef: async () => [cancelledSnapshot],
+      listFailingStatuses: async () => [{
+        context: "build",
+        description: "Check run cancelled",
+        targetUrl: cancelledSnapshot.targetUrl,
+      }],
+      rerunFailedGitHubActionsRunsForSnapshots: async (_octokit, _repo, snapshots) => {
+        rerunCalls.push({ runId: 12345, contexts: snapshots.map((snapshot) => snapshot.context) });
+        return [{
+          runId: 12345,
+          targetUrl: cancelledSnapshot.targetUrl,
+          contexts: snapshots.map((snapshot) => snapshot.context),
+        }];
+      },
+    },
+    {
+      now: () => now,
+      checkAgentHealth: async () => ({ ok: true }),
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => {
+        statusEvaluationCalls += 1;
+        return { needsFix: true, reason: "should not evaluate cancelled CI as code work" };
+      },
+      applyFixesWithAgent: async () => {
+        throw new Error("cancelled CI should not launch agent fixes");
+      },
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updatedPr = await storage.getPR(pr.id);
+  assert.equal(updatedPr?.status, "watching");
+  assert.equal(updatedPr?.prStage, "tests");
+  assert.equal(updatedPr?.testsPassed, null);
+  assert.equal(statusEvaluationCalls, 0);
+  assert.deepEqual(rerunCalls, [{ runId: 12345, contexts: ["build"] }]);
+
+  const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0]?.targetId, pr.id);
+  assert.equal(jobs[0]?.availableAt, "2026-05-18T11:01:00.000Z");
+  assert.equal(jobs[0]?.payload.monitorFollowUp, true);
+  assert.equal(jobs[0]?.payload.monitorReason, "cancelled GitHub Actions run was rerun");
+
+  const runs = await storage.listAgentRuns({ prId: pr.id });
+  assert.equal(runs[0]?.status, "completed");
+  assert.equal(runs[0]?.phase, "ci.rerun_queued");
+  const logs = await storage.getLogs(pr.id);
+  assert.ok(logs.some((log) => log.phase === "verify.ci.rerun" && log.message.includes("Reran cancelled GitHub Actions")));
+});
+
+test("babysitPR queues follow-up monitoring when PR remains not merge-ready", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 49,
+    title: "Still blocked",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/still-blocked",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/49",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    mergeableState: "blocked",
+    lastChecked: null,
+  });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const now = new Date("2026-05-18T10:00:00.000Z");
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      ...makeWatcherGitHubService(),
+      fetchPullSummary: async () => makePullSummary(pr, {
+        headSha: "blocked-head",
+        headRef: pr.branch,
+        branch: pr.branch,
+        mergeableState: "blocked",
+      }),
+    },
+    {
+      now: () => now,
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => ({ needsFix: false, reason: "unused" }),
+      applyFixesWithAgent: async () => ({ code: 0, stdout: "", stderr: "" }),
+      runCommand: async () => ({ code: 0, stdout: "", stderr: "" }),
+    },
+    undefined,
+    async (...args) => backgroundJobQueue.enqueue(...args),
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr", status: "queued" });
+  assert.equal(jobs.length, 1);
+  assert.equal(jobs[0]?.targetId, pr.id);
+  assert.match(jobs[0]?.dedupeKey ?? "", /:monitor:/);
+  assert.equal(jobs[0]?.availableAt, "2026-05-18T10:01:00.000Z");
+  assert.equal(jobs[0]?.payload.monitorFollowUp, true);
+  assert.equal(jobs[0]?.payload.monitorReason, "GitHub mergeable state is blocked");
+
+  const logs = await storage.getLogs(pr.id);
+  assert.ok(logs.some((log) => log.message.includes("queued follow-up monitoring")));
 });
 
 test("babysitPR honors CI healing retry budgets before launching the healing agent", async () => {

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -36,11 +36,13 @@ import {
   postFollowUpForFeedbackItem,
   postPRComment,
   postStatusReplyForFeedbackItem,
+  rerunFailedGitHubActionsRunsForSnapshots,
   resolveReviewThread,
   resolveGitHubAuthToken,
   updateStatusReply,
   APP_STATUS_COMMENT_PATTERN,
   type CiPollResult,
+  type GitHubActionsRerun,
   type GitHubPullSummary,
   type GitHubStatusFailure,
   type ParsedPRUrl,
@@ -64,6 +66,7 @@ import type { DeploymentHealingManager } from "./deploymentHealingManager";
 import { detectDeploymentPlatform } from "./deploymentPlatformDetector";
 import {
   applyEvaluationDecision,
+  isFeedbackClosedStatus,
   markInProgress,
   markResolved,
   markFailed,
@@ -93,6 +96,11 @@ const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 const MAX_BABYSIT_ENQUEUES_PER_SWEEP = 10;
 const DEFERRED_BABYSIT_SWEEP_DELAY_MS = 15_000;
 const DEFERRED_BABYSIT_TARGET_PREFIX = "runtime:deferred-babysit:";
+const PR_MONITOR_FOLLOW_UP_DELAY_MS = 60_000;
+const AUTHENTICATED_LOGIN_CACHE_TTL_MS = 10 * 60_000;
+const AUTHENTICATED_LOGIN_FAILURE_COOLDOWN_MS = 60_000;
+const AUTHENTICATED_LOGIN_LOOKUP_TIMEOUT_MS = 5_000;
+const AUTHENTICATED_LOGIN_LOOKUP_ATTEMPTS = 2;
 // Repos visited per non-full sweep. The PR-list fetch is a conditional GET, so
 // a quiet repo costs no rate-limit budget; visiting several per tick keeps the
 // round-robin rotation short instead of one-repo-per-tick. Actual babysit work
@@ -126,6 +134,7 @@ type GitHubService = {
   postFollowUpForFeedbackItem: typeof postFollowUpForFeedbackItem;
   postPRComment: typeof postPRComment;
   postStatusReplyForFeedbackItem: typeof postStatusReplyForFeedbackItem;
+  rerunFailedGitHubActionsRunsForSnapshots?: typeof rerunFailedGitHubActionsRunsForSnapshots;
   resolveReviewThread: typeof resolveReviewThread;
   resolveGitHubAuthToken: typeof resolveGitHubAuthToken;
   updateStatusReply: typeof updateStatusReply;
@@ -198,7 +207,11 @@ const defaultGitHubService: GitHubService = {
   fetchPullCloseState,
   fetchPullSummary,
   getAuthenticatedLogin: async (octokit) => {
-    const { data } = await octokit.rest.users.getAuthenticated();
+    const { data } = await octokit.request("GET /user", {
+      request: {
+        timeout: getAuthenticatedLoginLookupTimeoutMs(),
+      },
+    });
     const login = data.login?.trim().toLowerCase();
     return login ? login : null;
   },
@@ -208,6 +221,7 @@ const defaultGitHubService: GitHubService = {
   postFollowUpForFeedbackItem,
   postPRComment,
   postStatusReplyForFeedbackItem,
+  rerunFailedGitHubActionsRunsForSnapshots,
   resolveReviewThread,
   resolveGitHubAuthToken,
   updateStatusReply,
@@ -681,7 +695,11 @@ function hasAuditTrail(
   runStartedAtMs?: number,
 ): boolean {
   return feedbackItems.some((candidate) => {
-    if (candidate.id === item.id || !candidate.body.includes(item.auditToken)) {
+    if (
+      candidate.id === item.id
+      || isCodeFactoryComment(candidate.body)
+      || !candidate.body.includes(item.auditToken)
+    ) {
       return false;
     }
 
@@ -1236,6 +1254,39 @@ function summarizeUnknownError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function getAuthenticatedLoginLookupTimeoutMs(): number {
+  const raw = process.env.PATCHDECK_AUTH_LOGIN_TIMEOUT_MS;
+  if (!raw) {
+    return AUTHENTICATED_LOGIN_LOOKUP_TIMEOUT_MS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : AUTHENTICATED_LOGIN_LOOKUP_TIMEOUT_MS;
+}
+
+class AuthenticatedLoginLookupTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`GitHub authenticated-user lookup timed out after ${timeoutMs}ms`);
+    this.name = "AuthenticatedLoginLookupTimeoutError";
+  }
+}
+
+async function withAuthenticatedLoginTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new AuthenticatedLoginLookupTimeoutError(timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 function shouldApplyFeedbackSyncCooldown(message: string): boolean {
   const lower = message.toLowerCase();
   return lower.includes("rate limit")
@@ -1378,6 +1429,102 @@ function getLastCheckedSortValue(pr: PR | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+function getPRNotMergeReadyReason(pr: PR): string | null {
+  if (pr.status === "processing") {
+    return "work is still running";
+  }
+  if (pr.status === "error") {
+    return "last work run failed";
+  }
+  if (pr.status === "archived") {
+    return null;
+  }
+  if (pr.testsPassed === false) {
+    return "tests are failing";
+  }
+  if (pr.lintPassed === false) {
+    return "lint is failing";
+  }
+  if (pr.mergeableState !== "clean") {
+    return `GitHub mergeable state is ${pr.mergeableState ?? "unknown"}`;
+  }
+  if (pr.feedbackItems.some((item) => !isFeedbackClosedStatus(item.status))) {
+    return "tracked feedback is not resolved";
+  }
+  return null;
+}
+
+function isRerunnableCancelledGitHubActionsSnapshot(snapshot: CheckSnapshot): boolean {
+  return snapshot.provider === "github.check_run"
+    && snapshot.status === "completed"
+    && snapshot.conclusion === "cancelled"
+    && Boolean(snapshot.targetUrl?.includes("/actions/runs/"));
+}
+
+function summarizeGitHubActionsReruns(reruns: GitHubActionsRerun[]): string {
+  return reruns
+    .map((rerun) => `run ${rerun.runId} (${rerun.contexts.join(", ")})`)
+    .join("; ");
+}
+
+function isGenericStatusDescription(description: string): boolean {
+  const normalized = description.trim().toLowerCase();
+  return normalized.length === 0
+    || normalized === "failure"
+    || normalized === "failed"
+    || normalized === "check failed"
+    || normalized === "check run failure"
+    || normalized === "ci failure";
+}
+
+function shouldReplaceStatusDescription(current: string, candidate: string): boolean {
+  if (candidate.trim().length === 0) {
+    return false;
+  }
+  if (isGenericStatusDescription(current) && !isGenericStatusDescription(candidate)) {
+    return true;
+  }
+  return !isGenericStatusDescription(candidate) && candidate.length > current.length;
+}
+
+function buildStatusTaskCandidates(
+  failingStatuses: GitHubStatusFailure[],
+  failingCheckSnapshots: CheckSnapshot[],
+): { context: string; description: string; targetUrl: string | null }[] {
+  const byContext = new Map<string, { context: string; description: string; targetUrl: string | null }>();
+
+  for (const status of failingStatuses) {
+    byContext.set(status.context, {
+      context: status.context,
+      description: status.description,
+      targetUrl: status.targetUrl,
+    });
+  }
+
+  for (const snapshot of failingCheckSnapshots) {
+    const existing = byContext.get(snapshot.context);
+    const candidateDescription = snapshot.description?.trim() || existing?.description || "Check run failure";
+    if (!existing) {
+      byContext.set(snapshot.context, {
+        context: snapshot.context,
+        description: candidateDescription,
+        targetUrl: snapshot.targetUrl,
+      });
+      continue;
+    }
+
+    byContext.set(snapshot.context, {
+      context: existing.context,
+      description: shouldReplaceStatusDescription(existing.description, candidateDescription)
+        ? candidateDescription
+        : existing.description,
+      targetUrl: existing.targetUrl ?? snapshot.targetUrl,
+    });
+  }
+
+  return Array.from(byContext.values());
+}
+
 export class PRBabysitter {
   private readonly storage: IStorage;
   private readonly inProgress = new Map<string, {
@@ -1394,6 +1541,9 @@ export class PRBabysitter {
   private readonly clock: () => Date;
   private readonly agentHealthCache = new Map<CodingAgent, { checkedAtMs: number; result: AgentHealthResult }>();
   private readonly feedbackSyncCooldownUntilMs = new Map<string, number>();
+  private authenticatedLoginCache: { login: string; checkedAtMs: number } | null = null;
+  private authenticatedLoginFailureCooldownUntilMs = 0;
+  private authenticatedLoginLookupPromise: Promise<string | null> | null = null;
   private repoSyncCursor = 0;
   private deferredBabysitSweepSequence = 0;
   // Per-repo open-PR list snapshot + its etag, kept together so a conditional
@@ -1420,6 +1570,76 @@ export class PRBabysitter {
 
   private now(): Date {
     return this.clock();
+  }
+
+  private async getAuthenticatedLoginForWatcher(
+    octokit: Awaited<ReturnType<typeof buildOctokit>>,
+    needsAuthenticatedLogin: boolean,
+  ): Promise<string | null> {
+    if (!needsAuthenticatedLogin) {
+      return null;
+    }
+
+    const nowMs = this.now().getTime();
+    if (this.authenticatedLoginCache && nowMs - this.authenticatedLoginCache.checkedAtMs < AUTHENTICATED_LOGIN_CACHE_TTL_MS) {
+      return this.authenticatedLoginCache.login;
+    }
+
+    if (this.authenticatedLoginFailureCooldownUntilMs > nowMs) {
+      return null;
+    }
+
+    if (!this.authenticatedLoginLookupPromise) {
+      this.authenticatedLoginLookupPromise = this.lookupAuthenticatedLoginForWatcher(octokit)
+        .finally(() => {
+          this.authenticatedLoginLookupPromise = null;
+        });
+    }
+
+    return this.authenticatedLoginLookupPromise;
+  }
+
+  private async lookupAuthenticatedLoginForWatcher(
+    octokit: Awaited<ReturnType<typeof buildOctokit>>,
+  ): Promise<string | null> {
+    const timeoutMs = getAuthenticatedLoginLookupTimeoutMs();
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= AUTHENTICATED_LOGIN_LOOKUP_ATTEMPTS; attempt += 1) {
+      try {
+        const rawLogin = await withAuthenticatedLoginTimeout(
+          this.github.getAuthenticatedLogin?.(octokit) ?? Promise.resolve(null),
+          timeoutMs,
+        );
+        const login = rawLogin?.trim().toLowerCase() ?? "";
+        if (!login) {
+          this.authenticatedLoginCache = null;
+          this.authenticatedLoginFailureCooldownUntilMs = this.now().getTime() + AUTHENTICATED_LOGIN_FAILURE_COOLDOWN_MS;
+          return null;
+        }
+
+        this.authenticatedLoginCache = {
+          login,
+          checkedAtMs: this.now().getTime(),
+        };
+        this.authenticatedLoginFailureCooldownUntilMs = 0;
+        return login;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    this.authenticatedLoginFailureCooldownUntilMs = this.now().getTime() + AUTHENTICATED_LOGIN_FAILURE_COOLDOWN_MS;
+    log.warn(
+      {
+        err: summarizeUnknownError(lastError),
+        attempts: AUTHENTICATED_LOGIN_LOOKUP_ATTEMPTS,
+        timeoutMs,
+        cooldownMs: AUTHENTICATED_LOGIN_FAILURE_COOLDOWN_MS,
+      },
+      "Could not identify authenticated GitHub user for own-PR filtering; skipping own-only watcher work this pass",
+    );
+    return null;
   }
 
   private async scheduleDeferredBabysitSweep(): Promise<void> {
@@ -1456,6 +1676,53 @@ export class PRBabysitter {
         priority: 5,
       },
     );
+  }
+
+  private async schedulePRMonitorFollowUp(
+    pr: PR,
+    preferredAgent: CodingAgent,
+    reason: string,
+  ): Promise<void> {
+    if (!this.scheduleBackgroundJob || pr.watchEnabled === false || pr.status === "archived") {
+      return;
+    }
+
+    const queuedFollowUps = await this.storage.listBackgroundJobs({
+      kind: "babysit_pr",
+      targetId: pr.id,
+      status: "queued",
+    });
+    if (queuedFollowUps.length > 0) {
+      return;
+    }
+
+    const availableAt = new Date(this.now().getTime() + PR_MONITOR_FOLLOW_UP_DELAY_MS);
+    await this.scheduleBackgroundJob(
+      "babysit_pr",
+      pr.id,
+      `babysit_pr:${pr.id}:monitor:${availableAt.getTime()}`,
+      {
+        preferredAgent,
+        monitorFollowUp: true,
+        monitorReason: reason,
+        ...buildActivityPayload({
+          label: `Monitoring PR #${pr.number}`,
+          detail: `${pr.repo} - ${pr.title}`,
+          targetUrl: pr.url,
+        }),
+      },
+      {
+        availableAt,
+      },
+    );
+
+    await this.storage.addLog(pr.id, "info", `PR is not merge-ready; queued follow-up monitoring because ${reason}`, {
+      phase: "watcher",
+      metadata: {
+        reason,
+        availableAt: availableAt.toISOString(),
+      },
+    });
   }
 
   private isFeedbackSyncCoolingDown(prId: string): boolean {
@@ -2014,25 +2281,6 @@ export class PRBabysitter {
     const needsAuthenticatedLogin = Array.from(repoCandidates).some(
       (repo) => (repoSettingsByRepo.get(repo)?.ownPrsOnly ?? true),
     );
-    let authenticatedLoginPromise: Promise<string | null> | null = null;
-    const getAuthenticatedLogin = async (): Promise<string | null> => {
-      if (!needsAuthenticatedLogin) {
-        return null;
-      }
-
-      if (!authenticatedLoginPromise) {
-        authenticatedLoginPromise = (this.github.getAuthenticatedLogin?.(octokit) ?? Promise.resolve(null))
-          .catch((error) => {
-            log.warn(
-              { err: error instanceof Error ? error.message : String(error) },
-              "Failed to determine authenticated GitHub login for watcher filtering",
-            );
-            return null;
-          });
-      }
-
-      return authenticatedLoginPromise;
-    };
 
     const repos = Array.from(repoCandidates)
       .map((repo) => parseRepoSlug(repo))
@@ -2123,7 +2371,9 @@ export class PRBabysitter {
 
       const openNumbers = new Set(openPulls.map((p) => p.number));
       const repoOwnPrsOnly = repoSettingsByRepo.get(repoSlug)?.ownPrsOnly ?? true;
-      const authenticatedLogin = repoOwnPrsOnly ? await getAuthenticatedLogin() : null;
+      const authenticatedLogin = repoOwnPrsOnly
+        ? await this.getAuthenticatedLoginForWatcher(octokit, needsAuthenticatedLogin)
+        : null;
       const automationScopeNumbers = new Set(
         openPulls
           .filter((pull) => !repoOwnPrsOnly || (
@@ -2301,25 +2551,42 @@ export class PRBabysitter {
             continue;
           }
 
-          local = await this.storage.addPR({
-            number: pull.number,
-            title: pull.title,
-            repo: repoSlug,
-            branch: pull.branch,
-            author: pull.author,
-            url: pull.url,
-            status: "watching",
-            feedbackItems: [],
-            accepted: 0,
-            rejected: 0,
-            flagged: 0,
-            testsPassed: null,
-            lintPassed: null,
-            lastChecked: null,
-          });
+          const existingByNumber = await this.storage.getPRByRepoAndNumber(repoSlug, pull.number);
+          if (existingByNumber) {
+            const reactivated = await this.storage.updatePR(existingByNumber.id, {
+              title: pull.title,
+              repo: repoSlug,
+              branch: pull.branch,
+              author: pull.author,
+              url: pull.url,
+              status: "watching",
+            });
+            local = reactivated ?? existingByNumber;
+            await this.storage.addLog(local.id, "info", `Re-activated existing PR #${pull.number} from ${repoSlug}`, {
+              phase: "watcher",
+            });
+            localByNumber.set(pull.number, local);
+          } else {
+            local = await this.storage.addPR({
+              number: pull.number,
+              title: pull.title,
+              repo: repoSlug,
+              branch: pull.branch,
+              author: pull.author,
+              url: pull.url,
+              status: "watching",
+              feedbackItems: [],
+              accepted: 0,
+              rejected: 0,
+              flagged: 0,
+              testsPassed: null,
+              lintPassed: null,
+              lastChecked: null,
+            });
 
-          await this.storage.addLog(local.id, "info", `Auto-registered open PR #${pull.number} from ${repoSlug}`);
-          localByNumber.set(pull.number, local);
+            await this.storage.addLog(local.id, "info", `Auto-registered open PR #${pull.number} from ${repoSlug}`);
+            localByNumber.set(pull.number, local);
+          }
         }
 
         if (!automationScopeNumbers.has(pull.number)) {
@@ -3274,14 +3541,18 @@ export class PRBabysitter {
       } else {
         const existingHealingSession = await healingManager.getSessionByPrAndHead(pr.id, pullSummary.headSha);
         const canMarkHealthy = existingHealingSession
-          && ["triaging", "awaiting_repair_slot", "repairing", "awaiting_ci", "verifying", "cooldown"].includes(existingHealingSession.state);
+          && ["triaging", "awaiting_repair_slot", "repairing", "awaiting_ci", "verifying", "cooldown", "blocked"].includes(existingHealingSession.state);
 
         if (canMarkHealthy) {
           healingSession = await healingManager.markVerifying(existingHealingSession.id, {
             currentHeadSha: pullSummary.headSha,
+            endedAt: null,
           });
           healingSession = await healingManager.markHealed(healingSession.id, {
             currentHeadSha: pullSummary.headSha,
+            blockedReason: null,
+            escalationReason: null,
+            latestFingerprint: null,
             lastImprovementScore: healingSession.lastImprovementScore ?? 0,
           });
         } else {
@@ -3581,8 +3852,59 @@ export class PRBabysitter {
         }
       }
 
+      const rerunnableCancelledSnapshots = failingCheckSnapshots.filter(isRerunnableCancelledGitHubActionsSnapshot);
+      if (
+        pendingComments.length === 0
+        && rerunnableCancelledSnapshots.length > 0
+        && rerunnableCancelledSnapshots.length === failingCheckSnapshots.length
+        && this.github.rerunFailedGitHubActionsRunsForSnapshots
+      ) {
+        let reruns: GitHubActionsRerun[] = [];
+        try {
+          reruns = await this.github.rerunFailedGitHubActionsRunsForSnapshots(
+            octokit,
+            parsedRepo,
+            rerunnableCancelledSnapshots,
+          );
+        } catch (error) {
+          await logBestEffortFailure(
+            pr.id,
+            "verify.ci.rerun",
+            `Failed to rerun cancelled GitHub Actions checks: ${summarizeUnknownError(error)}`,
+          );
+        }
+
+        if (reruns.length > 0) {
+          await queueLog(pr.id, "info", `Reran cancelled GitHub Actions workflow run(s): ${summarizeGitHubActionsReruns(reruns)}`, {
+            phase: "verify.ci.rerun",
+            metadata: { reruns },
+          });
+          const rerunPr = await this.storage.updatePR(pr.id, {
+            status: "watching",
+            prStage: "tests",
+            testsPassed: null,
+            lastChecked: new Date().toISOString(),
+          });
+          if (rerunPr) {
+            await this.schedulePRMonitorFollowUp(rerunPr, preferredAgent, "cancelled GitHub Actions run was rerun");
+          }
+          await updateRunRecord({
+            status: "completed",
+            phase: "ci.rerun_queued",
+            lastError: null,
+          });
+          return;
+        }
+      }
+
+      const statusTaskCandidates = buildStatusTaskCandidates(failingStatuses, failingCheckSnapshots);
       const statusTasks: { context: string; description: string; targetUrl: string | null }[] = [];
-      if (config.autoHealCI && healingSession) {
+      const healingOwnsStatusEvaluation = Boolean(
+        config.autoHealCI
+        && healingSession
+        && (!isTerminalHealingState(healingSession.state) || healingSession.state === "blocked"),
+      );
+      if (healingOwnsStatusEvaluation && healingSession) {
         await queueLog(pr.id, "info", `Skipping legacy status-task evaluation because CI healing session ${healingSession.id} is active`, {
           phase: "evaluate.status",
           metadata: {
@@ -3591,10 +3913,10 @@ export class PRBabysitter {
           },
         });
       } else {
-        await queueLog(pr.id, "info", `Evaluating ${failingStatuses.length} failing status check(s)`, {
+        await queueLog(pr.id, "info", `Evaluating ${statusTaskCandidates.length} failing status check(s)`, {
           phase: "evaluate.status",
         });
-        for (const status of failingStatuses) {
+        for (const status of statusTaskCandidates) {
           const statusEvalPrompt = buildStatusEvaluationPrompt({
             pr,
             context: status.context,
@@ -3734,10 +4056,14 @@ export class PRBabysitter {
         await queueLog(pr.id, "info", `Checked PR #${pr.number}; no necessary fixes identified`, {
           phase: "run",
         });
-        await this.storage.updatePR(pr.id, {
+        const checkedPr = await this.storage.updatePR(pr.id, {
           status: "watching",
           lastChecked: new Date().toISOString(),
         });
+        const monitorReason = checkedPr ? getPRNotMergeReadyReason(checkedPr) : null;
+        if (checkedPr && monitorReason) {
+          await this.schedulePRMonitorFollowUp(checkedPr, preferredAgent, monitorReason);
+        }
         await updateRunRecord({
           status: "completed",
           phase: "run.completed",
@@ -4861,10 +5187,14 @@ export class PRBabysitter {
         }
       }
 
-      await this.storage.updatePR(pr.id, {
+      const completedPr = await this.storage.updatePR(pr.id, {
         status: "watching",
         lastChecked: new Date().toISOString(),
       });
+      const monitorReason = completedPr ? getPRNotMergeReadyReason(completedPr) : null;
+      if (completedPr && monitorReason) {
+        await this.schedulePRMonitorFollowUp(completedPr, preferredAgent, monitorReason);
+      }
       await queueLog(pr.id, "info", "PR work run complete", {
         phase: "run",
         metadata: { remoteName: remoteNameForLogs, branchMoved },
@@ -4927,10 +5257,14 @@ export class PRBabysitter {
               },
               lastError: null,
             });
-            await this.storage.updatePR(currentPr.id, {
+            const fallbackPr = await this.storage.updatePR(currentPr.id, {
               status: "watching",
               lastChecked: this.now().toISOString(),
             });
+            const monitorReason = fallbackPr ? getPRNotMergeReadyReason(fallbackPr) : null;
+            if (fallbackPr && monitorReason) {
+              await this.schedulePRMonitorFollowUp(fallbackPr, preferredAgent, monitorReason);
+            }
             return;
           } catch (fallbackError) {
             const fallbackMessage = summarizeUnknownError(fallbackError);

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -95,6 +95,7 @@ const QUIET_REPO_COOLDOWN_MS = 10 * 60_000;
 // later sweeps (babysit_pr jobs are dedupe-keyed, so nothing is lost).
 const MAX_BABYSIT_ENQUEUES_PER_SWEEP = 10;
 const DEFERRED_BABYSIT_SWEEP_DELAY_MS = 15_000;
+const DEFERRED_BABYSIT_BUDGET_DELAY_MS = 60_000;
 const DEFERRED_BABYSIT_TARGET_PREFIX = "runtime:deferred-babysit:";
 const PR_MONITOR_FOLLOW_UP_DELAY_MS = 60_000;
 const AUTHENTICATED_LOGIN_CACHE_TTL_MS = 10 * 60_000;
@@ -1646,7 +1647,7 @@ export class PRBabysitter {
     return null;
   }
 
-  private async scheduleDeferredBabysitSweep(): Promise<void> {
+  private async scheduleDeferredBabysitSweep(reason: string = "active batch drain"): Promise<void> {
     if (!this.scheduleBackgroundJob) {
       return;
     }
@@ -1659,7 +1660,9 @@ export class PRBabysitter {
       return;
     }
 
-    const availableAt = new Date(this.now().getTime() + DEFERRED_BABYSIT_SWEEP_DELAY_MS);
+    const budgetReserve = reason === "core budget reserve";
+    const delayMs = budgetReserve ? DEFERRED_BABYSIT_BUDGET_DELAY_MS : DEFERRED_BABYSIT_SWEEP_DELAY_MS;
+    const availableAt = new Date(this.now().getTime() + delayMs);
     const targetId = `${DEFERRED_BABYSIT_TARGET_PREFIX}${availableAt.getTime()}-${this.deferredBabysitSweepSequence++}`;
     await this.scheduleBackgroundJob(
       "sync_watched_repos",
@@ -1670,10 +1673,14 @@ export class PRBabysitter {
       {
         ...buildActivityPayload({
           label: "Backfilling deferred PR work",
-          detail: "Refilling PR work queue after the active batch drains",
+          detail: budgetReserve
+            ? "Waiting for GitHub core budget before refilling PR work queue"
+            : "Refilling PR work queue after the active batch drains",
           targetUrl: null,
         }),
         deferredBabysitBackfill: true,
+        deferredReason: reason,
+        cooldownMs: delayMs,
       },
       {
         availableAt,
@@ -2834,17 +2841,18 @@ export class PRBabysitter {
         }
       }
       if (babysitDeferred > 0) {
-        await this.scheduleDeferredBabysitSweep();
+        const deferredReason = babysitBudgetTight
+          ? "core budget reserve"
+          : inFlightBabysitJobs >= maxConcurrentBabysitRuns
+            ? "concurrency cap"
+            : "per-sweep cap";
+        await this.scheduleDeferredBabysitSweep(deferredReason);
         log.info(
           {
             repo: repoSlug,
             deferred: babysitDeferred,
             enqueued: babysitEnqueues,
-            reason: babysitBudgetTight
-              ? "core budget reserve"
-              : inFlightBabysitJobs >= maxConcurrentBabysitRuns
-                ? "concurrency cap"
-                : "per-sweep cap",
+            reason: deferredReason,
           },
           "Deferred PR work to a later sweep to pace GitHub usage",
         );

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -274,6 +274,10 @@ function maxPrStage(current: PRStage | undefined, candidate: PRStage): PRStage {
   return currentIdx >= candidateIdx ? current : candidate;
 }
 
+function isClosedPullSummary(pullSummary: GitHubPullSummary): boolean {
+  return pullSummary.merged || Boolean(pullSummary.mergedAt || pullSummary.closedAt);
+}
+
 function countDecisions(items: FeedbackItem[]): {
   accepted: number;
   rejected: number;
@@ -1931,6 +1935,69 @@ export class PRBabysitter {
     }
   }
 
+  private async archivePRFromPullSummary(
+    pr: PR,
+    pullSummary: GitHubPullSummary,
+    options?: {
+      runId?: string | null;
+      phase?: string | null;
+      feedback?: {
+        items: FeedbackItem[];
+        accepted: number;
+        rejected: number;
+        flagged: number;
+      };
+    },
+  ): Promise<PR | undefined> {
+    const now = this.now().toISOString();
+    const updates: Partial<PR> = {
+      number: pullSummary.number,
+      title: pullSummary.title,
+      body: pullSummary.body,
+      bodyHtml: pullSummary.bodyHtml,
+      repo: pullSummary.repoFullName,
+      branch: pullSummary.branch,
+      author: pullSummary.author,
+      url: pullSummary.url,
+      mergeableState: pullSummary.mergeableState,
+      status: "archived",
+      prStage: "done",
+      lastChecked: now,
+      lastSyncAttemptedAt: now,
+      lastSyncSucceededAt: now,
+      lastSyncError: null,
+    };
+
+    if (options?.feedback) {
+      updates.feedbackItems = options.feedback.items;
+      updates.accepted = options.feedback.accepted;
+      updates.rejected = options.feedback.rejected;
+      updates.flagged = options.feedback.flagged;
+    }
+
+    const archived = await this.storage.updatePR(pr.id, updates);
+    await this.supersedeActiveHealingSessionsForArchivedPr(pr.id);
+    await this.storage.addLog(
+      pr.id,
+      "info",
+      pullSummary.merged
+        ? `PR #${pr.number} was merged on GitHub — archived`
+        : `PR #${pr.number} is no longer open on GitHub — archived`,
+      {
+        runId: options?.runId ?? null,
+        phase: options?.phase ?? null,
+        metadata: {
+          merged: pullSummary.merged,
+          mergedAt: pullSummary.mergedAt,
+          closedAt: pullSummary.closedAt,
+          mergeCommitSha: pullSummary.mergeCommitSha,
+        },
+      },
+    );
+
+    return archived;
+  }
+
   getActiveRunCount(): number {
     return this.inProgress.size;
   }
@@ -2167,8 +2234,9 @@ export class PRBabysitter {
     let refreshedAuthor = pr.author;
     let refreshedUrl = pr.url;
     let refreshedMergeableState = pr.mergeableState;
+    let pullSummary: GitHubPullSummary | null = null;
     try {
-      const pullSummary = await this.github.fetchPullSummary(octokit, parsed);
+      pullSummary = await this.github.fetchPullSummary(octokit, parsed);
       refreshedTitle = pullSummary.title;
       refreshedBody = pullSummary.body;
       refreshedBodyHtml = pullSummary.bodyHtml;
@@ -2179,6 +2247,20 @@ export class PRBabysitter {
       refreshedMergeableState = pullSummary.mergeableState;
     } catch {
       // Non-fatal: keep existing PR metadata if the summary fetch fails.
+    }
+
+    if (pullSummary && isClosedPullSummary(pullSummary)) {
+      const archived = await this.archivePRFromPullSummary(pr, pullSummary, {
+        runId: options?.runId ?? null,
+        phase,
+        feedback: {
+          items: merged,
+          accepted: counters.accepted,
+          rejected: counters.rejected,
+          flagged: counters.flagged,
+        },
+      });
+      return archived ?? pr;
     }
 
     const candidateStage: PRStage = counters.accepted + counters.rejected + counters.flagged > 0
@@ -3318,6 +3400,36 @@ export class PRBabysitter {
         lastError: null,
       });
 
+      const prBeforeRun = await this.storage.getPR(prId);
+      if (!prBeforeRun) {
+        throw new Error("PR not found");
+      }
+      const parsedRepoBeforeRun = parseRepoSlug(prBeforeRun.repo);
+      if (!parsedRepoBeforeRun) {
+        throw new Error(`Invalid repository slug: ${prBeforeRun.repo}`);
+      }
+
+      const config = await this.storage.getConfig();
+      const octokit = await this.github.buildOctokit(config);
+      const preflightPullSummary = await this.github.fetchPullSummary(octokit, {
+        owner: parsedRepoBeforeRun.owner,
+        repo: parsedRepoBeforeRun.repo,
+        number: prBeforeRun.number,
+      });
+      if (isClosedPullSummary(preflightPullSummary)) {
+        await this.archivePRFromPullSummary(prBeforeRun, preflightPullSummary, {
+          runId,
+          phase: "run",
+        });
+        await updateRunRecord({
+          status: "completed",
+          phase: preflightPullSummary.merged ? "run.pr_merged" : "run.pr_closed",
+          initialHeadSha: preflightPullSummary.headSha || runRecord.initialHeadSha,
+          lastError: null,
+        });
+        return;
+      }
+
       await this.storage.updatePR(prId, {
         status: "processing",
         prStage: "applying",
@@ -3328,7 +3440,6 @@ export class PRBabysitter {
         metadata: { preferredAgent, recoveryMode },
       });
 
-      const config = await this.storage.getConfig();
       const selectedAgent = forcedResolvedAgent || preferredAgent;
       await this.ensureAgentHealthy(selectedAgent, [prId]);
 
@@ -3442,7 +3553,6 @@ export class PRBabysitter {
         }
       };
 
-      const octokit = await this.github.buildOctokit(config);
       const parsedPr: ParsedPRUrl = {
         owner: parsedRepo.owner,
         repo: parsedRepo.repo,

--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { BackgroundJobDispatcher, CancelBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
+import { BackgroundJobDispatcher, CancelBackgroundJobError, DeferBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
 
@@ -398,6 +398,49 @@ test("BackgroundJobDispatcher retries transient handler errors before completing
     assert.equal(stored?.status, "completed");
     assert.equal(stored?.attemptCount, 2);
     assert.equal(stored?.lastError, null);
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("BackgroundJobDispatcher defers jobs without consuming retry attempts", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", {
+    prId: "pr-1",
+  });
+  const availableAt = new Date(Date.now() + 60_000);
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    maxAttempts: 1,
+    handlers: {
+      babysit_pr: async () => {
+        attempts += 1;
+        throw new DeferBackgroundJobError("GitHub core budget is in reserve; passive PR monitor deferred", availableAt);
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(
+      async () => attempts === 1 && (await storage.getBackgroundJob(job.id))?.status === "queued",
+      500,
+    );
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(attempts, 1);
+    assert.equal(stored?.status, "queued");
+    assert.equal(stored?.attemptCount, 0);
+    assert.equal(stored?.availableAt, availableAt.toISOString());
+    assert.match(stored?.lastError ?? "", /core budget is in reserve/);
   } finally {
     dispatcher.stop();
   }

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -25,6 +25,16 @@ export class TerminalBackgroundJobError extends Error {
   }
 }
 
+export class DeferBackgroundJobError extends Error {
+  readonly availableAt: Date;
+
+  constructor(message: string, availableAt: Date) {
+    super(message);
+    this.name = "DeferBackgroundJobError";
+    this.availableAt = availableAt;
+  }
+}
+
 export class BackgroundJobDispatcher {
   private readonly storage: IStorage;
   private readonly queue: BackgroundJobQueue;
@@ -278,6 +288,15 @@ export class BackgroundJobDispatcher {
             now,
           });
           return;
+        case "defer":
+          await this.queue.defer({
+            jobId: job.id,
+            leaseToken,
+            error: summarizeError(error),
+            now,
+            availableAt: error instanceof DeferBackgroundJobError ? error.availableAt : now,
+          });
+          return;
         case "retry":
           await this.queue.retry({
             jobId: job.id,
@@ -308,9 +327,12 @@ export class BackgroundJobDispatcher {
     }
   }
 
-  private resolveFailureAction(job: BackgroundJob, error: unknown): "cancel" | "retry" | "fail" {
+  private resolveFailureAction(job: BackgroundJob, error: unknown): "cancel" | "defer" | "retry" | "fail" {
     if (error instanceof CancelBackgroundJobError) {
       return "cancel";
+    }
+    if (error instanceof DeferBackgroundJobError) {
+      return "defer";
     }
     if (error instanceof TerminalBackgroundJobError) {
       return "fail";

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { TerminalBabysitterError } from "./babysitter";
-import { BackgroundJobDispatcher, CancelBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
+import { BackgroundJobDispatcher, CancelBackgroundJobError, DeferBackgroundJobError, TerminalBackgroundJobError } from "./backgroundJobDispatcher";
 import { createBackgroundJobHandlers } from "./backgroundJobHandlers";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
 import { MemStorage } from "./memoryStorage";
 import type { DeploymentHealingManager } from "./deploymentHealingManager";
+import { clearRateLimitStateForTests, recordResourceBudget } from "./rateLimitState";
 
 async function seedPR(storage: MemStorage): Promise<string> {
   const pr = await storage.addPR({
@@ -163,6 +164,43 @@ test("babysit_pr handler delegates to the babysitter with the queued preferred a
       claudeEffort: "default",
     },
   }]);
+});
+
+test("babysit_pr handler defers passive monitor follow-ups while the core budget is reserved", async () => {
+  clearRateLimitStateForTests();
+  const storage = new MemStorage();
+  const prId = await seedPR(storage);
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "babysit_pr",
+    prId,
+    `babysit_pr:${prId}:monitor`,
+    { preferredAgent: "codex", monitorFollowUp: true },
+  );
+  let called = false;
+
+  const handlers = createBackgroundJobHandlers({
+    storage,
+    babysitter: {
+      syncAndBabysitTrackedRepos: async () => undefined,
+      runQueuedBabysitPR: async () => {
+        called = true;
+      },
+    },
+  });
+
+  recordResourceBudget("core", 900, 5000);
+  try {
+    await assert.rejects(
+      handlers.babysit_pr!(job),
+      (error: unknown) => error instanceof DeferBackgroundJobError
+        && error.message.includes("core budget is in reserve")
+        && error.availableAt.getTime() > Date.now(),
+    );
+    assert.equal(called, false);
+  } finally {
+    clearRateLimitStateForTests();
+  }
 });
 
 test("babysit_pr handler cancels jobs whose PR row is missing", async () => {

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -2,7 +2,7 @@ import type { BackgroundJob, DeploymentPlatform } from "@shared/schema";
 import type { CodingAgent } from "./agentRunner";
 import { resolveRepoAgentRuntimeSettings, resolveRepoCodingAgent } from "./agentSettings";
 import { TerminalBabysitterError, type PRBabysitter } from "./babysitter";
-import { CancelBackgroundJobError, TerminalBackgroundJobError, type BackgroundJobHandlers } from "./backgroundJobDispatcher";
+import { CancelBackgroundJobError, DeferBackgroundJobError, TerminalBackgroundJobError, type BackgroundJobHandlers } from "./backgroundJobDispatcher";
 import { createAdapter } from "./deploymentAdapters";
 import type { DeploymentHealingManager } from "./deploymentHealingManager";
 import { runDeploymentHealingRepair } from "./deploymentHealingAgent";
@@ -23,9 +23,12 @@ import { decomposeIssueBody, hashIssueBody } from "./issueDecompose";
 import { verifySubtasksAgainstPr } from "./issueVerify";
 import { runIssueWorkRepair } from "./issueWorkAgent";
 import { answerPRQuestion } from "./prQuestionAgent";
+import { getRateLimitState } from "./rateLimitState";
 import type { ReleaseManager } from "./releaseManager";
 import { runWithRequestPriority } from "./requestPriority";
 import type { IStorage } from "./storage";
+
+const PASSIVE_MONITOR_BUDGET_DEFER_MS = 60_000;
 
 type BackgroundJobHandlerDeps = {
   buildOctokitFn?: typeof buildOctokit;
@@ -55,6 +58,39 @@ function wait(ms: number): Promise<void> {
 
 function shouldPostInitialIssueWorkNotice(job: BackgroundJob): boolean {
   return job.attemptCount <= 1;
+}
+
+function resolvePassiveMonitorDefer(): { reason: string; availableAt: Date } | null {
+  const core = getRateLimitState("core");
+  if (!core.limited && !core.belowReserve && !core.belowFloor) {
+    return null;
+  }
+
+  const resetAtMs = core.resetAt?.getTime() ?? null;
+  const availableAt = resetAtMs && resetAtMs > Date.now()
+    ? new Date(Math.max(resetAtMs, Date.now() + 30_000))
+    : new Date(Date.now() + PASSIVE_MONITOR_BUDGET_DEFER_MS);
+
+  if (core.limited) {
+    return {
+      reason: core.resetAt
+        ? `GitHub core rate limit active until ${core.resetAt.toISOString()}; passive PR monitor deferred`
+        : "GitHub core rate limit active; passive PR monitor deferred",
+      availableAt,
+    };
+  }
+
+  if (core.belowFloor) {
+    return {
+      reason: "GitHub core budget is below the hard floor; passive PR monitor deferred",
+      availableAt,
+    };
+  }
+
+  return {
+    reason: "GitHub core budget is in reserve; passive PR monitor deferred",
+    availableAt,
+  };
 }
 
 export function createBackgroundJobHandlers(params: {
@@ -139,6 +175,13 @@ export function createBackgroundJobHandlers(params: {
         const pr = await storage.getPR(job.targetId);
         if (!pr) {
           throw new CancelBackgroundJobError(`PR ${job.targetId} no longer exists`);
+        }
+
+        if (job.payload.monitorFollowUp === true) {
+          const defer = resolvePassiveMonitorDefer();
+          if (defer) {
+            throw new DeferBackgroundJobError(defer.reason, defer.availableAt);
+          }
         }
 
         const config = await storage.getConfig();

--- a/server/backgroundJobQueue.ts
+++ b/server/backgroundJobQueue.ts
@@ -38,6 +38,11 @@ export type BackgroundJobRetryParams = BackgroundJobFinalizeParams & {
   availableAt?: QueueDateInput;
 };
 
+export type BackgroundJobDeferParams = BackgroundJobFinalizeParams & {
+  error: string;
+  availableAt: QueueDateInput;
+};
+
 export type BackgroundJobCancelParams = BackgroundJobFinalizeParams & {
   error?: string | null;
 };
@@ -129,6 +134,17 @@ export class BackgroundJobQueue {
       params.leaseToken,
       params.error,
       this.resolveNow(params.availableAt ?? now),
+      now,
+    );
+  }
+
+  async defer(params: BackgroundJobDeferParams): Promise<BackgroundJob | undefined> {
+    const now = this.resolveNow(params.now);
+    return this.storage.deferBackgroundJob(
+      params.jobId,
+      params.leaseToken,
+      params.error,
+      this.resolveNow(params.availableAt),
       now,
     );
   }

--- a/server/ciHealingManager.test.ts
+++ b/server/ciHealingManager.test.ts
@@ -159,8 +159,10 @@ test("CIHealingManager can verify an awaiting repair session that becomes health
 
   const verifying = await manager.markVerifying(session.id, {
     currentHeadSha: "sha-a",
+    endedAt: null,
   });
   assert.equal(verifying.state, "verifying");
+  assert.equal(verifying.endedAt, null);
 
   const healed = await manager.markHealed(session.id, {
     currentHeadSha: "sha-a",
@@ -168,6 +170,45 @@ test("CIHealingManager can verify an awaiting repair session that becomes health
     lastImprovementScore: 0,
   });
   assert.equal(healed.state, "healed");
+  assert.equal(healed.latestFingerprint, null);
+  assert.ok(healed.endedAt);
+});
+
+test("CIHealingManager can clear a blocked session after external CI turns healthy", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+  const pr = await storage.addPR(makePR());
+  const manager = new CIHealingManager(storage);
+  const session = await storage.createHealingSession({
+    prId: pr.id,
+    repo: pr.repo,
+    prNumber: pr.number,
+    initialHeadSha: "sha-a",
+    currentHeadSha: "sha-a",
+    state: "blocked",
+    endedAt: "2026-04-01T10:00:00.000Z",
+    blockedReason: "External CI failure",
+    escalationReason: null,
+    latestFingerprint: "github-check-run:cancelled:triage",
+    attemptCount: 0,
+    lastImprovementScore: null,
+  });
+
+  const verifying = await manager.markVerifying(session.id, {
+    currentHeadSha: "sha-a",
+    endedAt: null,
+  });
+  assert.equal(verifying.state, "verifying");
+  assert.equal(verifying.endedAt, null);
+
+  const healed = await manager.markHealed(session.id, {
+    currentHeadSha: "sha-a",
+    blockedReason: null,
+    latestFingerprint: null,
+    lastImprovementScore: 0,
+  });
+  assert.equal(healed.state, "healed");
+  assert.equal(healed.blockedReason, null);
   assert.equal(healed.latestFingerprint, null);
   assert.ok(healed.endedAt);
 });

--- a/server/ciHealingManager.ts
+++ b/server/ciHealingManager.ts
@@ -38,7 +38,7 @@ const NEXT_STATES: Record<HealingSessionState, ReadonlyArray<HealingSessionState
   verifying: ["healed", "awaiting_repair_slot", "cooldown", "blocked", "escalated", "superseded"],
   cooldown: ["awaiting_repair_slot", "blocked", "escalated", "superseded"],
   healed: [],
-  blocked: [],
+  blocked: ["verifying", "healed"],
   escalated: [],
   superseded: [],
 };

--- a/server/github.ts
+++ b/server/github.ts
@@ -94,6 +94,14 @@ export type GitHubStatusFailure = {
   targetUrl: string | null;
 };
 
+export type GitHubActionsRerun = {
+  runId: number;
+  targetUrl: string | null;
+  contexts: string[];
+};
+
+const GITHUB_ACTIONS_RUN_URL_PATTERN = /\/actions\/runs\/(\d+)(?:\/|$)/;
+
 type GitHubCommitStatusResponse = {
   state?: string | null;
   context?: string | null;
@@ -623,6 +631,68 @@ export async function fetchCheckSnapshotsForRef(
     statuses: (statusResponse.data.statuses ?? []) as GitHubCommitStatusResponse[],
     checkRuns,
   });
+}
+
+function extractGitHubActionsRunId(targetUrl: string | null): number | null {
+  if (!targetUrl) {
+    return null;
+  }
+
+  const match = GITHUB_ACTIONS_RUN_URL_PATTERN.exec(targetUrl);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const runId = Number.parseInt(match[1], 10);
+  return Number.isFinite(runId) && runId > 0 ? runId : null;
+}
+
+export async function rerunFailedGitHubActionsRunsForSnapshots(
+  octokit: Octokit,
+  repo: ParsedRepoSlug,
+  snapshots: CheckSnapshot[],
+): Promise<GitHubActionsRerun[]> {
+  const byRunId = new Map<number, GitHubActionsRerun>();
+
+  for (const snapshot of snapshots) {
+    if (
+      snapshot.provider !== "github.check_run"
+      || snapshot.status !== "completed"
+      || snapshot.conclusion !== "cancelled"
+    ) {
+      continue;
+    }
+
+    const runId = extractGitHubActionsRunId(snapshot.targetUrl);
+    if (runId === null) {
+      continue;
+    }
+
+    const existing = byRunId.get(runId);
+    if (existing) {
+      existing.contexts.push(snapshot.context);
+      continue;
+    }
+
+    byRunId.set(runId, {
+      runId,
+      targetUrl: snapshot.targetUrl,
+      contexts: [snapshot.context],
+    });
+  }
+
+  const reruns = Array.from(byRunId.values());
+  for (const rerun of reruns) {
+    await withGitHubErrorHandling("rerun failed workflow jobs", repo, () =>
+      octokit.rest.actions.reRunWorkflowFailedJobs({
+        owner: repo.owner,
+        repo: repo.repo,
+        run_id: rerun.runId,
+      }),
+    );
+  }
+
+  return reruns;
 }
 
 function resolveConfiguredGitHubToken(config: Config): string | undefined {

--- a/server/github.ts
+++ b/server/github.ts
@@ -1117,8 +1117,10 @@ function attachRateLimitHook(
       if (responseResource === "core" || responseResource === "graphql") {
         const limitRaw = response.headers?.["x-ratelimit-limit"];
         const limit = typeof limitRaw === "string" ? Number.parseInt(limitRaw, 10) : Number.NaN;
+        const resetRaw = response.headers?.["x-ratelimit-reset"];
+        const reset = typeof resetRaw === "string" ? Number.parseInt(resetRaw, 10) : undefined;
         if (Number.isFinite(remaining) && Number.isFinite(limit)) {
-          recordResourceBudget(responseResource, remaining, limit);
+          recordResourceBudget(responseResource, remaining, limit, reset);
         }
       }
       if (Number.isFinite(remaining) && remaining > 0) {

--- a/server/github.ts
+++ b/server/github.ts
@@ -58,6 +58,10 @@ export type GitHubPullSummary = {
   baseSha: string;
   mergeable: boolean | null;
   mergeableState: string | null;
+  merged: boolean;
+  mergedAt: string | null;
+  closedAt: string | null;
+  mergeCommitSha: string | null;
 };
 
 export type GitHubIssueSummary = {
@@ -1563,6 +1567,10 @@ export async function fetchPullSummary(
     baseSha: pull.base?.sha || "",
     mergeable: typeof pull.mergeable === "boolean" ? pull.mergeable : null,
     mergeableState: typeof pull.mergeable_state === "string" ? pull.mergeable_state : null,
+    merged: Boolean(pull.merged_at),
+    mergedAt: pull.merged_at || null,
+    closedAt: pull.closed_at || null,
+    mergeCommitSha: pull.merge_commit_sha || null,
   };
 }
 
@@ -2304,6 +2312,10 @@ function mapPullToSummary(pull: GitHubPullListItem, repo: ParsedRepoSlug): GitHu
     baseSha: pull.base?.sha || "",
     mergeable: null,
     mergeableState: null,
+    merged: false,
+    mergedAt: null,
+    closedAt: null,
+    mergeCommitSha: null,
   };
 }
 

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -787,6 +787,34 @@ export class MemStorage implements IStorage {
     return this.cloneBackgroundJob(updated);
   }
 
+  async deferBackgroundJob(
+    id: string,
+    leaseToken: string,
+    error: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    const existing = this.backgroundJobs.get(id);
+    if (!existing || existing.status !== "leased" || existing.leaseToken !== leaseToken) {
+      return undefined;
+    }
+
+    const updated = applyBackgroundJobUpdate(existing, {
+      status: "queued",
+      availableAt,
+      leaseOwner: null,
+      leaseToken: null,
+      leaseExpiresAt: null,
+      heartbeatAt: null,
+      attemptCount: Math.max(0, existing.attemptCount - 1),
+      lastError: error,
+      completedAt: null,
+      updatedAt,
+    });
+    this.backgroundJobs.set(id, updated);
+    return this.cloneBackgroundJob(updated);
+  }
+
   async cancelBackgroundJob(
     id: string,
     leaseToken: string,

--- a/server/rateLimitState.test.ts
+++ b/server/rateLimitState.test.ts
@@ -20,6 +20,9 @@ test("getRateLimitState reports unlimited by default", () => {
   assert.equal(state.resetAt, null);
   assert.equal(state.recentlyLimited, false);
   assert.equal(state.lastLimitedAt, null);
+  assert.equal(state.resources.core.budget, null);
+  assert.equal(state.resources.core.belowReserve, false);
+  assert.equal(state.resources.core.belowFloor, false);
 });
 
 test("markRateLimited with unix seconds sets a future reset", () => {
@@ -122,6 +125,25 @@ test("recordResourceBudget keeps the latest observation per resource", () => {
   assert.deepEqual(getResourceBudget("core"), { remaining: 4200, limit: 5000 });
   recordResourceBudget("core", 900, 5000);
   assert.deepEqual(getResourceBudget("core"), { remaining: 900, limit: 5000 });
+});
+
+test("getRateLimitState includes the latest resource budget and reserve state", () => {
+  const resetAt = new Date(Date.now() + 600_000);
+  recordResourceBudget("core", 900, 5000, resetAt);
+
+  const state = getRateLimitState();
+
+  assert.deepEqual(state.resources.core.budget, { remaining: 900, limit: 5000, resetAt });
+  assert.equal(state.resources.core.belowReserve, true);
+  assert.equal(state.resources.core.belowFloor, false);
+});
+
+test("expired resource budgets stop gating background work after the reset time", () => {
+  recordResourceBudget("core", 900, 5000, new Date(Date.now() - 1_000));
+
+  assert.equal(getResourceBudget("core"), null);
+  assert.equal(isResourceBudgetBelowReserve("core"), false);
+  assert.equal(isResourceBudgetBelowFloor("core"), false);
 });
 
 test("recordResourceBudget tracks core and graphql budgets independently", () => {

--- a/server/rateLimitState.ts
+++ b/server/rateLimitState.ts
@@ -11,6 +11,9 @@ export type ResourceSnapshot = {
   resetAt: Date | null;
   recentlyLimited: boolean;
   lastLimitedAt: Date | null;
+  budget: ResourceBudget | null;
+  belowReserve: boolean;
+  belowFloor: boolean;
 };
 
 export type RateLimitSnapshot = ResourceSnapshot & {
@@ -37,7 +40,7 @@ const state: Record<RateLimitResource, ResourceState> = {
   search: { resetAt: null, lastLimitedAt: null },
 };
 
-export type ResourceBudget = { remaining: number; limit: number };
+export type ResourceBudget = { remaining: number; limit: number; resetAt?: Date | null };
 
 const budgets: Record<RateLimitResource, ResourceBudget | null> = {
   core: null,
@@ -100,15 +103,34 @@ export function markRateLimited(
 
 function snapshotResource(resource: RateLimitResource, now: number): ResourceSnapshot {
   const entry = state[resource];
+  const budget = getResourceBudget(resource);
+  const belowReserve = isResourceBudgetBelowReserve(resource);
+  const belowFloor = isResourceBudgetBelowFloor(resource);
   const recentlyLimited = entry.lastLimitedAt !== null
     && (now - entry.lastLimitedAt.getTime()) <= RECENT_RATE_LIMIT_WINDOW_MS;
   if (entry.resetAt && entry.resetAt.getTime() <= now) {
     entry.resetAt = null;
   }
   if (!entry.resetAt) {
-    return { limited: false, resetAt: null, recentlyLimited, lastLimitedAt: entry.lastLimitedAt };
+    return {
+      limited: false,
+      resetAt: null,
+      recentlyLimited,
+      lastLimitedAt: entry.lastLimitedAt,
+      budget,
+      belowReserve,
+      belowFloor,
+    };
   }
-  return { limited: true, resetAt: entry.resetAt, recentlyLimited, lastLimitedAt: entry.lastLimitedAt };
+  return {
+    limited: true,
+    resetAt: entry.resetAt,
+    recentlyLimited,
+    lastLimitedAt: entry.lastLimitedAt,
+    budget,
+    belowReserve,
+    belowFloor,
+  };
 }
 
 export function getRateLimitState(resource?: RateLimitResource): RateLimitSnapshot {
@@ -131,12 +153,23 @@ export function getRateLimitState(resource?: RateLimitResource): RateLimitSnapsh
         .reduce((a, b) => (a.getTime() >= b.getTime() ? a : b))
     : null;
   const recentlyLimited = RESOURCES.some((r) => resources[r].recentlyLimited);
+  const belowReserve = RESOURCES.some((r) => resources[r].belowReserve);
+  const belowFloor = RESOURCES.some((r) => resources[r].belowFloor);
   const lastLimitedAt = RESOURCES
     .map((r) => resources[r].lastLimitedAt)
     .filter((d): d is Date => d !== null)
     .sort((a, b) => b.getTime() - a.getTime())[0] ?? null;
 
-  return { limited, resetAt, recentlyLimited, lastLimitedAt, resources };
+  return {
+    limited,
+    resetAt,
+    recentlyLimited,
+    lastLimitedAt,
+    budget: null,
+    belowReserve,
+    belowFloor,
+    resources,
+  };
 }
 
 export function clearRateLimited(resource: RateLimitResource = "core"): void {
@@ -156,15 +189,31 @@ export function recordResourceBudget(
   resource: RateLimitResource,
   remaining: number,
   limit: number,
+  reset?: Date | number,
 ): void {
   if (!Number.isFinite(remaining) || !Number.isFinite(limit) || limit <= 0) {
     return;
   }
-  budgets[resource] = { remaining: Math.max(0, remaining), limit };
+  const resetAt = parseReset(reset);
+  budgets[resource] = {
+    remaining: Math.max(0, remaining),
+    limit,
+    ...(resetAt ? { resetAt } : {}),
+  };
+}
+
+function readFreshResourceBudget(resource: RateLimitResource): ResourceBudget | null {
+  const budget = budgets[resource];
+  if (!budget) return null;
+  if (budget.resetAt && budget.resetAt.getTime() <= Date.now()) {
+    budgets[resource] = null;
+    return null;
+  }
+  return budget;
 }
 
 export function getResourceBudget(resource: RateLimitResource): ResourceBudget | null {
-  const budget = budgets[resource];
+  const budget = readFreshResourceBudget(resource);
   return budget ? { ...budget } : null;
 }
 
@@ -175,7 +224,7 @@ export function getResourceBudget(resource: RateLimitResource): ResourceBudget |
  * budget is unknown — an unobserved budget must not block work.
  */
 export function isResourceBudgetBelowReserve(resource: RateLimitResource): boolean {
-  const budget = budgets[resource];
+  const budget = readFreshResourceBudget(resource);
   if (!budget) return false;
   return budget.remaining <= budget.limit * BUDGET_RESERVE_FRACTION;
 }
@@ -187,7 +236,7 @@ export function isResourceBudgetBelowReserve(resource: RateLimitResource): boole
  * zero. Returns false when the budget is unknown.
  */
 export function isResourceBudgetBelowFloor(resource: RateLimitResource): boolean {
-  const budget = budgets[resource];
+  const budget = readFreshResourceBudget(resource);
   if (!budget) return false;
   return budget.remaining <= budget.limit * BUDGET_FLOOR_FRACTION;
 }

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -5,7 +5,7 @@ import express from "express";
 import type { Octokit } from "@octokit/rest";
 import type { AppUpdateStatus, FeedbackItem, Issue, IssueListPage, NewPR } from "@shared/schema";
 import type { AppRuntime } from "./appRuntime";
-import { clearRateLimited, markRateLimited } from "./rateLimitState";
+import { clearRateLimitStateForTests, markRateLimited, recordResourceBudget } from "./rateLimitState";
 import type { ReleaseAgentPullSummary, ReleaseEvaluationDecision } from "./releaseAgent";
 import { ReleaseManager, type ReleaseGitHubService } from "./releaseManager";
 import { MemStorage } from "./memoryStorage";
@@ -222,6 +222,7 @@ test("PATCH /api/config accepts legacy single githubToken updates", async () => 
 test("GET /api/github-rate-limit reports the current reset time", async () => {
   const resetAt = new Date(Date.now() + 600_000);
   markRateLimited(resetAt);
+  recordResourceBudget("core", 900, 5000);
 
   const harness = await createHarness();
 
@@ -234,6 +235,9 @@ test("GET /api/github-rate-limit reports the current reset time", async () => {
       resetAt: string | null;
       recentlyLimited: boolean;
       lastLimitedAt: string | null;
+      budget: { remaining: number; limit: number; percentRemaining: number; resetAt: string | null } | null;
+      belowReserve: boolean;
+      belowFloor: boolean;
     };
     const body = await response.json() as ResourceBody & {
       resources: { core: ResourceBody; graphql: ResourceBody; search: ResourceBody };
@@ -244,10 +248,18 @@ test("GET /api/github-rate-limit reports the current reset time", async () => {
     assert.ok(body.lastLimitedAt);
     assert.equal(body.resources.core.limited, true);
     assert.equal(body.resources.core.resetAt, resetAt.toISOString());
+    assert.deepEqual(body.resources.core.budget, {
+      remaining: 900,
+      limit: 5000,
+      percentRemaining: 18,
+      resetAt: null,
+    });
+    assert.equal(body.resources.core.belowReserve, true);
+    assert.equal(body.resources.core.belowFloor, false);
     assert.equal(body.resources.graphql.limited, false);
     assert.equal(body.resources.search.limited, false);
   } finally {
-    clearRateLimited();
+    clearRateLimitStateForTests();
     await harness.close();
   }
 });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -273,6 +273,16 @@ export async function registerRoutes(
       resetAt: snapshot.resetAt ? snapshot.resetAt.toISOString() : null,
       recentlyLimited: snapshot.recentlyLimited,
       lastLimitedAt: snapshot.lastLimitedAt ? snapshot.lastLimitedAt.toISOString() : null,
+      budget: snapshot.budget
+        ? {
+            remaining: snapshot.budget.remaining,
+            limit: snapshot.budget.limit,
+            percentRemaining: Math.round((snapshot.budget.remaining / snapshot.budget.limit) * 100),
+            resetAt: snapshot.budget.resetAt ? snapshot.budget.resetAt.toISOString() : null,
+          }
+        : null,
+      belowReserve: snapshot.belowReserve,
+      belowFloor: snapshot.belowFloor,
     });
     res.json({
       limited: state.limited,

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -3033,6 +3033,65 @@ export class SqliteStorage implements IStorage {
     });
   }
 
+  async deferBackgroundJob(
+    id: string,
+    leaseToken: string,
+    error: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    return this.withWriteTransaction(() => {
+      const current = this.get<BackgroundJobRow>(`
+        SELECT id, kind, target_id, dedupe_key, status, priority, available_at,
+               lease_owner, lease_token, lease_expires_at, heartbeat_at, attempt_count,
+               last_error, payload_json, created_at, updated_at, completed_at
+        FROM background_jobs
+        WHERE id = ? AND status = 'leased' AND lease_token = ?
+      `, id, leaseToken);
+
+      if (!current) {
+        return undefined;
+      }
+
+      const updated = applyBackgroundJobUpdate(this.parseBackgroundJobRow(current), {
+        status: "queued",
+        availableAt,
+        leaseOwner: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        heartbeatAt: null,
+        attemptCount: Math.max(0, current.attempt_count - 1),
+        lastError: error,
+        completedAt: null,
+        updatedAt,
+      });
+
+      this.run(`
+        UPDATE background_jobs
+        SET status = 'queued',
+            available_at = ?,
+            lease_owner = NULL,
+            lease_token = NULL,
+            lease_expires_at = NULL,
+            heartbeat_at = NULL,
+            attempt_count = ?,
+            last_error = ?,
+            completed_at = NULL,
+            updated_at = ?
+        WHERE id = ? AND status = 'leased' AND lease_token = ?
+      `,
+        updated.availableAt,
+        updated.attemptCount,
+        updated.lastError,
+        updated.updatedAt,
+        id,
+        leaseToken,
+      );
+
+      return updated;
+    });
+  }
+
   async cancelBackgroundJob(
     id: string,
     leaseToken: string,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -195,6 +195,7 @@ export interface IStorage {
   }): Promise<BackgroundJob | undefined>;
   heartbeatBackgroundJob(id: string, leaseToken: string, heartbeatAt: string, leaseExpiresAt: string): Promise<BackgroundJob | undefined>;
   completeBackgroundJob(id: string, leaseToken: string, completedAt: string): Promise<BackgroundJob | undefined>;
+  deferBackgroundJob(id: string, leaseToken: string, error: string, availableAt: string, updatedAt: string): Promise<BackgroundJob | undefined>;
   retryBackgroundJob(id: string, leaseToken: string, error: string, availableAt: string, updatedAt: string): Promise<BackgroundJob | undefined>;
   failBackgroundJob(id: string, leaseToken: string, error: string, completedAt: string): Promise<BackgroundJob | undefined>;
   cancelBackgroundJob(id: string, leaseToken: string, error: string | null, completedAt: string): Promise<BackgroundJob | undefined>;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,12 @@ export default {
   darkMode: ["class"],
   content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
   theme: {
+    fontSize: {
+      label: ["0.6875rem", { lineHeight: "1rem" }],
+      body: ["0.8125rem", { lineHeight: "1.3rem" }],
+      title: ["0.9375rem", { lineHeight: "1.4rem" }],
+      display: ["1.25rem", { lineHeight: "1.5rem" }],
+    },
     extend: {
       borderRadius: {
         lg: ".5625rem", /* 9px */


### PR DESCRIPTION
## Summary
- Keep Queue Work / Apply / existing PR actions as durable PR work intent by re-enabling watch, restoring errored PRs to watching, and queuing babysit work.
- Continue monitoring PRs after a completed run until GitHub reports they are actually merge-ready.
- Archive merged/closed PRs immediately when a queued babysit run starts, so already-merged PRs do not keep running agents or rescheduling monitor jobs.
- Fix deferred PR backfill so archived-but-open PR rows are reactivated instead of inserted again, avoiding duplicate `(repo, number)` failures.
- Fix PR readiness UI so queued/running work is shown as active automation instead of a stale error/idle state.
- Fix PR feedback and CI healing regressions: ignore app command comments as audit trails, clear blocked healing when CI turns healthy, and rerun cancelled GitHub Actions runs when safe.
- Add GitHub budget-aware throttling: passive PR monitor jobs defer without consuming retry attempts, deferred PR backfills cool down under core budget reserve, and budget observations expire after GitHub reset.
- Keep PR list pages usable from a validated local cache while refreshes are stale/throttled, and expose core/graphql/search budget evidence in the header/settings runtime view.

## Verification
- `git diff --check`
- `npm run check`
- `npm run test:all` (742/742 passing)
- Live local verification: GitHub reports gsd-build/gsd-2#6300 merged at 2026-05-18T18:36:32Z; PatchDeck now archives it with current run `completed/run.pr_merged` and `/api/activities` shows no #6300 queued or running work.
- Local API verification: `/api/github-rate-limit` returns per-resource budgets with reserve/floor state and reset timestamps.
- Browser verification: `/prs` renders the PR list from localhost; `/settings` runtime shows the core/graphql/search GitHub budget panel with no render errors.
- GitHub PR checks are green and the PR is marked ready for review; merge state is `CLEAN`.
