### PR TITLE
feat: preview release readiness

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -543,6 +543,7 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
   const releases = await parseProjectFile("client/src/pages/releases.tsx");
 
   assertHasQueryKey(releases.sourceFile, "release route query", "/api/releases");
+  assertHasQueryKey(releases.sourceFile, "release preview query", "/api/repos/release-preview");
   assertHasQueryKey(releases.sourceFile, "github releases query", "/api/github-releases");
   assertHasQueryKey(releases.sourceFile, "runtime query", "/api/runtime");
   assertHasApiRequest(releases.sourceFile, "release retry mutation", "POST", /`\/api\/releases\/\$\{id\}\/retry`/);
@@ -552,10 +553,12 @@ test("releases route keeps the QA-tested list, expand, copy, retry, and GitHub l
     ["github link button", "Open on GitHub"],
     ["sync github button tooltip", "Sync from GitHub"],
     ["orphan section header", "Published outside the pipeline"],
+    ["release readiness preview", "Release preview"],
     ["empty release state", "No release activity yet."],
     ["watched repositories sidebar", "Watched repositories"],
   ]);
   assertHasExpression(releases.sourceFile, "github releases cache window", /staleTime:\s*5\s*\*\s*60\s*\*\s*1000/);
+  assertHasTestId(releases.sourceFile, "release readiness preview panel", "release-readiness-preview");
   assertHasExpression(releases.sourceFile, "github releases sync guard", /disabled=\{isFetchingGitHub \|\| runtimeState === undefined\}/);
 });
 

--- a/client/src/pages/releases.tsx
+++ b/client/src/pages/releases.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ExternalLink, Loader2, RefreshCw } from "lucide-react";
-import { apiRequest, queryClient } from "@/lib/queryClient";
+import { apiRequest, fetchJson, queryClient } from "@/lib/queryClient";
 import { AppHeader } from "@/components/AppHeader";
 import { GitHubReleaseCard } from "@/components/GitHubReleaseCard";
 import { SocialPostGenerator } from "@/components/SocialPostGenerator";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { toast } from "@/hooks/use-toast";
-import type { GitHubRelease, ReleaseRun, RepoGitHubReleases, RuntimeState } from "@shared/schema";
+import type { GitHubRelease, ReleasePreview, ReleaseRun, RepoGitHubReleases, RuntimeState } from "@shared/schema";
 
 type ReleaseRunStatus = ReleaseRun["status"];
 
