### PR TITLE
chore: release 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeremymcs/patchdeck",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeremymcs/patchdeck",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeremymcs/patchdeck",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Autonomous GitHub PR and issue workbench that watches repos, triages review feedback, and dispatches agents to fix code locally",
   "keywords": [
     "github",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "patchdeck"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "portpicker",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patchdeck"
-version = "1.2.0"
+version = "1.2.1"
 description = "Autonomous GitHub PR babysitter desktop app"
 authors = ["KimY"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/schemas/main/tauri-v2/tauri.conf.schema.json",
   "productName": "PatchDeck",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.fluxlabs.patchdeck",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump npm package version to 1.2.1
- align Tauri and Cargo release metadata to 1.2.1

## Tests
- npm run check
- npm run test:all
- npm run build

Note: npm publish was not run because this shell is not authenticated with npm (`npm whoami` returned ENEEDAUTH).