### PR TITLE
fix: instruct fix agent to write summaries in Simplified Chinese

### DIFF
--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -2753,6 +2753,7 @@ test("babysitPR uses a CODEFACTORY_HOME worktree, passes GitHub context, and ver
   assert.match(receivedPrompt, /GitHub follow-up replies and review-thread resolution will be handled by the babysitter/i);
   assert.match(receivedPrompt, /auditToken=codefactory-feedback:gh-review-comment-1/);
   assert.match(receivedPrompt, /FEEDBACK_SUMMARY_START/);
+  assert.match(receivedPrompt, /write every summary block in Simplified Chinese/);
   assert.equal(receivedEnv?.GITHUB_TOKEN, "test-token");
   assert.equal(receivedEnv?.GH_TOKEN, "test-token");
 

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -585,6 +585,7 @@ function buildAgentFixPrompt(params: {
     "   <A concise 1-2 sentence summary of what you did or why you were blocked>",
     "   FEEDBACK_SUMMARY_END",
     "   Include one block per audit token. These summaries will be posted as follow-up comments on the PR.",
+    "Language: write every summary block in Simplified Chinese. These summaries are posted on the PR, so use the same language for the whole comment.",
     "4) If documentation tasks were assigned, emit exactly one docs summary block in the following format:",
     "   DOCS_SUMMARY_START <changed|no_change>",
     "   <A concise 1-2 sentence summary of the docs you updated, or why no docs changes were necessary after inspection>",


### PR DESCRIPTION
## Problem

When PatchDeck resolves a review thread, the follow-up comment posted to GitHub mixes languages: the title line is Chinese (`已在提交 \`abc1234\` 中处理。`) but the agent summary is English, because the fix-agent prompt (`buildAgentFixPrompt`) never told the agent which language to use. Only the code-owner fallback prompt contained the Chinese-language instruction.

Example posted on PR #434:

> 已在提交 45fca2f 中处理。
>
> Restructured generate_installation_config.py so the --dry-run branch returns before assert_identity ... (English)

## Fix

Add a language instruction to `buildAgentFixPrompt` so every summary block the fix agent emits (posted as follow-up comments on the PR) is written in Simplified Chinese, matching the existing Chinese templates and the code-owner fallback prompt.

## Tests

- Extended the existing comment-task test to assert the fix-agent prompt instructs `write every summary block in Simplified Chinese`.
- Verified: `node --import tsx --test server/babysitter.test.ts` (110 tests pass), `npm run check` passes.
