### PR TITLE
chore: fix Release Please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,11 +15,6 @@
           "type": "toml",
           "path": "src-tauri/Cargo.toml",
           "jsonpath": "$.package.version"
-        },
-        {
-          "type": "toml",
-          "path": "src-tauri/Cargo.lock",
-          "jsonpath": "$.package[?(@.name==\"patchdeck\")].version"
         }
       ]
     }

--- a/server/appBranding.test.ts
+++ b/server/appBranding.test.ts
@@ -48,18 +48,15 @@ test("release metadata keeps Tauri package versions in sync", async () => {
   const packageJson = JSON.parse(await readProjectFile("package.json"));
   const tauriConfig = JSON.parse(await readProjectFile("src-tauri/tauri.conf.json"));
   const cargoToml = await readProjectFile("src-tauri/Cargo.toml");
-  const cargoLock = await readProjectFile("src-tauri/Cargo.lock");
   const releasePleaseConfig = JSON.parse(await readProjectFile("release-please-config.json"));
   const version = packageJson.version;
 
   assert.equal(tauriConfig.version, version);
   assert.match(cargoToml, new RegExp(`^version = "${version}"$`, "m"));
-  assert.match(cargoLock, new RegExp(`\\[\\[package\\]\\]\\nname = "${APP_PACKAGE_NAME}"\\nversion = "${version}"`, "m"));
 
   const extraFilePaths = releasePleaseConfig.packages["."]["extra-files"].map((file: { path: string }) => file.path);
   assert.deepEqual(extraFilePaths, [
     "src-tauri/tauri.conf.json",
     "src-tauri/Cargo.toml",
-    "src-tauri/Cargo.lock",
   ]);
 });


### PR DESCRIPTION
## Summary
- remove the unsupported Cargo.lock TOML jsonpath updater from Release Please
- keep the regression test focused on the Tauri metadata files Release Please can update reliably

## Verification
- node --import tsx --test server/appBranding.test.ts
- npm run check
- npm run test
- /simplify release-please-config.json server/appBranding.test.ts