### PR TITLE
feat: enrich PR question context

### DIFF
--- a/docs/public/pr-questions.md
+++ b/docs/public/pr-questions.md
@@ -28,9 +28,10 @@ When answering a question, the agent receives:
 - PR metadata such as title, number, repository, branch, author, URL, status, and last check time.
 - Current test/lint pass/fail fields when known.
 - Feedback items stored on the PR, including status, decision, author, file, line, and a body excerpt.
+- Changed files, bounded patch excerpts, and recent commit summaries fetched from GitHub when authentication is available.
 - The most recent 50 activity log entries for the PR.
 
-The Q&A agent does not fetch the full diff, commit history, external docs, or issue trackers unless that information is already present in the stored PR context or logs.
+The Q&A agent does not fetch external documentation or issue trackers unless that information is already present in the stored PR context or logs. Very large diffs are bounded before they are sent to the agent.
 
 ## Use Cases
 

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -58,7 +58,7 @@ test("answer_pr_question handler delegates for non-terminal questions", async ()
     `answer_pr_question:${question.id}`,
     { prId },
   );
-  const calls: Array<{ prId: string; questionId: string; question: string; preferredAgent: string }> = [];
+  const calls: Array<{ prId: string; questionId: string; question: string; preferredAgent: string; changedFiles?: string }> = [];
 
   const handlers = createBackgroundJobHandlers({
     storage,
@@ -68,7 +68,29 @@ test("answer_pr_question handler delegates for non-terminal questions", async ()
         questionId: params.questionId,
         question: params.question,
         preferredAgent: params.preferredAgent,
+        changedFiles: params.repositoryContext?.changedFiles,
       });
+    },
+    deps: {
+      resolveGitHubAuthTokenFn: async () => "token",
+      buildOctokitFn: () => ({
+        pulls: {
+          listFiles: async () => ({
+            data: [
+              { filename: "src/widget.ts", status: "modified", additions: 10, deletions: 2, changes: 12, patch: "@@ -1 +1 @@\n-old\n+new" },
+            ],
+          }),
+          listCommits: async () => ({
+            data: [
+              {
+                sha: "abcdef123456",
+                commit: { message: "feat: add widget\n\nbody", author: { name: "Alice" } },
+                author: { login: "alice" },
+              },
+            ],
+          }),
+        },
+      }) as never,
     },
   });
 
