### PR TITLE
fix: clear stale passing PR checks

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -7953,6 +7953,81 @@ test("babysitPR falls back to status-task fixes after CI healing escalates", asy
   assert.ok(!logs.some((log) => log.phase === "evaluate.status" && log.message.includes("Skipping legacy status-task evaluation")));
 });
 
+test("babysitPR clears stale failed test state when current checks pass", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const pr = await storage.addPR({
+    number: 51,
+    title: "Already green",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/already-green",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/51",
+    status: "watching",
+    feedbackItems: [],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: false,
+    lintPassed: null,
+    mergeableState: "clean",
+    lastChecked: null,
+  });
+  const backgroundJobQueue = new BackgroundJobQueue(storage);
+  const scheduledJobs: string[] = [];
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      ...makeWatcherGitHubService(),
+      fetchPullSummary: async () => makePullSummary(pr, {
+        headSha: "green-head",
+        headRef: pr.branch,
+        branch: pr.branch,
+        mergeableState: "clean",
+      }),
+      fetchCheckSnapshotsForRef: async (_octokit: unknown, _repo: unknown, prId: string, headSha: string) => [
+        makeCheckSnapshot({
+          prId,
+          sha: headSha,
+          status: "completed",
+          conclusion: "success",
+          description: "Check run success",
+        }),
+      ],
+      listFailingStatuses: async () => [],
+    },
+    {
+      resolveAgent: async () => "codex",
+      evaluateFixNecessityWithAgent: async () => {
+        throw new Error("green checks should not need agent evaluation");
+      },
+      applyFixesWithAgent: async () => {
+        throw new Error("green checks should not need a worktree");
+      },
+      runCommand: async () => {
+        throw new Error("green checks should not need git commands");
+      },
+    },
+    undefined,
+    async (kind, targetId, dedupeKey, payload, options) => {
+      scheduledJobs.push(kind);
+      return backgroundJobQueue.enqueue(kind, targetId, dedupeKey, payload, options);
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex");
+
+  const updated = await storage.getPR(pr.id);
+  const jobs = await storage.listBackgroundJobs({ kind: "babysit_pr" });
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(updated?.testsPassed, true);
+  assert.equal(jobs.length, 0);
+  assert.deepEqual(scheduledJobs, []);
+  assert.ok(logs.some((log) => log.message.includes("Checked PR #51; no necessary fixes identified")));
+  assert.ok(!logs.some((log) => log.message.includes("queued follow-up monitoring")));
+});
+
 test("babysitPR reruns cancelled GitHub Actions checks and queues monitoring", async () => {
   const storage = new MemStorage();
   await storage.updateConfig({ autoUpdateDocs: false });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1466,6 +1466,27 @@ function isRerunnableCancelledGitHubActionsSnapshot(snapshot: CheckSnapshot): bo
     && Boolean(snapshot.targetUrl?.includes("/actions/runs/"));
 }
 
+function isPassingCheckSnapshot(snapshot: CheckSnapshot): boolean {
+  if (snapshot.provider === "github.commit_status") {
+    return snapshot.status === "success";
+  }
+
+  if (snapshot.provider === "github.check_run") {
+    return snapshot.status === "completed"
+      && (snapshot.conclusion === "success" || snapshot.conclusion === "neutral" || snapshot.conclusion === "skipped");
+  }
+
+  return false;
+}
+
+function getObservedTestsPassed(checkSnapshots: CheckSnapshot[]): true | null {
+  if (checkSnapshots.length > 0 && checkSnapshots.every(isPassingCheckSnapshot)) {
+    return true;
+  }
+
+  return null;
+}
+
 function summarizeGitHubActionsReruns(reruns: GitHubActionsRerun[]): string {
   return reruns
     .map((rerun) => `run ${rerun.runId} (${rerun.contexts.join(", ")})`)
@@ -3601,6 +3622,17 @@ export class PRBabysitter {
             observedAt,
           }));
       const failingCheckSnapshots = checkSnapshots.filter((snapshot) => isFailingCheckSnapshot(snapshot));
+      const observedTestsPassed = getObservedTestsPassed(checkSnapshots);
+      if (observedTestsPassed !== null && pr.testsPassed !== observedTestsPassed) {
+        const updatedPr = await this.storage.updatePR(pr.id, {
+          testsPassed: observedTestsPassed,
+          prStage: "tests",
+          lastChecked: new Date().toISOString(),
+        });
+        if (updatedPr) {
+          pr = updatedPr;
+        }
+      }
       const classifiedHealingFailures = classifyCIFailures(failingCheckSnapshots);
       const healableHealingFailures = classifiedHealingFailures.filter((failure) => failure.classification === "healable_in_branch");
       const blockedHealingFailures = classifiedHealingFailures.filter((failure) => failure.classification === "blocked_external");


### PR DESCRIPTION
## Summary
- clear stale `testsPassed:false` when the current GitHub check snapshots are all passing
- prevent green PRs from re-queueing monitor-only babysitter jobs forever
- add a regression test for stale failed test state on green checks

## Verification
- `npm run check`
- `node --import tsx --test server/babysitter.test.ts`
- `npm run test:all`
- live localhost verification: PRs 6026, 6107, and 6134 now report `testsPassed:true` after monitor passes