### PR TITLE
feat: add PR work contract visibility

### DIFF
--- a/client/src/lib/prListCache.test.ts
+++ b/client/src/lib/prListCache.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { PRSummary } from "@shared/schema";
+import { prWorkContractSchema, type PRSummary } from "@shared/schema";
 import {
   PR_LIST_CACHE_RETENTION_MS,
   PR_LIST_STALE_MS,
@@ -46,6 +46,7 @@ const samplePR: PRSummary = {
   lastSyncSucceededAt: null,
   lastSyncError: null,
   watchEnabled: true,
+  workContract: prWorkContractSchema.parse({}),
   addedAt: "2026-05-18T12:00:00.000Z",
 };
 

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -4,7 +4,8 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { AlertTriangle, Bot, CheckCircle2, ChevronDown, ChevronUp, CircleDashed, Loader2, PanelRightClose, PanelRightOpen, Pause, Play, PlayCircle, RefreshCw } from "lucide-react";
 import { queryClient, apiRequest, fetchJson } from "@/lib/queryClient";
-import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, RuntimeState, WatchedRepo } from "@shared/schema";
+import type { ActivityItem, ActivitySnapshot, Config, FeedbackItem, HealingSession, Issue, IssueListPage, LogEntry, OperatorWarning, PR, PRQuestion, PRSummary, PRWorkContract, RuntimeState, WatchedRepo } from "@shared/schema";
+import { formatPRWorkBlocker, formatPRWorkPhase } from "@shared/prWorkContract";
 import { AppHeader } from "@/components/AppHeader";
 import { OnboardingPanel } from "@/components/OnboardingPanel";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -55,6 +56,11 @@ function formatClock(timestamp: string | null): string | null {
   }
 
   return new Date(timestamp).toLocaleTimeString("en-US", { hour12: false });
