### PR TITLE
chore: bump Tauri version to 1.2.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "patchdeck"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
  "portpicker",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patchdeck"
-version = "1.0.0"
+version = "1.2.0"
 description = "Autonomous GitHub PR babysitter desktop app"
 authors = ["KimY"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/schemas/main/tauri-v2/tauri.conf.schema.json",
   "productName": "PatchDeck",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "identifier": "com.fluxlabs.patchdeck",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump Tauri app metadata to 1.2.0
- align the Rust package lock entry with the release version

## Verification
- ruby -e "require 'json'; JSON.parse(File.read('src-tauri/tauri.conf.json')); puts 'tauri config json ok'"
- cargo metadata --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1
- npm run check