### PR TITLE
fix: sync Tauri release versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,24 @@
     ".": {
       "release-type": "node",
       "include-component-in-tag": false,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "src-tauri/tauri.conf.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "toml",
+          "path": "src-tauri/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "src-tauri/Cargo.lock",
+          "jsonpath": "$.package[?(@.name==\"patchdeck\")].version"
+        }
+      ]
     }
   }
 }

--- a/server/appBranding.test.ts
+++ b/server/appBranding.test.ts
@@ -43,3 +43,23 @@ test("standalone metadata names the app PatchDeck (display) and patchdeck (packa
   assert.equal(tauriConfig.app.windows[0].title, APP_DISPLAY_NAME);
   assert.match(cargoToml, new RegExp(`^name = "${APP_PACKAGE_NAME}"$`, "m"));
 });
+
+test("release metadata keeps Tauri package versions in sync", async () => {
+  const packageJson = JSON.parse(await readProjectFile("package.json"));
+  const tauriConfig = JSON.parse(await readProjectFile("src-tauri/tauri.conf.json"));
+  const cargoToml = await readProjectFile("src-tauri/Cargo.toml");
+  const cargoLock = await readProjectFile("src-tauri/Cargo.lock");
+  const releasePleaseConfig = JSON.parse(await readProjectFile("release-please-config.json"));
+  const version = packageJson.version;
+
+  assert.equal(tauriConfig.version, version);
+  assert.match(cargoToml, new RegExp(`^version = "${version}"$`, "m"));
+  assert.match(cargoLock, new RegExp(`\\[\\[package\\]\\]\\nname = "${APP_PACKAGE_NAME}"\\nversion = "${version}"`, "m"));
+
+  const extraFilePaths = releasePleaseConfig.packages["."]["extra-files"].map((file: { path: string }) => file.path);
+  assert.deepEqual(extraFilePaths, [
+    "src-tauri/tauri.conf.json",
+    "src-tauri/Cargo.toml",
+    "src-tauri/Cargo.lock",
+  ]);
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "patchdeck"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "portpicker",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patchdeck"
-version = "1.2.1"
+version = "1.3.0"
 description = "Autonomous GitHub PR babysitter desktop app"
 authors = ["KimY"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/schemas/main/tauri-v2/tauri.conf.schema.json",
   "productName": "PatchDeck",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "identifier": "com.fluxlabs.patchdeck",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- add Release Please extra-files for Tauri config, Cargo manifest, and Cargo lock package version
- update Tauri metadata to match the current 1.3.0 package version
- add a regression test that keeps release metadata and Tauri versions in sync

## Tests
- node --import tsx --test server/appBranding.test.ts
- npm run check
- npm run test