### PR TITLE
fix: update Release Please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
 
   publish-npm:


### PR DESCRIPTION
## Summary
- update googleapis/release-please-action from v4 to v5 so the Release workflow uses the maintained action/runtime
- fixes the current main Release job failure in release-please after PR #143 was merged

## Tests
- git diff --check

Workflow-only change; GitHub Actions is the meaningful verification.