### PR TITLE
feat: show deployment healing sessions

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import Dashboard from "@/pages/dashboard";
 import PRs from "@/pages/prs";
 import Settings from "@/pages/settings";
 import Releases from "@/pages/releases";
+import Deployments from "@/pages/deployments";
 import Issues from "@/pages/issues";
 import Logs from "@/pages/logs";
 import NotFound from "@/pages/not-found";
@@ -47,6 +48,14 @@ function ReleasesRoute() {
   );
 }
 
+function DeploymentsRoute() {
+  return (
+    <PageErrorBoundary pageName="Deployments">
+      <Deployments />
+    </PageErrorBoundary>
+  );
+}
+
 function IssuesRoute() {
   return (
     <PageErrorBoundary pageName="Issues">
@@ -78,6 +87,7 @@ function AppRouter() {
       <Route path="/prs" component={PRsRoute} />
       <Route path="/settings" component={SettingsRoute} />
       <Route path="/releases" component={ReleasesRoute} />
+      <Route path="/deployments" component={DeploymentsRoute} />
       <Route path="/issues" component={IssuesRoute} />
       <Route path="/logs" component={LogsRoute} />
       <Route component={NotFoundRoute} />

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -10,7 +10,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { toast } from "@/hooks/use-toast";
 import { ACTIVITY_POLL_INTERVAL_MS, getUiPollIntervalMs } from "@/lib/polling";
 
-type AppHeaderSection = "dashboard" | "prs" | "issues" | "releases" | "logs" | "settings";
+type AppHeaderSection = "dashboard" | "prs" | "issues" | "releases" | "deployments" | "logs" | "settings";
 type GitHubRateLimitState = {
   limited: boolean;
   resetAt: string | null;
@@ -38,6 +38,7 @@ const PRIMARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href:
   { section: "issues", label: "Issues", href: "/issues" },
   { section: "prs", label: "PRs", href: "/prs" },
   { section: "releases", label: "Releases", href: "/releases" },
+  { section: "deployments", label: "Deployments", href: "/deployments" },
 ];
 
 const SECONDARY_NAV_ITEMS: Array<{ section: AppHeaderSection; label: string; href: string }> = [

--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -265,12 +265,14 @@ test("full app QA route matrix is wired through the hash router", async () => {
     { label: "PRs", path: "/prs", component: "PRsRoute" },
     { label: "settings", path: "/settings", component: "SettingsRoute" },
     { label: "releases", path: "/releases", component: "ReleasesRoute" },
+    { label: "deployments", path: "/deployments", component: "DeploymentsRoute" },
     { label: "issues", path: "/issues", component: "IssuesRoute" },
     { label: "logs", path: "/logs", component: "LogsRoute" },
     { label: "not found fallback", component: "NotFoundRoute" },
   ]);
   assertHasExpression(sourceFile, "route runtime crash containment", /<PageErrorBoundary\s+pageName="Pull requests">[\s\S]*<PRs\s*\/>[\s\S]*<\/PageErrorBoundary>/);
   assertHasExpression(sourceFile, "issues runtime crash containment", /<PageErrorBoundary\s+pageName="Issues">[\s\S]*<Issues\s*\/>[\s\S]*<\/PageErrorBoundary>/);
+  assertHasExpression(sourceFile, "deployments runtime crash containment", /<PageErrorBoundary\s+pageName="Deployments">[\s\S]*<Deployments\s*\/>[\s\S]*<\/PageErrorBoundary>/);
   assertHasExpression(sourceFile, "not found runtime crash containment", /<PageErrorBoundary\s+pageName="Not found">[\s\S]*<NotFound\s*\/>[\s\S]*<\/PageErrorBoundary>/);
   assertHasExpression(notFoundSourceFile, "shared header", /<AppHeader\s+active="dashboard"/);
   assertHasStringValue(notFoundSourceFile, "not found panel test id", "not-found-panel");
@@ -557,6 +559,21 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
   ]);
   assertHasExpression(releases.sourceFile, "github releases cache window", /staleTime:\s*5\s*\*\s*60\s*\*\s*1000/);
   assertHasExpression(releases.sourceFile, "github releases sync guard", /disabled=\{isFetchingGitHub \|\| runtimeState === undefined\}/);
+});
+
+test("deployments route keeps deployment healing visibility wired", async () => {
+  const { sourceFile } = await parseProjectFile("client/src/pages/deployments.tsx");
+  const { sourceFile: settingsSourceFile } = await parseProjectFile("client/src/pages/settings.tsx");
+  const { sourceFile: headerSourceFile } = await parseProjectFile("client/src/components/AppHeader.tsx");
+
+  assertHasQueryKey(sourceFile, "deployment healing sessions query", "/api/deployment-healing-sessions");
+  assertHasTestId(sourceFile, "deployment session card", "deployment-healing-session-card");
+  assertHasTestId(sourceFile, "deployment empty state", "deployment-healing-empty-state");
+  assertHasStringValue(sourceFile, "follow-up PR label", "Follow-up PR");
+  assertHasExpression(sourceFile, "deployment log field", /\bdeploymentLog\b/);
+  assertHasStringValue(settingsSourceFile, "deployment healing toggle", "Automatic deployment healing");
+  assertHasExpression(settingsSourceFile, "deployment healing config key", /\bautoHealDeployments\b/);
+  assertHasStringValue(headerSourceFile, "deployments nav item", "/deployments");
 });
 
 test("onboarding panel keeps the QA-tested GitHub setup poll and install actions wired", async () => {

--- a/client/src/pages/deployments.tsx
+++ b/client/src/pages/deployments.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { DeploymentHealingSession, DeploymentHealingState } from "@shared/schema";
+import { AppHeader } from "@/components/AppHeader";
+import { UpdateBanner } from "@/components/UpdateBanner";
+
+const ACTIVE_STATES = new Set<DeploymentHealingState>(["monitoring", "failed", "fixing"]);
+
+function formatDateTime(value: string | null) {
+  if (!value) return "never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function stateClassName(state: DeploymentHealingState) {
+  switch (state) {
+    case "fix_submitted":
+      return "border-success-border bg-success-muted text-success-foreground";
+    case "escalated":
+      return "border-destructive/40 bg-destructive/10 text-destructive";
+    case "failed":
+      return "border-warning-border bg-warning-muted text-warning-foreground";
+    case "fixing":
+      return "border-primary/40 bg-primary/10 text-primary";
+    case "monitoring":
+    default:
+      return "border-border bg-muted/30 text-muted-foreground";
+  }
+}
+
+function DeploymentSessionCard({ session }: { session: DeploymentHealingSession }) {
+  return (
+    <article className="rounded-md border border-border bg-background/60 p-4" data-testid="deployment-healing-session-card">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-body text-foreground">{session.repo}</span>
+            <span className="rounded-md border border-border px-1.5 py-0.5 text-label uppercase tracking-wider text-muted-foreground">
+              {session.platform}
+            </span>
+            <span className={`rounded-md border px-1.5 py-0.5 text-label uppercase tracking-wider ${stateClassName(session.state)}`}>
+              {session.state.replace("_", " ")}
+            </span>
+          </div>
+          <a
+            href={session.triggerPrUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 block truncate text-title font-medium text-foreground hover:text-primary"
+          >
+            #{session.triggerPrNumber} {session.triggerPrTitle}
+          </a>
+        </div>
+        <div className="text-right font-mono text-label text-muted-foreground">
+          <div>updated {formatDateTime(session.updatedAt)}</div>
+          <div>created {formatDateTime(session.createdAt)}</div>
+        </div>
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-body sm:grid-cols-2 lg:grid-cols-4">
+        <div>
+          <dt className="text-label uppercase tracking-wider text-muted-foreground">Deployment</dt>
+          <dd className="mt-1 font-mono text-foreground">{session.deploymentId ?? "not captured"}</dd>
+        </div>
+        <div>
+          <dt className="text-label uppercase tracking-wider text-muted-foreground">Merge SHA</dt>
+          <dd className="mt-1 truncate font-mono text-foreground" title={session.mergeSha}>{session.mergeSha}</dd>
+        </div>
+        <div>
+          <dt className="text-label uppercase tracking-wider text-muted-foreground">Fix branch</dt>
+          <dd className="mt-1 truncate font-mono text-foreground">{session.fixBranch ?? "none"}</dd>
+        </div>
+        <div>
+          <dt className="text-label uppercase tracking-wider text-muted-foreground">Follow-up PR</dt>
+          <dd className="mt-1">
+            {session.fixPrUrl ? (
+              <a href={session.fixPrUrl} target="_blank" rel="noreferrer" className="font-mono text-primary hover:underline">
+                #{session.fixPrNumber}
+              </a>
+            ) : (
+              <span className="text-muted-foreground">none</span>
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      {session.error && (
+        <div className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-body text-destructive">
+          {session.error}
+        </div>
+      )}
+
+      {session.deploymentLog && (
+        <pre className="mt-4 max-h-48 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-label text-muted-foreground">
+          {session.deploymentLog}
+        </pre>
+      )}
+    </article>
+  );
+}
+
+export default function Deployments() {
+  const { data: sessions = [], isLoading } = useQuery<DeploymentHealingSession[]>({
+    queryKey: ["/api/deployment-healing-sessions"],
+    refetchInterval: 5000,
+  });
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+
+  const repoList = useMemo(() => {
+    return Array.from(new Set(sessions.map((session) => session.repo))).sort((a, b) => a.localeCompare(b));
+  }, [sessions]);
+
+  const filteredSessions = useMemo(() => {
+    const visible = selectedRepo ? sessions.filter((session) => session.repo === selectedRepo) : sessions;
+    return [...visible].sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+  }, [selectedRepo, sessions]);
+
+  const activeCount = sessions.filter((session) => ACTIVE_STATES.has(session.state)).length;
+
+  return (
+    <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
+      <UpdateBanner />
+      <AppHeader
+        active="deployments"
+        status={sessions.length > 0 ? (
+          <span>
+            <span className="font-mono text-foreground">{activeCount}</span> active / <span className="font-mono text-foreground">{sessions.length}</span> total
+          </span>
+        ) : null}
+      />
+
+      <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
+        <aside className="flex max-h-[42vh] w-full shrink-0 flex-col overflow-hidden border-b border-border lg:max-h-none lg:w-72 lg:border-b-0 lg:border-r">
+          <div className="border-b border-border px-4 py-2 text-label font-medium uppercase tracking-wider text-muted-foreground">
+            Deployment sessions
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            <button
+              type="button"
+              onClick={() => setSelectedRepo(null)}
+              className={`flex w-full items-center justify-between border-b border-border px-4 py-3 text-left text-body ${selectedRepo === null ? "bg-muted/30 text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+            >
+              <span>All repositories</span>
+              <span className="font-mono text-label">{sessions.length}</span>
+            </button>
+            {repoList.map((repo) => (
+              <button
+                key={repo}
+                type="button"
+                onClick={() => setSelectedRepo(repo)}
+                className={`flex w-full items-center justify-between border-b border-border px-4 py-3 text-left text-body ${selectedRepo === repo ? "bg-muted/30 text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+              >
+                <span className="truncate font-mono">{repo}</span>
+                <span className="font-mono text-label">{sessions.filter((session) => session.repo === repo).length}</span>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <main className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6">
+          <div className="mb-4 flex flex-wrap items-baseline justify-between gap-3">
+            <h2 className="text-title font-semibold tracking-tight">
+              {selectedRepo ?? "All deployment healing"}
+            </h2>
+            <span className="font-mono text-label text-muted-foreground">
+              {filteredSessions.length} session{filteredSessions.length === 1 ? "" : "s"}
+            </span>
+          </div>
+
+          {isLoading && sessions.length === 0 ? (
+            <div className="rounded-md border border-border px-4 py-8 text-center text-body text-muted-foreground">Loading deployment sessions…</div>
+          ) : filteredSessions.length === 0 ? (
+            <div className="rounded-md border border-border px-4 py-8 text-center" data-testid="deployment-healing-empty-state">
+              <p className="text-body text-muted-foreground">No deployment healing sessions yet.</p>
+              <p className="mt-1 text-body text-muted-foreground">
+                Sessions appear after merged PRs are monitored for supported deployment failures.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {filteredSessions.map((session) => (
+                <DeploymentSessionCard key={session.id} session={session} />
+              ))}
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1384,6 +1384,26 @@ export default function Settings() {
                 defaultValue={DEFAULT_SETTING_VALUES.healingCooldownSeconds}
                 disabled={updateConfigMutation.isPending}
               />
+              <label className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-body">Automatic deployment healing</div>
+                  <div className="text-label text-muted-foreground">
+                    Monitor supported post-merge deployments and open follow-up fix PRs when they fail.
+                  </div>
+                </div>
+                <input
+                  type="checkbox"
+                  aria-label="Automatic deployment healing"
+                  checked={config?.autoHealDeployments ?? false}
+                  onChange={(e) =>
+                    updateConfigMutation.mutate({
+                      autoHealDeployments: e.target.checked,
+                    })
+                  }
+                  disabled={updateConfigMutation.isPending}
+                  className="h-4 w-4 accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                />
+              </label>
               <SettingRow
                 label="Deployment check delay (seconds)"
                 description="Wait before checking a freshly produced deployment"

--- a/docs/public/configuration.md
+++ b/docs/public/configuration.md
@@ -71,7 +71,7 @@ The settings page in the dashboard provides a UI for:
 - **GitHub progress replies** — Toggle whether the babysitter posts public Accepted/running/completed status replies while working through review comments.
 - **Babysitter run concurrency** — Set how many `babysit_pr` jobs can be in-flight (`queued` + `leased`) across watcher sweeps.
 - **CI healing** — Enable autonomous CI repair and tune retry/session limits.
-- **Deployment healing** — Not yet exposed in the dashboard; use `PATCH /api/config` for the deployment-healing keys listed below.
+- **Deployment healing** — Enable post-merge deployment monitoring and tune the deployment-healing timing keys listed below.
 - **Theme** — Toggle between light and dark mode.
 
 ### Agent Health and Drain Mode
@@ -186,7 +186,7 @@ Deployment healing also requires the matching platform CLI on the machine runnin
 - Install and authenticate `vercel` to heal Vercel deployments.
 - Install and authenticate `railway` to heal Railway deployments.
 
-Deployment session history is exposed through `GET /api/deployment-healing-sessions`, `GET /api/deployment-healing-sessions/:id`, and the matching MCP read tools. The dashboard settings page and MCP `update_config` tool do not yet expose these deployment-healing knobs; use `PATCH /api/config` for them.
+Deployment session history is exposed on the dashboard Deployments page, through `GET /api/deployment-healing-sessions`, `GET /api/deployment-healing-sessions/:id`, and the matching MCP read tools.
 
 ## Build & Deploy
 

--- a/docs/public/pr-babysitter.md
+++ b/docs/public/pr-babysitter.md
@@ -79,7 +79,7 @@ For a detected platform, the deployment-healing flow is:
 4. Run the configured coding agent from the merge SHA, push a `deploy-fix/<platform>-<timestamp>` branch, and open a follow-up PR back to the merged base branch.
 5. Mark the session as `fix_submitted` on success or `escalated` when monitoring times out or the repair attempt cannot be completed automatically.
 
-Deployment-healing sessions move through `monitoring`, `failed`, `fixing`, `fix_submitted`, and `escalated`. Operator visibility is currently API- and MCP-based via `GET /api/deployment-healing-sessions`, `GET /api/deployment-healing-sessions/:id`, `list_deployment_healing_sessions`, and `get_deployment_healing_session`; there is no dedicated dashboard panel yet.
+Deployment-healing sessions move through `monitoring`, `failed`, `fixing`, `fix_submitted`, and `escalated`. Operator visibility is available on the dashboard Deployments page, through `GET /api/deployment-healing-sessions` and `GET /api/deployment-healing-sessions/:id`, and through the MCP `list_deployment_healing_sessions` and `get_deployment_healing_session` tools.
 
 Deployment healing requires the matching platform CLI to be installed and authenticated on the same machine as patchdeck:
 


### PR DESCRIPTION
## Summary
- add a Deployments dashboard page for deployment-healing sessions
- expose the automatic deployment-healing toggle in Settings
- refresh docs and QA surface coverage

## Verification
- npm run check
- npm run test:all