### PR TITLE
chore: align release please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## Summary
- configure Release Please to use plain vX.Y.Z tags
- match the existing v1.2.0 GitHub release/tag so it does not generate a bogus 1.3.0 PR

## Verification
- parsed release-please-config.json and .release-please-manifest.json with Node
- confirmed PR #128 was closed