### PR TITLE
fix: contain page render crashes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,17 +13,74 @@ import Issues from "@/pages/issues";
 import Logs from "@/pages/logs";
 import NotFound from "@/pages/not-found";
 import { WebLoginGate } from "@/components/WebLoginGate";
+import { PageErrorBoundary } from "@/components/PageErrorBoundary";
+
+function DashboardRoute() {
+  return (
+    <PageErrorBoundary pageName="Dashboard">
+      <Dashboard />
+    </PageErrorBoundary>
+  );
+}
+
+function PRsRoute() {
+  return (
+    <PageErrorBoundary pageName="Pull requests">
+      <PRs />
+    </PageErrorBoundary>
+  );
+}
+
+function SettingsRoute() {
+  return (
+    <PageErrorBoundary pageName="Settings">
+      <Settings />
+    </PageErrorBoundary>
+  );
+}
+
+function ReleasesRoute() {
+  return (
+    <PageErrorBoundary pageName="Releases">
+      <Releases />
+    </PageErrorBoundary>
+  );
+}
+
+function IssuesRoute() {
+  return (
+    <PageErrorBoundary pageName="Issues">
+      <Issues />
+    </PageErrorBoundary>
+  );
+}
+
+function LogsRoute() {
+  return (
+    <PageErrorBoundary pageName="Logs">
+      <Logs />
+    </PageErrorBoundary>
+  );
+}
+
+function NotFoundRoute() {
+  return (
+    <PageErrorBoundary pageName="Not found">
+      <NotFound />
+    </PageErrorBoundary>
+  );
+}
 
 function AppRouter() {
   return (
     <Switch>
-      <Route path="/" component={Dashboard} />
-      <Route path="/prs" component={PRs} />
-      <Route path="/settings" component={Settings} />
-      <Route path="/releases" component={Releases} />
-      <Route path="/issues" component={Issues} />
-      <Route path="/logs" component={Logs} />
-      <Route component={NotFound} />
+      <Route path="/" component={DashboardRoute} />
+      <Route path="/prs" component={PRsRoute} />
+      <Route path="/settings" component={SettingsRoute} />
+      <Route path="/releases" component={ReleasesRoute} />
+      <Route path="/issues" component={IssuesRoute} />
+      <Route path="/logs" component={LogsRoute} />
+      <Route component={NotFoundRoute} />
     </Switch>
   );
 }

