### PR TITLE
fix: show ready PRs with green rail

### DIFF
--- a/client/src/lib/fullAppQaSurface.test.ts
+++ b/client/src/lib/fullAppQaSurface.test.ts
@@ -342,6 +342,7 @@ test("dashboard keeps the QA-tested PR, repo, feedback, and side-panel workflows
   assertHasExpression(sourceFile, "queue status badge", /\bQueueStatusBadge\b/);
   assertHasExpression(sourceFile, "queue status index", /\bqueueStatusById\b/);
   assertHasExpression(sourceFile, "PR number search helper", /\bmatchesNumberSearch\b/);
+  assertHasExpression(sourceFile, "PR ready merge rail", /isPRSummaryReadyToMerge\(pr\)\s*\?\s*["']success["']\s*:\s*prStatusTone\(pr\)/);
   assertHasStringValue(sourceFile, "PR number search placeholder", "Search #");
   assertHasExpression(sourceFile, "issue-linked PR index", /\bbuildIssueLinkedPRIndex\b/);
   assertHasStringValue(sourceFile, "linked issues tab label", /Linked Issues \(/);

--- a/client/src/pages/prs.tsx
+++ b/client/src/pages/prs.tsx
@@ -476,6 +476,7 @@ const PRRow = memo(function PRRow({
   const checkedAt = formatClock(pr.lastChecked);
   const watchEnabled = isPRWatchEnabled(pr);
   const workContract = getSafePRWorkContract(pr.workContract);
+  const railTone = isPRSummaryReadyToMerge(pr) ? "success" : prStatusTone(pr);
   return (
     <div
       onClick={() => onSelect(pr.id)}
@@ -494,8 +495,8 @@ const PRRow = memo(function PRRow({
       data-testid={`pr-row-${pr.id}`}
       className={`w-full cursor-pointer border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
         isSelected
-          ? "border-l-[3px] border-l-primary bg-muted"
-          : `border-l-2 ${toneRailClass(prStatusTone(pr))}`
+          ? `border-l-[3px] ${toneRailClass(railTone)} bg-muted`
+          : `border-l-2 ${toneRailClass(railTone)}`
       }`}
     >
       <div className="flex items-start gap-3">


### PR DESCRIPTION
## Summary
- show ready-to-merge PR rows with the success/green left rail
- keep selected ready PR rows green instead of primary blue
- add QA surface coverage for the ready merge rail

## Verification
- npm run check
- node --test client/src/lib/fullAppQaSurface.test.ts