### PR TITLE
chore: limit Release Please commit batch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "commit-batch-size": 1,
   "packages": {
     ".": {
       "release-type": "node",

--- a/server/appBranding.test.ts
+++ b/server/appBranding.test.ts
@@ -53,6 +53,7 @@ test("release metadata keeps Tauri package versions in sync", async () => {
 
   assert.equal(tauriConfig.version, version);
   assert.match(cargoToml, new RegExp(`^version = "${version}"$`, "m"));
+  assert.equal(releasePleaseConfig["commit-batch-size"], 1);
 
   const extraFilePaths = releasePleaseConfig.packages["."]["extra-files"].map((file: { path: string }) => file.path);
   assert.deepEqual(extraFilePaths, [


### PR DESCRIPTION
## Summary
- set Release Please commit-batch-size to 1 so it stops at the latest release SHA instead of prefetching older history
- add a regression assertion so the release config guard stays in place

## Verification
- npm install
- node --import tsx --test server/appBranding.test.ts
- npm run check
- npm run test
- /simplify release-please-config.json server/appBranding.test.ts