### PR TITLE
fix: increase agent evaluation and apply timeouts for slow models

### DIFF
--- a/server/agentRunner.ts
+++ b/server/agentRunner.ts
@@ -232,7 +232,7 @@ export async function evaluateFixNecessityWithAgent(params: {
           outputFile,
           extractionPrompt,
         ], settings),
-        { cwd, timeoutMs: 180000 },
+        { cwd, timeoutMs: 420000 },
       );
 
       if (result.code !== 0) {
@@ -268,7 +268,7 @@ export async function evaluateFixNecessityWithAgent(params: {
   const result = await runAgentCommand(
     "claude",
     claudeArgs,
-    { cwd, timeoutMs: 180000 },
+    { cwd, timeoutMs: 420000 },
   );
 
   if (result.code !== 0) {
@@ -288,7 +288,7 @@ export async function applyFixesWithAgent(params: {
   onStdoutChunk?: (chunk: string) => void;
   onStderrChunk?: (chunk: string) => void;
 }): Promise<CommandResult> {
-  const { agent, cwd, prompt, settings, env, timeoutMs = 900000, onStdoutChunk, onStderrChunk } = params;
+  const { agent, cwd, prompt, settings, env, timeoutMs = 1800000, onStdoutChunk, onStderrChunk } = params;
 
   if (agent === "codex") {
     const result = await runAgentCommand(


### PR DESCRIPTION
## Problem

Fixed timeouts in `server/agentRunner.ts` are too tight for slower model providers (e.g. DeepSeek via a LiteLLM bridge), which causes two failure modes:

1. **Evaluation timeout (3 min, `180000`).** Evaluating whether a long review comment needs a fix routinely exceeds 3 minutes for models with slower first-token/long-context latency. An evaluation timeout fails the whole run and pushes the PR into recovery mode; recovery runs never trigger the code-owner fallback, so the run just fails.

2. **Apply timeout (15 min, `900000`).** Multi-file fixes (e.g. editing contract shapes plus regenerating ~20 fixtures) exceed 15 minutes. When apply is killed mid-run, the uncommitted worktree edits are discarded.

## Changes

`server/agentRunner.ts`:
- Evaluation timeout: `180000` → `420000` (7 min) for both codex and claude evaluation.
- Default apply timeout: `900000` → `1800000` (30 min), matching the code-owner fallback timeout (`CODE_OWNER_FALLBACK_TIMEOUT_MS`).

## Tests

Existing timeout tests still pass (they assert the formatted timeout string from stderr, not the default).

## Environment

- Node.js 22, WSL2, codex CLI 0.146.0 (DeepSeek-backed provider)