@@ -84,6 +84,87 @@ function CopyButton({ text }: { text: string }) {
     >
       {copied ? "copied" : "copy"}
     </button>
+  );
+}
+
+function ReleasePreviewPanel({
+  preview,
+  loading,
+}: {
+  preview?: ReleasePreview;
+  loading: boolean;
+}) {
+  if (loading && !preview) {
+    return (
+      <div className="mb-4 rounded-md border border-border px-4 py-3 text-body text-muted-foreground">
+        Loading release preview…
+      </div>
+    );
+  }
+
+  if (!preview) return null;
+
+  if (preview.state === "empty") {
+    return (
+      <div className="mb-4 rounded-md border border-border px-4 py-3" data-testid="release-readiness-preview">
+        <div className="text-label font-medium uppercase tracking-wider text-muted-foreground">Release preview</div>
+        <div className="mt-1 text-body text-muted-foreground">
+          No unreleased merged pull requests found for <span className="font-mono text-foreground">{preview.repo}</span>.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="mb-4 rounded-md border border-border px-4 py-3" data-testid="release-readiness-preview">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-label font-medium uppercase tracking-wider text-muted-foreground">Release preview</div>
+          <a
+            href={preview.triggerPr?.url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-1 block text-body font-medium text-foreground hover:text-primary"
+          >
+            Next trigger: #{preview.triggerPr?.number} {preview.triggerPr?.title}
+          </a>
+        </div>
+        <div className="text-right font-mono text-label text-muted-foreground">
+          <div>base {preview.baseBranch}</div>
+          <div>latest {preview.latestTag ?? "none"}</div>
+        </div>
+      </div>
+
+      {preview.candidateVersions && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {(["patch", "minor", "major"] as const).map((bump) => (
+            <span key={bump} className="rounded-md border border-border px-2 py-1 text-label uppercase tracking-wider text-muted-foreground">
+              {bump} <span className="font-mono text-foreground">{preview.candidateVersions?.[bump]}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 grid gap-1 text-label">
+        <div className="text-label uppercase tracking-wider text-muted-foreground">
+          Included PRs <span className="font-mono text-foreground">{preview.includedPrs.length}</span>
+        </div>
+        {preview.includedPrs.slice(0, 6).map((pr) => (
+          <a key={`${pr.number}-${pr.mergeSha}`} href={pr.url} target="_blank" rel="noreferrer" className="truncate text-muted-foreground hover:text-foreground">
+            <span className="font-mono">#{pr.number}</span> {pr.title}
+          </a>
+        ))}
+        {preview.includedPrs.length > 6 && (
+          <div className="text-muted-foreground">+{preview.includedPrs.length - 6} more included PRs</div>
+        )}
+      </div>
+
+      <div className="mt-3 text-label text-muted-foreground">
+        {preview.existingRunId
+          ? `Existing release run ${preview.existingRunId.slice(0, 8)} is ${preview.existingRunStatus}.`
+          : "Manual release will evaluate this candidate before publishing."}
+      </div>
+    </section>
   );
 }
 
@@ -412,6 +493,12 @@ export default function Releases() {
 
   const selectedRuns = selectedRepo ? runsByRepo.get(selectedRepo) ?? [] : [];
   const selectedOrphans = selectedRepo ? orphansByRepo.get(selectedRepo) ?? [] : [];
+  const { data: releasePreview, isFetching: isFetchingReleasePreview } = useQuery<ReleasePreview>({
+    queryKey: ["/api/repos/release-preview", selectedRepo],
+    enabled: Boolean(selectedRepo) && runtimeState !== undefined,
+    queryFn: async () => fetchJson<ReleasePreview>(`/api/repos/release-preview?repo=${encodeURIComponent(selectedRepo ?? "")}`),
+    staleTime: 5 * 60 * 1000,
+  });
 
   const handleSyncGitHub = () => {
     queryClient.invalidateQueries({ queryKey: ["/api/github-releases"] });
@@ -507,14 +594,16 @@ export default function Releases() {
             </div>
           ) : (
             <div className="p-6">
-              <div className="mb-4 flex items-baseline justify-between">
-                <h2 className="text-title font-semibold tracking-tight">{selectedRepo}</h2>
-                <span className="font-mono text-label text-muted-foreground">
-                  {selectedRuns.length} pipeline · {selectedOrphans.length} external
-                </span>
-              </div>
+	              <div className="mb-4 flex items-baseline justify-between">
+	                <h2 className="text-title font-semibold tracking-tight">{selectedRepo}</h2>
+	                <span className="font-mono text-label text-muted-foreground">
+	                  {selectedRuns.length} pipeline · {selectedOrphans.length} external
+	                </span>
+	              </div>
 
-              {selectedRuns.length === 0 && selectedOrphans.length === 0 ? (
+	              <ReleasePreviewPanel preview={releasePreview} loading={isFetchingReleasePreview} />
+
+	              {selectedRuns.length === 0 && selectedOrphans.length === 0 ? (
                 <div className="rounded-md border border-border px-4 py-8 text-center">
                   <p className="text-body text-muted-foreground">No release activity yet.</p>
                   <p className="mt-1 text-body text-muted-foreground">

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -17,6 +17,7 @@ import type {
   PRSummary,
   PRQuestion,
   ReleaseRun,
+  ReleasePreview,
   ReleaseSocialPost,
   RepoGitHubReleases,
   RuntimeState,
@@ -150,6 +151,7 @@ export type AppRuntime = {
   syncRepos(options?: { fullSweep?: boolean; scope?: RepoSyncScope }): Promise<{ ok: true }>;
   listIssueCoverage(): Promise<IssueCoverage[]>;
   createManualRelease(repoInput: string): Promise<ReleaseRun>;
+  previewManualRelease(repoInput: string): Promise<ReleasePreview>;
   listPRs(view?: "active" | "archived"): Promise<PRSummary[]>;
   getPR(id: string): Promise<PR | null>;
   addPR(url: string): Promise<PR>;
@@ -2415,6 +2417,15 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
 
       notifyChange();
       return release;
+    },
+
+    async previewManualRelease(repoInput) {
+      const parsedRepo = parseRepoSlug(repoInput);
+      if (!parsedRepo) {
+        throw new AppRuntimeError(400, "Invalid repository. Use owner/repo or https://github.com/owner/repo");
+      }
+
+      return releaseManager.previewManualRepoRelease(formatRepoSlug(parsedRepo));
     },
 
     async listIssues(input) {

--- a/server/releaseManager.test.ts
+++ b/server/releaseManager.test.ts
@@ -174,6 +174,83 @@ test("ReleaseManager enqueues a manual repo release from the latest unreleased m
   assert.equal(await manager.waitForIdle(), true);
 });
 
+test("ReleaseManager previews the next manual release candidate without queueing work", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+  const { manager } = createQueuedManager({ storage });
+
+  const preview = await manager.previewManualRepoRelease("jeremymcs/patchdeck");
+  const jobs = await storage.listBackgroundJobs({
+    kind: "process_release_run",
+    status: "queued",
+  });
+
+  assert.equal(preview.state, "ready");
+  assert.equal(preview.repo, "jeremymcs/patchdeck");
+  assert.equal(preview.baseBranch, "main");
+  assert.equal(preview.latestTag, "v1.2.3");
+  assert.equal(preview.triggerPr?.number, 71);
+  assert.equal(preview.includedPrs.length, 2);
+  assert.deepEqual(preview.candidateVersions, {
+    patch: "v1.2.4",
+    minor: "v1.3.0",
+    major: "v2.0.0",
+  });
+  assert.equal(preview.existingRunId, null);
+  assert.equal(jobs.length, 0);
+});
+
+test("ReleaseManager previews empty release state when no merged PRs are unreleased", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+  const { manager } = createQueuedManager({
+    storage,
+    github: {
+      listUnreleasedMergedPulls: async () => [],
+    },
+  });
+
+  const preview = await manager.previewManualRepoRelease("jeremymcs/patchdeck");
+
+  assert.equal(preview.state, "empty");
+  assert.equal(preview.triggerPr, null);
+  assert.deepEqual(preview.includedPrs, []);
+  assert.equal(preview.candidateVersions, null);
+});
+
+test("ReleaseManager preview links an existing release run for the same trigger", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig(makeConfig());
+  const existing = await storage.createReleaseRun({
+    repo: "jeremymcs/patchdeck",
+    baseBranch: "main",
+    triggerPrNumber: 71,
+    triggerPrTitle: "Release automation",
+    triggerPrUrl: "https://github.com/jeremymcs/patchdeck/pull/71",
+    triggerMergeSha: "abc123",
+    triggerMergedAt: "2026-03-28T15:00:00.000Z",
+    source: "manual",
+    status: "published",
+    decisionReason: null,
+    recommendedBump: "patch",
+    proposedVersion: "v1.2.4",
+    releaseTitle: "Release v1.2.4",
+    releaseNotes: "Notes",
+    includedPrs: [],
+    targetSha: "abc123",
+    githubReleaseId: 123,
+    githubReleaseUrl: "https://github.com/jeremymcs/patchdeck/releases/tag/v1.2.4",
+    error: null,
+    completedAt: "2026-03-28T18:00:00.000Z",
+  });
+  const { manager } = createQueuedManager({ storage });
+
+  const preview = await manager.previewManualRepoRelease("jeremymcs/patchdeck");
+
+  assert.equal(preview.existingRunId, existing.id);
+  assert.equal(preview.existingRunStatus, "published");
+});
+
 test("ReleaseManager publishes manual release runs when auto-release settings are disabled", async () => {
   const storage = new MemStorage();
   await storage.updateConfig(makeConfig({

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -1,5 +1,5 @@
 import type { Octokit } from "@octokit/rest";
-import type { Config, ReleaseRun, ReleaseRunIncludedPR } from "@shared/schema";
+import type { Config, ReleasePreview, ReleaseRun, ReleaseRunIncludedPR } from "@shared/schema";
 import type { CodingAgent } from "./agentRunner";
 import { resolveRepoAgentRuntimeSettings, resolveRepoCodingAgent } from "./agentSettings";
 import { parseRepoSlug } from "./github";
@@ -222,6 +222,62 @@ export class ReleaseManager {
 
     this.scheduleProcessing(created);
     return created;
+  }
+
+  async previewManualRepoRelease(repoInput: string): Promise<ReleasePreview> {
+    const parsedRepo = parseRepoSlug(repoInput);
+    if (!parsedRepo) {
+      throw new Error(`Invalid repository slug: ${repoInput}`);
+    }
+
+    const repo = `${parsedRepo.owner}/${parsedRepo.repo}`;
+    const config = await this.storage.getConfig();
+    const octokit = await this.github.buildOctokit(config);
+    const baseBranch = await this.github.getDefaultBranch(octokit, parsedRepo);
+    const latestTag = await this.github.findLatestSemverReleaseTag(octokit, parsedRepo);
+    const unreleased = await this.github.listUnreleasedMergedPulls(octokit, parsedRepo, {
+      baseBranch,
+    });
+    const triggerPr = [...unreleased].sort((a, b) => Date.parse(a.mergedAt) - Date.parse(b.mergedAt)).at(-1);
+
+    if (!triggerPr) {
+      return {
+        repo,
+        baseBranch,
+        latestTag,
+        state: "empty",
+        triggerPr: null,
+        includedPrs: [],
+        candidateVersions: null,
+        existingRunId: null,
+        existingRunStatus: null,
+      };
+    }
+
+    const includedPulls = this.github.listMergedPullsForReleaseCandidate
+      ? await this.github.listMergedPullsForReleaseCandidate(octokit, parsedRepo, {
+        baseBranch,
+        untilMergedAt: triggerPr.mergedAt,
+        triggerPr,
+      })
+      : [triggerPr];
+    const existing = await this.storage.getReleaseRunByTrigger(repo, triggerPr.number, triggerPr.mergeSha);
+
+    return {
+      repo,
+      baseBranch,
+      latestTag,
+      state: "ready",
+      triggerPr: toIncludedPR(triggerPr),
+      includedPrs: includedPulls.map(toIncludedPR),
+      candidateVersions: {
+        patch: this.github.bumpReleaseTag(latestTag, "patch"),
+        minor: this.github.bumpReleaseTag(latestTag, "minor"),
+        major: this.github.bumpReleaseTag(latestTag, "major"),
+      },
+      existingRunId: existing?.id ?? null,
+      existingRunStatus: existing?.status ?? null,
+    };
   }
 
   async retryReleaseRun(id: string): Promise<ReleaseRun | undefined> {

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1187,6 +1187,31 @@ test("POST /api/repos/release queues a manual release run for the requested repo
   }
 });
 
+test("GET /api/repos/release-preview returns the next manual release candidate", async () => {
+  const storage = new MemStorage();
+  const harness = await createHarness(storage, {
+    releaseManager: makeReleaseManagerForRoutes(storage),
+  });
+
+  try {
+    const response = await fetch(`${harness.baseUrl}/api/repos/release-preview?repo=acme/widgets`);
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.state, "ready");
+    assert.equal(body.repo, "acme/widgets");
+    assert.equal(body.triggerPr.number, 42);
+    assert.equal(body.includedPrs.length, 1);
+    assert.deepEqual(body.candidateVersions, {
+      patch: "v1.2.4",
+      minor: "v1.2.4",
+      major: "v1.2.4",
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
 test("POST /api/repos/release reports drain reason and does not queue release work", async () => {
   const storage = new MemStorage();
   const harness = await createHarness(storage, {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -481,6 +481,15 @@ export async function registerRoutes(
     }
   });
 
+  app.get("/api/repos/release-preview", async (req, res) => {
+    try {
+      const repo = z.string().min(1).parse(req.query.repo);
+      res.json(await runtime.previewManualRelease(repo));
+    } catch (error: unknown) {
+      sendAppAwareError(res, error);
+    }
+  });
+
   app.get("/api/prs", async (_req, res) => {
     res.json(await runtime.listPRs("active"));
   });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -642,6 +642,23 @@ export const releaseRunSchema = z.object({
 });
 export type ReleaseRun = z.infer<typeof releaseRunSchema>;
 
+export const releasePreviewSchema = z.object({
+  repo: z.string(),
+  baseBranch: z.string(),
+  latestTag: z.string().nullable(),
+  state: z.enum(["ready", "empty"]),
+  triggerPr: releaseRunIncludedPRSchema.nullable(),
+  includedPrs: z.array(releaseRunIncludedPRSchema),
+  candidateVersions: z.object({
+    patch: z.string(),
+    minor: z.string(),
+    major: z.string(),
+  }).nullable(),
+  existingRunId: z.string().nullable(),
+  existingRunStatus: releaseRunStatusEnum.nullable(),
+});
+export type ReleasePreview = z.infer<typeof releasePreviewSchema>;
+
 export const deploymentPlatformEnum = z.enum(["vercel", "railway"]);
 export type DeploymentPlatform = z.infer<typeof deploymentPlatformEnum>;
 


### PR DESCRIPTION
## Summary
- add a release preview API for the next unreleased merged PR without queueing release work
- show release candidate details, included PRs, latest tag, and candidate semver targets on Releases
- cover manager, route, and UI surface behavior

## Verification
- npm run check
- npm run test:all