--- a/client/src/components/PageErrorBoundary.tsx
+++ b/client/src/components/PageErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type PageErrorBoundaryProps = {
+  pageName: string;
+  children: ReactNode;
+};
+
+type PageErrorBoundaryState = {
+  hasError: boolean;
+  message: string;
+};
+
+export class PageErrorBoundary extends Component<PageErrorBoundaryProps, PageErrorBoundaryState> {
+  state: PageErrorBoundaryState = {
+    hasError: false,
+    message: "",
+  };
+
+  static getDerivedStateFromError(error: unknown): PageErrorBoundaryState {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Page runtime error", {
+      pageName: this.props.pageName,
+      error,
+      componentStack: info.componentStack,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background p-6">
+          <div className="w-full max-w-2xl border border-destructive/40 bg-destructive/10 p-4 text-body text-destructive">
+            <div className="text-label uppercase tracking-wider text-destructive/80">Page runtime error</div>
+            <div className="mt-2 text-title text-foreground">{this.props.pageName}</div>
+            <pre className="mt-3 whitespace-pre-wrap break-words text-body">{this.state.message || "Unknown render error"}</pre>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-4 rounded-md border border-destructive/50 px-3 py-1 text-label font-medium uppercase tracking-wider text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -261,13 +261,17 @@ test("full app QA route matrix is wired through the hash router", async () => {
 
   assertHasExpression(sourceFile, "hash router", /\buseHashLocation\b/);
   assertHasRoutes(sourceFile, [
-    { label: "dashboard", path: "/", component: "Dashboard" },
-    { label: "settings", path: "/settings", component: "Settings" },
-    { label: "releases", path: "/releases", component: "Releases" },
-    { label: "issues", path: "/issues", component: "Issues" },
-    { label: "logs", path: "/logs", component: "Logs" },
-    { label: "not found fallback", component: "NotFound" },
+    { label: "dashboard", path: "/", component: "DashboardRoute" },
+    { label: "PRs", path: "/prs", component: "PRsRoute" },
+    { label: "settings", path: "/settings", component: "SettingsRoute" },
+    { label: "releases", path: "/releases", component: "ReleasesRoute" },
+    { label: "issues", path: "/issues", component: "IssuesRoute" },
+    { label: "logs", path: "/logs", component: "LogsRoute" },
+    { label: "not found fallback", component: "NotFoundRoute" },
   ]);
+  assertHasExpression(sourceFile, "route runtime crash containment", /<PageErrorBoundary\s+pageName="Pull requests">[\s\S]*<PRs\s*\/>[\s\S]*<\/PageErrorBoundary>/);
+  assertHasExpression(sourceFile, "issues runtime crash containment", /<PageErrorBoundary\s+pageName="Issues">[\s\S]*<Issues\s*\/>[\s\S]*<\/PageErrorBoundary>/);
+  assertHasExpression(sourceFile, "not found runtime crash containment", /<PageErrorBoundary\s+pageName="Not found">[\s\S]*<NotFound\s*\/>[\s\S]*<\/PageErrorBoundary>/);
   assertHasExpression(notFoundSourceFile, "shared header", /<AppHeader\s+active="dashboard"/);
   assertHasStringValue(notFoundSourceFile, "not found panel test id", "not-found-panel");
 });

--- a/client/src/pages/issues.tsx
+++ b/client/src/pages/issues.tsx
@@ -1,4 +1,4 @@
-import { Component, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { AlertTriangle, CheckCircle2, CircleDashed, CircleSlash, ExternalLink, Loader2, PanelRightClose, PanelRightOpen, Plus, RefreshCw, ShieldCheck, Trash2, Wrench, X } from "lucide-react";
 import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
@@ -730,40 +730,6 @@ function IssueLogPanel({
       </div>
     </div>
   );
-}
-
-type IssuesErrorBoundaryState = {
-  hasError: boolean;
-  message: string;
-};
-
-class IssuesErrorBoundary extends Component<{ children: ReactNode }, IssuesErrorBoundaryState> {
-  state: IssuesErrorBoundaryState = {
-    hasError: false,
-    message: "",
-  };
-
-  static getDerivedStateFromError(error: unknown): IssuesErrorBoundaryState {
-    return {
-      hasError: true,
-      message: error instanceof Error ? error.message : String(error),
-    };
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="flex min-h-screen items-center justify-center bg-background p-6">
-          <div className="max-w-2xl border border-destructive/40 bg-destructive/10 p-4 text-body text-destructive">
-            <div className="text-label uppercase tracking-wider text-destructive/80">Issues UI runtime error</div>
-            <pre className="mt-2 whitespace-pre-wrap break-words">{this.state.message || "Unknown render error"}</pre>
-          </div>
-        </div>
-      );
-    }
-
-    return this.props.children;
-  }
 }
 
 function IssuesPage() {
@@ -2171,9 +2137,5 @@ function IssuesPage() {
 }
 
 export default function Issues() {
-  return (
-    <IssuesErrorBoundary>
-      <IssuesPage />
-    </IssuesErrorBoundary>
-  );
+  return <IssuesPage />;
 }


### PR DESCRIPTION
## Summary
- add a shared page error boundary around each app route so render crashes show a visible recovery panel instead of blacking out the app
- move the existing Issues-only boundary into the shared route policy
- pin the route QA test to require crash containment for PRs, Issues, and Not Found routes

## Verification
- npm run check
- node --import tsx --test client/src/lib/fullAppQaSurface.test.ts client/src/lib/prWorkContractView.test.ts
- npx eslint client/src/App.tsx client/src/components/PageErrorBoundary.tsx client/src/pages/issues.tsx client/src/lib/fullAppQaSurface.test.ts
- node --import tsx --test --test-name-pattern "syncAndBabysitTrackedRepos times out authenticated login lookup and cools down" server/babysitter.test.ts

## Notes
- npm run test:all passed 744/745 and hit one server babysitter timing assertion; rerunning that exact test passed.