+}
+
+function formatContractTime(timestamp: string | null): string | null {
+  const clock = formatClock(timestamp);
+  return clock ? `at ${clock}` : null;
 }
 
 function formatGitHubUsername(username?: string | null): string {
@@ -337,10 +343,13 @@ function ReadyToMergeIndicator({
 function MergeReadinessChecklist({
   checks,
   ready,
+  contract,
 }: {
   checks: ReturnType<typeof buildPRReadinessChecks>;
   ready: boolean;
+  contract: PRWorkContract;
 }) {
+  const nextAction = formatContractTime(contract.nextActionAt);
   return (
     <div
       className={`mt-2 rounded-md border px-3 py-2 text-label ${
@@ -357,6 +366,30 @@ function MergeReadinessChecklist({
         <div className="rounded-md border border-current/40 px-1.5 py-0 text-label uppercase tracking-wider">
           {ready ? "ready" : "not ready"}
         </div>
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-current/20 pt-2 text-label">
+        <span className="font-medium uppercase tracking-wider text-foreground">Contract</span>
+        <span>
+          intent: <span className="text-foreground">{contract.intent.replaceAll("_", " ")}</span>
+        </span>
+        <span>
+          phase: <span className="text-foreground">{formatPRWorkPhase(contract.phase)}</span>
+        </span>
+        {contract.blocker && (
+          <span>
+            why: <span className="text-foreground">{formatPRWorkBlocker(contract.blocker)}</span>
+          </span>
+        )}
+        {nextAction && (
+          <span>
+            next: <span className="font-mono text-foreground">{nextAction}</span>
+          </span>
+        )}
+        {contract.reason && (
+          <span className="min-w-0 flex-1 truncate" title={contract.reason}>
+            {contract.reason}
+          </span>
+        )}
       </div>
       <div className="mt-2 grid gap-1 sm:grid-cols-2">
         {checks.map((check) => (
@@ -497,6 +530,11 @@ const PRRow = memo(function PRRow({
             </a>
             <span>{formatGitHubUsername(pr.author)}</span>
             <span>{formatPRWorkState(pr.status, pr.prStage)}</span>
+            {pr.workContract.blocker && (
+              <span title={pr.workContract.reason ?? undefined}>
+                why: {formatPRWorkBlocker(pr.workContract.blocker)}
+              </span>
+            )}
             <QueueStatusBadge status={queueStatus} />
             {!watchEnabled && <WatchPausedIndicator />}
             <span>{pr.accepted + pr.rejected + pr.flagged} triaged</span>
@@ -1723,6 +1761,7 @@ export default function Dashboard() {
                     <MergeReadinessChecklist
                       checks={selectedPRReadinessChecks}
                       ready={isPRDetailReadyToMerge(selectedPR)}
+                      contract={selectedPR.workContract}
                     />
                     {isPRDetailReadyToMerge(selectedPR) && (
                       <ReadyToMergeIndicator

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -106,6 +106,11 @@ test("runtime queueBabysit enqueues a babysit job using the configured agent", a
   assert.equal(jobs[0]?.payload.activityLabel, "Working PR #42");
   assert.equal(jobs[0]?.payload.activityDetail, "acme/widgets - feat: add widget");
   assert.equal(jobs[0]?.payload.activityTargetUrl, pr.url);
+
+  const selected = await runtime.getPR(pr.id);
+  assert.equal(selected?.currentRun?.status, "queued");
+  assert.equal(selected?.workContract.phase, "fixing");
+  assert.equal(selected?.workContract.blocker, "automation_queued");
 });
 
 test("runtime queueBabysit records durable PR work intent", async () => {
@@ -124,6 +129,12 @@ test("runtime queueBabysit records durable PR work intent", async () => {
 
   assert.equal(updated.status, "watching");
   assert.equal(updated.watchEnabled, true);
+  assert.equal(updated.workContract.intent, "make_merge_ready");
+  assert.equal(updated.workContract.phase, "fixing");
+  assert.equal(updated.workContract.blocker, "automation_queued");
+  assert.equal(updated.workContract.attemptCount, 1);
+  assert.ok(updated.workContract.lastAttemptAt);
+  assert.ok(updated.workContract.staleAfter);
 
   const config = await storage.getConfig();
   assert.deepEqual(config.watchedRepos, ["acme/widgets"]);

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -26,6 +26,7 @@ import type {
 } from "@shared/schema";
 import { z } from "zod";
 import { addPRSchema, askQuestionSchema } from "@shared/schema";
+import { derivePRWorkContract, markPRWorkQueuedContract } from "@shared/prWorkContract";
 import type { IStorage } from "./storage";
 import { getDefaultStorage } from "./storage";
 import { PRBabysitter } from "./babysitter";
@@ -596,12 +597,42 @@ function latestRunLog(logs: LogEntry[], runId: string): LogEntry | undefined {
   return undefined;
 }
 
+function currentRunStatusFromPRJob(job: BackgroundJob | undefined): CurrentRunStatus | null {
+  if (!job || (job.status !== "queued" && job.status !== "leased")) {
+    return null;
+  }
+
+  const activity = readActivityPayload(job.payload);
+  const preferredAgent = job.payload.preferredAgent;
+  const phase = job.status === "queued" ? "pr.queued" : "pr.running";
+  return {
+    id: job.id,
+    status: job.status === "queued" ? "queued" : "running",
+    phase,
+    label: job.status === "queued" ? "PR work queued" : "PR work running",
+    detail: activity?.detail ?? job.lastError,
+    agent: preferredAgent === "codex" || preferredAgent === "claude" ? preferredAgent : null,
+    startedAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    lastError: job.lastError,
+  };
+}
+
 async function deriveCurrentPrRun(pr: PR | PRSummary, storage: IStorage, logs?: LogEntry[]): Promise<CurrentRunStatus | null> {
+  const jobs = await storage.listBackgroundJobs({
+    kind: "babysit_pr",
+    targetId: pr.id,
+  });
+  const queuedJobRun = currentRunStatusFromPRJob(getLatestBackgroundJob(jobs.filter((job) => job.status === "queued")));
+  if (queuedJobRun) return queuedJobRun;
+
   const runs = await storage.listAgentRuns({ prId: pr.id });
   const latestRun = runs
     .slice()
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
-  if (!latestRun) return null;
+  if (!latestRun) {
+    return currentRunStatusFromPRJob(getLatestBackgroundJob(jobs.filter((job) => job.status === "leased")));
+  }
 
   const prLogs = logs ?? await storage.getLogs(pr.id);
   const detailLog = latestRunLog(prLogs, latestRun.id);
@@ -619,11 +650,18 @@ async function deriveCurrentPrRun(pr: PR | PRSummary, storage: IStorage, logs?: 
 }
 
 async function attachDerivedPrStage<T extends PR | PRSummary>(pr: T, storage: IStorage): Promise<T> {
-  const withCurrentRun = async (updates: Pick<PR, "prStage">): Promise<T> => ({
-    ...pr,
-    ...updates,
-    currentRun: await deriveCurrentPrRun(pr, storage),
-  });
+  const withCurrentRun = async (updates: Pick<PR, "prStage">, logs?: LogEntry[]): Promise<T> => {
+    const currentRun = await deriveCurrentPrRun(pr, storage, logs);
+    const nextPr = {
+      ...pr,
+      ...updates,
+      currentRun,
+    };
+    return {
+      ...nextPr,
+      workContract: derivePRWorkContract(nextPr, { currentRun }),
+    };
+  };
 
   if (pr.status === "watching") {
     return withCurrentRun({ prStage: "feedback_synced" });
@@ -632,11 +670,7 @@ async function attachDerivedPrStage<T extends PR | PRSummary>(pr: T, storage: IS
     return withCurrentRun({ prStage: "done" });
   }
   const logs = await storage.getLogs(pr.id);
-  return {
-    ...pr,
-    prStage: derivePrStageFromLogs(logs),
-    currentRun: await deriveCurrentPrRun(pr, storage, logs),
-  };
+  return withCurrentRun({ prStage: derivePrStageFromLogs(logs) }, logs);
 }
 
 function issueWorkStageFromLogs(
@@ -2003,7 +2037,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
   };
 
   const queueBabysitWithAgent = async (pr: PR, preferredAgent: Config["codingAgent"]) => {
-    await scheduleBackgroundJob(
+    const job = await scheduleBackgroundJob(
       "babysit_pr",
       pr.id,
       buildBackgroundJobDedupeKey("babysit_pr", pr.id),
@@ -2016,6 +2050,14 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         }),
       },
     );
+    await storage.updatePR(pr.id, {
+      workContract: markPRWorkQueuedContract(pr.workContract, {
+        now: new Date(),
+        availableAt: new Date(job.availableAt),
+        reason: "PR work is queued.",
+        leaseOwner: preferredAgent,
+      }),
+    });
   };
 
   const activatePRWorkIntent = async (pr: PR, config: Config): Promise<{ pr: PR; config: Config }> => {

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -8178,6 +8178,12 @@ test("babysitPR queues follow-up monitoring when PR remains not merge-ready", as
   assert.equal(jobs[0]?.payload.monitorFollowUp, true);
   assert.equal(jobs[0]?.payload.monitorReason, "GitHub mergeable state is blocked");
 
+  const updatedPr = await storage.getPR(pr.id);
+  assert.equal(updatedPr?.workContract.phase, "monitoring");
+  assert.equal(updatedPr?.workContract.blocker, "checks_pending");
+  assert.equal(updatedPr?.workContract.reason, "GitHub mergeable state is blocked");
+  assert.equal(updatedPr?.workContract.nextActionAt, "2026-05-18T10:01:00.000Z");
+
   const logs = await storage.getLogs(pr.id);
   assert.ok(logs.some((log) => log.message.includes("queued follow-up monitoring")));
 });

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "crypto";
 import { access } from "fs/promises";
 import path from "path";
-import type { AgentRun, CheckSnapshot, FeedbackItem, HealingSession, PR, PRStage } from "@shared/schema";
+import type { AgentRun, CheckSnapshot, FeedbackItem, HealingSession, PR, PRStage, PRWorkBlocker } from "@shared/schema";
+import { markPRWorkMonitoringContract, markPRWorkQueuedContract } from "@shared/prWorkContract";
 import type { IStorage } from "./storage";
 import {
   applyFixesWithAgent,
@@ -1459,6 +1460,40 @@ function getPRNotMergeReadyReason(pr: PR): string | null {
   return null;
 }
 
+function getPRWorkBlockerForReason(reason: string): PRWorkBlocker {
+  const normalized = reason.toLowerCase();
+  if (normalized.includes("rate limit") || normalized.includes("budget")) {
+    return "rate_limited";
+  }
+  if (normalized.includes("test") || normalized.includes("lint") || normalized.includes("ci")) {
+    return "checks_failed";
+  }
+  if (normalized.includes("feedback") || normalized.includes("comment") || normalized.includes("review")) {
+    return "review_feedback";
+  }
+  if (normalized.includes("conflict")) {
+    return "merge_conflict";
+  }
+  if (normalized.includes("mergeable state is") || normalized.includes("pending")) {
+    return "checks_pending";
+  }
+  if (normalized.includes("permission") || normalized.includes("auth")) {
+    return "missing_permissions";
+  }
+  if (normalized.includes("running") || normalized.includes("failed")) {
+    return "automation_stalled";
+  }
+  return "unknown_needs_triage";
+}
+
+function parseJobAvailableAt(value: string | undefined, fallback: Date): Date {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed : fallback;
+}
+
 function isRerunnableCancelledGitHubActionsSnapshot(snapshot: CheckSnapshot): boolean {
   return snapshot.provider === "github.check_run"
     && snapshot.status === "completed"
@@ -1747,6 +1782,14 @@ export class PRBabysitter {
         availableAt,
       },
     );
+    await this.storage.updatePR(pr.id, {
+      workContract: markPRWorkMonitoringContract(pr.workContract, {
+        now: this.now(),
+        blocker: getPRWorkBlockerForReason(reason),
+        reason,
+        nextActionAt: availableAt,
+      }),
+    });
 
     await this.storage.addLog(pr.id, "info", `PR is not merge-ready; queued follow-up monitoring because ${reason}`, {
       phase: "watcher",
@@ -2831,6 +2874,26 @@ export class PRBabysitter {
             || babysitEnqueues >= MAX_BABYSIT_ENQUEUES_PER_SWEEP
             || inFlightBabysitJobs >= maxConcurrentBabysitRuns
           ) {
+            const deferredReason = babysitBudgetTight
+              ? "core budget reserve"
+              : inFlightBabysitJobs >= maxConcurrentBabysitRuns
+                ? "concurrency cap"
+                : "per-sweep cap";
+            const deferredDelayMs = babysitBudgetTight
+              ? DEFERRED_BABYSIT_BUDGET_DELAY_MS
+              : DEFERRED_BABYSIT_SWEEP_DELAY_MS;
+            const blocker = babysitBudgetTight ? "rate_limited" : "automation_stalled";
+            const reason = `Deferred automatic PR work because of ${deferredReason}.`;
+            if (local.workContract.blocker !== blocker || local.workContract.reason !== reason) {
+              await this.storage.updatePR(local.id, {
+                workContract: markPRWorkMonitoringContract(local.workContract, {
+                  now: this.now(),
+                  blocker,
+                  reason,
+                  nextActionAt: new Date(this.now().getTime() + deferredDelayMs),
+                }),
+              });
+            }
             babysitDeferred += 1;
             continue;
           }
@@ -2840,7 +2903,7 @@ export class PRBabysitter {
             phase: "watcher",
             metadata: { repo: repoSlug },
           });
-          await this.scheduleBackgroundJob(
+          const job = await this.scheduleBackgroundJob(
             "babysit_pr",
             local.id,
             buildBackgroundJobDedupeKey("babysit_pr", local.id),
@@ -2853,6 +2916,14 @@ export class PRBabysitter {
               }),
             },
           );
+          await this.storage.updatePR(local.id, {
+            workContract: markPRWorkQueuedContract(local.workContract, {
+              now: this.now(),
+              availableAt: parseJobAvailableAt(job.availableAt, this.now()),
+              reason: "Watcher queued automatic PR work.",
+              leaseOwner: currentConfig.codingAgent as CodingAgent,
+            }),
+          });
         } else {
           await this.storage.addLog(local.id, "info", "Watcher queued automatic PR work", {
             phase: "watcher",

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
 import type { SQLInputValue } from "node:sqlite";
-import { backgroundJobStatusEnum, docsAssessmentSchema, feedbackStatusEnum, prStageEnum } from "@shared/schema";
+import { backgroundJobStatusEnum, docsAssessmentSchema, feedbackStatusEnum, prStageEnum, prWorkContractSchema } from "@shared/schema";
 import type {
   AgentRun,
   AgentRunStatus,
@@ -167,6 +167,7 @@ type PRRow = {
   last_sync_error: string | null;
   watch_enabled: number;
   docs_assessment_json: string | null;
+  work_contract_json: string | null;
   added_at: string;
 };
 
@@ -627,6 +628,7 @@ export class SqliteStorage implements IStorage {
         last_sync_error TEXT,
         watch_enabled INTEGER NOT NULL DEFAULT 1,
         docs_assessment_json TEXT,
+        work_contract_json TEXT,
         added_at TEXT NOT NULL,
         UNIQUE(repo, number)
       );
@@ -983,6 +985,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("prs", "body_html", "TEXT");
     this.ensureColumn("prs", "pr_stage", "TEXT");
     this.ensureColumn("prs", "mergeable_state", "TEXT");
+    this.ensureColumn("prs", "work_contract_json", "TEXT");
 
     const configExists = this.get<{ present: number }>("SELECT 1 AS present FROM config WHERE id = 1");
     if (!configExists) {
@@ -1305,6 +1308,7 @@ export class SqliteStorage implements IStorage {
       lastSyncError: row.last_sync_error ?? null,
       watchEnabled: Boolean(row.watch_enabled),
       docsAssessment: this.parseDocsAssessment(row.docs_assessment_json),
+      workContract: this.parsePRWorkContract(row.work_contract_json),
       addedAt: row.added_at,
     };
   }
@@ -1334,6 +1338,7 @@ export class SqliteStorage implements IStorage {
       lastSyncError: row.last_sync_error ?? null,
       watchEnabled: Boolean(row.watch_enabled),
       docsAssessment: this.parseDocsAssessment(row.docs_assessment_json),
+      workContract: this.parsePRWorkContract(row.work_contract_json),
       addedAt: row.added_at,
     };
   }
@@ -1353,6 +1358,18 @@ export class SqliteStorage implements IStorage {
       return docsAssessmentSchema.parse(JSON.parse(raw));
     } catch {
       return null;
+    }
+  }
+
+  private parsePRWorkContract(raw: string | null): PR["workContract"] {
+    if (!raw) {
+      return prWorkContractSchema.parse({});
+    }
+
+    try {
+      return prWorkContractSchema.parse(JSON.parse(raw));
+    } catch {
+      return prWorkContractSchema.parse({});
     }
   }
 
@@ -1661,7 +1678,7 @@ export class SqliteStorage implements IStorage {
   async getPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
       FROM prs
       WHERE status != 'archived'
       ORDER BY number DESC
@@ -1675,7 +1692,7 @@ export class SqliteStorage implements IStorage {
   async getArchivedPRs(): Promise<PR[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
       FROM prs
       WHERE status = 'archived'
       ORDER BY number DESC
@@ -1689,7 +1706,7 @@ export class SqliteStorage implements IStorage {
   async getPRSummaries(): Promise<PRSummary[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
       FROM prs
       WHERE status != 'archived'
       ORDER BY number DESC
@@ -1701,7 +1718,7 @@ export class SqliteStorage implements IStorage {
   async getArchivedPRSummaries(): Promise<PRSummary[]> {
     const rows = this.all<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
       FROM prs
       WHERE status = 'archived'
       ORDER BY number DESC
@@ -1713,7 +1730,7 @@ export class SqliteStorage implements IStorage {
   async getPR(id: string): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
       FROM prs
       WHERE id = ?
     `, id);
@@ -1729,7 +1746,7 @@ export class SqliteStorage implements IStorage {
   async getPRByRepoAndNumber(repo: string, number: number): Promise<PR | undefined> {
     const row = this.get<PRRow>(`
       SELECT id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
+             tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
       FROM prs
       WHERE repo = ? AND number = ?
     `, repo, number);
@@ -1749,8 +1766,8 @@ export class SqliteStorage implements IStorage {
       this.run(`
         INSERT INTO prs (
           id, number, title, body, body_html, pr_stage, repo, branch, author, url, status, accepted, rejected, flagged,
-          tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, added_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          tests_passed, lint_passed, mergeable_state, last_checked, last_sync_attempted_at, last_sync_succeeded_at, last_sync_error, watch_enabled, docs_assessment_json, work_contract_json, added_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
         full.id,
         full.number,
@@ -1775,6 +1792,7 @@ export class SqliteStorage implements IStorage {
         full.lastSyncError ?? null,
         Number(full.watchEnabled),
         full.docsAssessment ? JSON.stringify(full.docsAssessment) : null,
+        JSON.stringify(full.workContract),
         full.addedAt,
       );
 
@@ -1796,7 +1814,7 @@ export class SqliteStorage implements IStorage {
         UPDATE prs
         SET number = ?, title = ?, body = ?, body_html = ?, pr_stage = ?, repo = ?, branch = ?, author = ?, url = ?, status = ?,
             accepted = ?, rejected = ?, flagged = ?, tests_passed = ?, lint_passed = ?, mergeable_state = ?, last_checked = ?,
-            last_sync_attempted_at = ?, last_sync_succeeded_at = ?, last_sync_error = ?, watch_enabled = ?, docs_assessment_json = ?
+            last_sync_attempted_at = ?, last_sync_succeeded_at = ?, last_sync_error = ?, watch_enabled = ?, docs_assessment_json = ?, work_contract_json = ?
         WHERE id = ?
       `,
         updated.number,
@@ -1821,6 +1839,7 @@ export class SqliteStorage implements IStorage {
         updated.lastSyncError ?? null,
         Number(updated.watchEnabled),
         updated.docsAssessment ? JSON.stringify(updated.docsAssessment) : null,
+        JSON.stringify(updated.workContract),
         id,
       );
 

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -10,6 +10,7 @@ import { DEFAULT_CONFIG } from "./defaultConfig";
 import { getCodeFactoryPaths } from "./paths";
 import { SQLITE_LOCK_TIMEOUT_MS, SqliteStorage } from "./sqliteStorage";
 import { MemStorage } from "./memoryStorage";
+import { markPRWorkQueuedContract } from "@shared/prWorkContract";
 
 function createRawDatabase(root: string): DatabaseSync {
   const db = new DatabaseSync(getCodeFactoryPaths(root).stateDbPath, {
@@ -578,6 +579,54 @@ test("SqliteStorage defaults watchEnabled to true for new PRs", async () => {
     assert.equal(reloaded?.watchEnabled, true);
   } finally {
     storage.close();
+  }
+});
+
+test("SqliteStorage persists PR work contract state", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const first = new SqliteStorage(root);
+
+  let prId: string;
+  try {
+    const pr = await first.addPR({
+      number: 108,
+      title: "Contracted work",
+      repo: "alex-morgan-o/lolodex",
+      branch: "feature/contract",
+      author: "octocat",
+      url: "https://github.com/alex-morgan-o/lolodex/pull/108",
+      status: "watching",
+      feedbackItems: [],
+      accepted: 0,
+      rejected: 0,
+      flagged: 0,
+      testsPassed: null,
+      lintPassed: null,
+      lastChecked: null,
+    });
+    prId = pr.id;
+    await first.updatePR(pr.id, {
+      workContract: markPRWorkQueuedContract(pr.workContract, {
+        now: new Date("2026-05-19T12:00:00.000Z"),
+        availableAt: new Date("2026-05-19T12:05:00.000Z"),
+        leaseOwner: "claude",
+      }),
+    });
+  } finally {
+    first.close();
+  }
+
+  const second = new SqliteStorage(root);
+  try {
+    const reloaded = await second.getPR(prId!);
+    assert.equal(reloaded?.workContract.intent, "make_merge_ready");
+    assert.equal(reloaded?.workContract.phase, "fixing");
+    assert.equal(reloaded?.workContract.blocker, "automation_queued");
+    assert.equal(reloaded?.workContract.nextActionAt, "2026-05-19T12:05:00.000Z");
+    assert.equal(reloaded?.workContract.attemptCount, 1);
+    assert.equal(reloaded?.workContract.leaseOwner, "claude");
+  } finally {
+    second.close();
   }
 });
 

--- a/shared/prWorkContract.ts
+++ b/shared/prWorkContract.ts
@@ -1,0 +1,253 @@
+import { prWorkContractSchema } from "./schema";
+import type {
+  CurrentRunStatus,
+  FeedbackItem,
+  PR,
+  PRSummary,
+  PRWorkBlocker,
+  PRWorkContract,
+  PRWorkPhase,
+} from "./schema";
+
+export const PR_WORK_CONTRACT_STALE_MS = 30 * 60_000;
+
+type PRContractSource = Pick<
+  PR,
+  | "status"
+  | "testsPassed"
+  | "lintPassed"
+  | "mergeableState"
+  | "lastSyncError"
+  | "workContract"
+> & {
+  feedbackItems?: FeedbackItem[];
+};
+
+type ContractPatch = {
+  phase: PRWorkPhase;
+  blocker: PRWorkBlocker | null;
+  reason: string | null;
+  nextActionAt?: string | null;
+  lastAttemptAt?: string | null;
+  attemptCount?: number;
+  leaseOwner?: string | null;
+  staleAfter?: string | null;
+};
+
+export function normalizePRWorkContract(contract?: PRWorkContract | null): PRWorkContract {
+  return prWorkContractSchema.parse(contract ?? {});
+}
+
+function isFeedbackClosedStatus(status: FeedbackItem["status"]): boolean {
+  return status === "resolved" || status === "rejected";
+}
+
+function hasOpenFeedback(items: FeedbackItem[] | undefined): boolean {
+  return Boolean(items?.some((item) => !isFeedbackClosedStatus(item.status)));
+}
+
+function hasActiveFeedbackWork(items: FeedbackItem[] | undefined): boolean {
+  return Boolean(items?.some((item) => item.status === "queued" || item.status === "in_progress"));
+}
+
+function addMs(now: Date, ms: number): string {
+  return new Date(now.getTime() + ms).toISOString();
+}
+
+function applyContractPatch(
+  existing: PRWorkContract | undefined | null,
+  patch: ContractPatch,
+  now: Date,
+  options: { touchUpdatedAt?: boolean } = {},
+): PRWorkContract {
+  const current = normalizePRWorkContract(existing);
+  return prWorkContractSchema.parse({
+    ...current,
+    ...patch,
+    updatedAt: options.touchUpdatedAt === false ? current.updatedAt : now.toISOString(),
+  });
+}
+
+export function markPRWorkQueuedContract(
+  existing: PRWorkContract | undefined | null,
+  options: {
+    now: Date;
+    reason?: string;
+    availableAt?: Date;
+    leaseOwner?: string | null;
+    staleMs?: number;
+  },
+): PRWorkContract {
+  const current = normalizePRWorkContract(existing);
+  return applyContractPatch(existing, {
+    phase: "fixing",
+    blocker: "automation_queued",
+    reason: options.reason ?? "PR work is queued.",
+    nextActionAt: (options.availableAt ?? options.now).toISOString(),
+    lastAttemptAt: options.now.toISOString(),
+    attemptCount: current.attemptCount + 1,
+    leaseOwner: options.leaseOwner ?? null,
+    staleAfter: addMs(options.now, options.staleMs ?? PR_WORK_CONTRACT_STALE_MS),
+  }, options.now);
+}
+
+export function markPRWorkMonitoringContract(
+  existing: PRWorkContract | undefined | null,
+  options: {
+    now: Date;
+    blocker: PRWorkBlocker | null;
+    reason: string | null;
+    nextActionAt?: Date | null;
+  },
+): PRWorkContract {
+  return applyContractPatch(existing, {
+    phase: options.blocker ? "monitoring" : "ready",
+    blocker: options.blocker,
+    reason: options.reason,
+    nextActionAt: options.nextActionAt ? options.nextActionAt.toISOString() : null,
+    leaseOwner: null,
+    staleAfter: null,
+  }, options.now);
+}
+
+export function derivePRWorkContract(
+  pr: PRContractSource,
+  options: {
+    currentRun?: CurrentRunStatus | null;
+    now?: Date;
+  } = {},
+): PRWorkContract {
+  const now = options.now ?? new Date();
+  const current = normalizePRWorkContract(pr.workContract);
+  const currentRun = options.currentRun ?? null;
+
+  if (currentRun?.status === "queued") {
+    return applyContractPatch(current, {
+      phase: "fixing",
+      blocker: "automation_queued",
+      reason: currentRun.detail ?? "PR work is queued.",
+      nextActionAt: current.nextActionAt,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (currentRun?.status === "running") {
+    return applyContractPatch(current, {
+      phase: "fixing",
+      blocker: "automation_running",
+      reason: currentRun.detail ?? "PR work is running.",
+      nextActionAt: null,
+      leaseOwner: currentRun.agent,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (currentRun?.status === "failed") {
+    return applyContractPatch(current, {
+      phase: "blocked",
+      blocker: "automation_stalled",
+      reason: currentRun.lastError ?? currentRun.detail ?? "Last PR work run failed.",
+      nextActionAt: current.nextActionAt,
+      leaseOwner: null,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.status === "done" || pr.status === "archived") {
+    return applyContractPatch(current, {
+      phase: "ready",
+      blocker: null,
+      reason: pr.status === "archived" ? "PR is closed on GitHub." : "PR work is complete.",
+      nextActionAt: null,
+      leaseOwner: null,
+      staleAfter: null,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.status === "processing") {
+    return applyContractPatch(current, {
+      phase: "fixing",
+      blocker: "automation_running",
+      reason: "Automation work is running.",
+      nextActionAt: null,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.status === "error") {
+    return applyContractPatch(current, {
+      phase: "blocked",
+      blocker: "automation_stalled",
+      reason: pr.lastSyncError ?? "Last automation run failed.",
+      nextActionAt: current.nextActionAt,
+      leaseOwner: null,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.testsPassed === false || pr.lintPassed === false) {
+    return applyContractPatch(current, {
+      phase: "fixing",
+      blocker: "checks_failed",
+      reason: pr.testsPassed === false ? "Tests are failing." : "Lint is failing.",
+      nextActionAt: current.nextActionAt,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (hasOpenFeedback(pr.feedbackItems)) {
+    return applyContractPatch(current, {
+      phase: hasActiveFeedbackWork(pr.feedbackItems) ? "fixing" : "waiting_review",
+      blocker: "review_feedback",
+      reason: "Tracked review feedback still needs attention.",
+      nextActionAt: current.nextActionAt,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.mergeableState === "clean") {
+    return applyContractPatch(current, {
+      phase: "ready",
+      blocker: null,
+      reason: "GitHub reports this PR is ready to merge.",
+      nextActionAt: null,
+      leaseOwner: null,
+      staleAfter: null,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.mergeableState === "dirty") {
+    return applyContractPatch(current, {
+      phase: "blocked",
+      blocker: "merge_conflict",
+      reason: "GitHub reports merge conflicts.",
+      nextActionAt: current.nextActionAt,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  if (pr.mergeableState === "draft") {
+    return applyContractPatch(current, {
+      phase: "blocked",
+      blocker: "draft_pr",
+      reason: "GitHub reports this PR is still a draft.",
+      nextActionAt: current.nextActionAt,
+    }, now, { touchUpdatedAt: false });
+  }
+
+  return applyContractPatch(current, {
+    phase: "monitoring",
+    blocker: "checks_pending",
+    reason: `GitHub mergeable state is ${pr.mergeableState ?? "unknown"}.`,
+    nextActionAt: current.nextActionAt,
+  }, now, { touchUpdatedAt: false });
+}
+
+export function formatPRWorkBlocker(blocker: PRWorkBlocker | null): string {
+  if (!blocker) return "none";
+  return blocker.replaceAll("_", " ");
+}
+
+export function formatPRWorkPhase(phase: PRWorkPhase): string {
+  return phase.replaceAll("_", " ");
+}
+
+export function getPRWorkContractSummary(pr: Pick<PRSummary, "workContract">): string {
+  const contract = normalizePRWorkContract(pr.workContract);
+  if (!contract.blocker) {
+    return formatPRWorkPhase(contract.phase);
+  }
+  return `${formatPRWorkPhase(contract.phase)}: ${formatPRWorkBlocker(contract.blocker)}`;
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -7,6 +7,36 @@ export type PRStatus = z.infer<typeof prStatusEnum>;
 export const prStageEnum = z.enum(["feedback_synced", "triaged", "applying", "tests", "done"]);
 export type PRStage = z.infer<typeof prStageEnum>;
 
+export const prWorkIntentEnum = z.enum(["make_merge_ready"]);
+export type PRWorkIntent = z.infer<typeof prWorkIntentEnum>;
+
+export const prWorkPhaseEnum = z.enum([
+  "monitoring",
+  "fixing",
+  "waiting_ci",
+  "waiting_review",
+  "ready",
+  "blocked",
+]);
+export type PRWorkPhase = z.infer<typeof prWorkPhaseEnum>;
+
+export const prWorkBlockerEnum = z.enum([
+  "automation_queued",
+  "automation_running",
+  "automation_stalled",
+  "checks_failed",
+  "checks_pending",
+  "draft_pr",
+  "external_ci_failure",
+  "lease_stale",
+  "merge_conflict",
+  "missing_permissions",
+  "rate_limited",
+  "review_feedback",
+  "unknown_needs_triage",
+]);
+export type PRWorkBlocker = z.infer<typeof prWorkBlockerEnum>;
+
 export const triageDecision = z.enum(["accept", "reject", "flag"]);
 export type TriageDecision = z.infer<typeof triageDecision>;
 
@@ -70,6 +100,20 @@ export const currentRunStatusSchema = z.object({
 });
 export type CurrentRunStatus = z.infer<typeof currentRunStatusSchema>;
 
+export const prWorkContractSchema = z.object({
+  intent: prWorkIntentEnum.default("make_merge_ready"),
+  phase: prWorkPhaseEnum.default("monitoring"),
+  blocker: prWorkBlockerEnum.nullable().default(null),
+  reason: z.string().nullable().default(null),
+  nextActionAt: z.string().nullable().default(null),
+  lastAttemptAt: z.string().nullable().default(null),
+  attemptCount: z.number().int().nonnegative().default(0),
+  leaseOwner: z.string().nullable().default(null),
+  staleAfter: z.string().nullable().default(null),
+  updatedAt: z.string().nullable().default(null),
+});
+export type PRWorkContract = z.infer<typeof prWorkContractSchema>;
+
 export const prSchema = z.object({
   id: z.string(),
   number: z.number(),
@@ -96,6 +140,7 @@ export const prSchema = z.object({
   watchEnabled: z.boolean().default(true),
   docsAssessment: docsAssessmentSchema.nullable().optional(),
   currentRun: currentRunStatusSchema.nullable().optional(),
+  workContract: prWorkContractSchema.default({}),
   addedAt: z.string(),
 });
 export type PR = z.infer<typeof prSchema>;


### PR DESCRIPTION
## Summary
- add a persisted PR work contract with intent, phase, blocker, retry timing, attempts, lease owner, and stale deadline
- derive contract state from queued/running PR jobs plus readiness signals so Queue Work has a visible make-merge-ready contract
- show the contract reason in the PR list and Merge Readiness panel

## Verification
- npm run check
- npm run test:all
- npm run build
- Browser sanity check on localhost:5002/#/prs with a seeded PR contract fixture