@@ -80,6 +102,7 @@ test("answer_pr_question handler delegates for non-terminal questions", async ()
     questionId: question.id,
     question: "What changed?",
     preferredAgent: "claude",
+    changedFiles: "- src/widget.ts (modified, +10/-2, 12 changes)\n@@ -1 +1 @@\n-old\n+new",
   });
 });
 

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -22,7 +22,7 @@ import { buildIssueReplyBody, buildIssueVerifyComment, buildIssueWorkStatusComme
 import { decomposeIssueBody, hashIssueBody } from "./issueDecompose";
 import { verifySubtasksAgainstPr } from "./issueVerify";
 import { runIssueWorkRepair } from "./issueWorkAgent";
-import { answerPRQuestion } from "./prQuestionAgent";
+import { answerPRQuestion, type PRQuestionRepositoryContext } from "./prQuestionAgent";
 import { getRateLimitState } from "./rateLimitState";
 import type { ReleaseManager } from "./releaseManager";
 import { runWithRequestPriority } from "./requestPriority";
@@ -111,6 +111,60 @@ export function createBackgroundJobHandlers(params: {
   const runIssueWorkRepairFn = params.deps?.runIssueWorkRepairFn ?? runIssueWorkRepair;
   const resolveGitHubAuthTokenFn = params.deps?.resolveGitHubAuthTokenFn ?? resolveGitHubAuthToken;
   const runDeploymentHealingRepairFn = params.deps?.runDeploymentHealingRepairFn ?? runDeploymentHealingRepair;
+
+  async function buildQuestionRepositoryContext(prUrl: string): Promise<PRQuestionRepositoryContext | null> {
+    const parsed = parsePRUrl(prUrl);
+    if (!parsed) return null;
+
+    try {
+      const octokit = await buildOctokitFn(await storage.getConfig());
+      const [filesResponse, commitsResponse] = await Promise.all([
+        octokit.pulls.listFiles({
+          owner: parsed.owner,
+          repo: parsed.repo,
+          pull_number: parsed.number,
+          per_page: 100,
+        }),
+        octokit.pulls.listCommits({
+          owner: parsed.owner,
+          repo: parsed.repo,
+          pull_number: parsed.number,
+          per_page: 30,
+        }),
+      ]);
+
+      const changedFiles = filesResponse.data.map((file) => {
+        const patch = typeof file.patch === "string" && file.patch.trim()
+          ? `\n${file.patch.split("\n").slice(0, 80).join("\n")}`
+          : "";
+        return [
+          `- ${file.filename} (${file.status}, +${file.additions}/-${file.deletions}, ${file.changes} changes)`,
+          patch,
+        ].join("");
+      }).join("\n\n");
+
+      const commits = commitsResponse.data.map((commit) => {
+        const message = commit.commit.message.split("\n")[0] ?? "";
+        const author = commit.commit.author?.name ?? commit.author?.login ?? "unknown";
+        return `- ${commit.sha.slice(0, 7)} ${message} (${author})`;
+      }).join("\n");
+
+      return {
+        changedFiles,
+        commits,
+        note: filesResponse.data.length >= 100
+          ? "Only the first 100 changed files were included."
+          : undefined,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        changedFiles: "(unavailable)",
+        commits: "(unavailable)",
+        note: `Could not fetch live GitHub change context: ${message.slice(0, 300)}`,
+      };
+    }
+  }
 
   async function postIssueWorkStatusComment(
     octokit: {
@@ -661,6 +715,7 @@ export function createBackgroundJobHandlers(params: {
         question: question.question,
         preferredAgent: resolveRepoCodingAgent(config, repoSettings),
         agentSettings: resolveRepoAgentRuntimeSettings(config, repoSettings),
+        repositoryContext: pr ? await buildQuestionRepositoryContext(pr.url) : null,
       });
     },
 

--- a/server/prQuestionAgent.test.ts
+++ b/server/prQuestionAgent.test.ts
@@ -58,6 +58,35 @@ async function withFakeAgent(
   }
 }
 
+async function withCapturingFakeAgent(
+  run: (promptPath: string) => Promise<void>,
+): Promise<void> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), "fake-agent-bin-"));
+  const promptPath = path.join(tempRoot, "prompt.txt");
+  const fakeClaudePath = path.join(tempRoot, "claude");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(
+      fakeClaudePath,
+      [
+        "#!/usr/bin/env node",
+        "const fs = require('node:fs');",
+        `fs.writeFileSync(${JSON.stringify(promptPath)}, process.argv[process.argv.length - 1] || '', 'utf8');`,
+        "process.stdout.write('Answer from captured context');",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeClaudePath, 0o755);
+    process.env.PATH = [tempRoot, originalPath].filter(Boolean).join(path.delimiter);
+    await run(promptPath);
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
 describe("answerPRQuestion", () => {
   it("sets status to 'error' when the PR does not exist", async () => {
     const storage = new MemStorage();
@@ -270,6 +299,31 @@ describe("answerPRQuestion", () => {
       assert.equal(updated.status, "error");
       assert.match(updated.error ?? "", /empty response/i);
       assert.equal(updated.answer, null);
+    });
+  });
+
+  it("includes bounded repository change context in the agent prompt", async () => {
+    await withCapturingFakeAgent(async (promptPath) => {
+      const storage = new MemStorage();
+      const prId = await seedPR(storage);
+      const q = await storage.addQuestion(prId, "What changed?");
+
+      await answerPRQuestion({
+        storage,
+        prId,
+        questionId: q.id,
+        question: q.question,
+        preferredAgent: "claude",
+        repositoryContext: {
+          changedFiles: "- src/widget.ts (modified, +10/-2, 12 changes)\n@@ -1 +1 @@\n-old\n+new",
+          commits: "- abcdef1 feat: add widget (Alice)",
+        },
+      });
+
+      const prompt = await import("node:fs/promises").then((fs) => fs.readFile(promptPath, "utf8"));
+      assert.match(prompt, /## Repository Change Context/);
+      assert.match(prompt, /src\/widget\.ts/);
+      assert.match(prompt, /abcdef1 feat: add widget/);
     });
   });
 });

--- a/server/prQuestionAgent.ts
+++ b/server/prQuestionAgent.ts
@@ -13,13 +13,14 @@ export async function answerPRQuestion(params: {
   question: string;
   preferredAgent: CodingAgent;
   agentSettings?: AgentRuntimeSettings;
+  repositoryContext?: PRQuestionRepositoryContext | null;
 }): Promise<void> {
-  const { storage, prId, questionId, question, preferredAgent, agentSettings } = params;
+  const { storage, prId, questionId, question, preferredAgent, agentSettings, repositoryContext } = params;
 
   await storage.updateQuestion(questionId, { status: "answering" });
 
   try {
-    const context = await buildPRContext(storage, prId);
+    const context = await buildPRContext(storage, prId, repositoryContext ?? null);
     const agent = await resolveAgent(preferredAgent);
     const prompt = buildPrompt(context, question);
 
@@ -77,9 +78,25 @@ type PRContext = {
   lastChecked: string | null;
   feedbackSummary: string;
   recentLogs: string;
+  repositoryContext: string;
 };
 
-async function buildPRContext(storage: IStorage, prId: string): Promise<PRContext> {
+export type PRQuestionRepositoryContext = {
+  changedFiles: string;
+  commits: string;
+  note?: string;
+};
+
+function truncateForPrompt(value: string, maxLength: number) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 25).trimEnd()}\n[truncated for context]`;
+}
+
+async function buildPRContext(
+  storage: IStorage,
+  prId: string,
+  repositoryContext: PRQuestionRepositoryContext | null,
+): Promise<PRContext> {
   const pr = await storage.getPR(prId);
   if (!pr) throw new Error("PR not found");
 
@@ -113,6 +130,16 @@ async function buildPRContext(storage: IStorage, prId: string): Promise<PRContex
     lastChecked: pr.lastChecked,
     feedbackSummary: feedbackLines.length > 0 ? feedbackLines.join("\n") : "(no feedback items)",
     recentLogs: recentLogs || "(no recent activity)",
+    repositoryContext: repositoryContext
+      ? [
+        repositoryContext.note ? `Note: ${repositoryContext.note}` : "",
+        "Changed files and patch excerpts:",
+        truncateForPrompt(repositoryContext.changedFiles || "(no changed files available)", 12000),
+        "",
+        "Recent commits:",
+        truncateForPrompt(repositoryContext.commits || "(no commit context available)", 4000),
+      ].filter(Boolean).join("\n")
+      : "(repository diff and commit context unavailable)",
   };
 }
 
@@ -135,6 +162,9 @@ function buildPrompt(ctx: PRContext, question: string): string {
     "",
     "## Feedback Items",
     ctx.feedbackSummary,
+    "",
+    "## Repository Change Context",
+    ctx.repositoryContext,
     "",
     "## Recent Activity Logs (most recent 50 entries)",
     ctx.recentLogs,


### PR DESCRIPTION
## Summary
- include bounded GitHub changed-file and commit context in PR Q&A prompts
- keep Q&A resilient when live GitHub context cannot be fetched
- update PR Q&A docs and regression coverage

## Verification
- npm run check
- npm run test:all