### PR TITLE
feat: recover from failed automation without manual clearing

### DIFF
--- a/LOCAL_API.md
+++ b/LOCAL_API.md
@@ -678,6 +678,7 @@ Partially update the configuration.  Only the provided fields are changed.
   "includeRepositoryLinksInGitHubComments": true,
   "postGitHubProgressReplies": false,
   "autoHealCI": false,
+  "maxAgentRetryAttempts": 3,
   "maxHealingAttemptsPerSession": 3,
   "maxHealingAttemptsPerFingerprint": 2,
   "maxConcurrentHealingRuns": 1,
@@ -1024,6 +1025,7 @@ Install the patchdeck code-review GitHub Actions workflow on a repository.
   includeRepositoryLinksInGitHubComments: boolean;
   postGitHubProgressReplies: boolean;
   autoHealCI: boolean;
+  maxAgentRetryAttempts: number; // Retries allowed for failed work that re-runs the coding agent; infrastructure failures use a separate budget
   maxHealingAttemptsPerSession: number;
   maxHealingAttemptsPerFingerprint: number;
   maxConcurrentHealingRuns: number;

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Most configuration is editable in Settings:
 - GitHub comment branding
 - GitHub progress replies
 - CI healing
+- Agent retry attempts for failed work
 - Theme
 
 Key defaults:
@@ -188,6 +189,11 @@ Key defaults:
 - Automatic release creation is disabled.
 - Automatic CI healing is disabled.
 - Automatic deployment healing is disabled.
+- Failed work retries automatically with exponential backoff. **Max agent retry attempts** (default 3)
+  bounds how often a retry may re-run the coding agent; network and GitHub failures retry on a
+  separate, more generous budget because they cost a request rather than an agent run. Work that
+  needs a person — expired agent credentials, a missing CLI — is parked and shown under
+  **Needs attention**, and is retried again roughly hourly so it resumes on its own once fixed.
 - Drain mode pauses new agent work without deleting tracked state.
 
 ## Authentication

--- a/client/src/lib/activityQueue.test.ts
+++ b/client/src/lib/activityQueue.test.ts
@@ -81,3 +81,41 @@ test("buildQueueStatusIndex summarizes queued and running activities", () => {
 test("getQueueStatusForTarget returns null for missing targets", () => {
   assert.equal(getQueueStatusForTarget(snapshot, "missing", Date.parse("2026-05-12T12:00:00.000Z")), null);
 });
+
+test("buildQueueStatusIndex distinguishes a backing-off retry from a normal queue wait", () => {
+  const retrying: ActivitySnapshot = {
+    failed: [],
+    inProgress: [],
+    queued: [
+      {
+        id: "queued-1",
+        kind: "work_issue",
+        status: "queued",
+        label: "Working issue #7",
+        detail: null,
+        targetId: "issue-7",
+        targetUrl: null,
+        queuedAt: "2026-05-12T11:00:00.000Z",
+        availableAt: "2026-05-12T12:05:00.000Z",
+        startedAt: null,
+        updatedAt: "2026-05-12T11:59:30.000Z",
+        attemptCount: 2,
+        lastError: "connect ECONNRESET",
+      },
+    ],
+    warnings: [],
+    generatedAt: "2026-05-12T12:00:00.000Z",
+  };
+
+  const index = buildQueueStatusIndex(retrying, Date.parse("2026-05-12T12:00:00.000Z"));
+  const status = index.get("issue-7");
+
+  assert.equal(status?.label, "retrying (attempt 3)");
+  assert.match(status?.detail ?? "", /retry in ~5m/);
+  assert.match(status?.detail ?? "", /ECONNRESET/);
+});
+
+test("buildQueueStatusIndex still reads as a queue position for untried work", () => {
+  const index = buildQueueStatusIndex(snapshot, Date.parse("2026-05-12T12:00:00.000Z"));
+  assert.equal(index.get("issue-7")?.label, "up next");
+});

--- a/client/src/lib/activityQueue.ts
+++ b/client/src/lib/activityQueue.ts
@@ -31,13 +31,22 @@ export function buildQueueStatusIndex(snapshot: ActivitySnapshot, nowMs = Date.n
     const availableDelayMs = getAvailableDelayMs(activity, nowMs);
     const waitMs = availableDelayMs + inProgressBudgetMs + queuedBudgetMs;
 
+    // A queued job with attempts behind it is backing off after a failure, not
+    // waiting its turn. Say so, and say why — automation retrying quietly looks
+    // identical to automation being stuck.
+    const isRetrying = availableDelayMs > 0 && activity.attemptCount > 0;
+
     statusById.set(activity.targetId, {
-      label: position === 1 ? "up next" : `#${position} in queue`,
-      detail: availableDelayMs > 0
-        ? `available in ~${formatDuration(availableDelayMs)}`
-        : waitMs > 0
-          ? `starts in ~${formatDuration(waitMs)}`
-          : "starting soon",
+      label: isRetrying
+        ? `retrying (attempt ${activity.attemptCount + 1})`
+        : position === 1 ? "up next" : `#${position} in queue`,
+      detail: isRetrying
+        ? `retry in ~${formatDuration(availableDelayMs)}${activity.lastError ? ` - ${activity.lastError}` : ""}`
+        : availableDelayMs > 0
+          ? `available in ~${formatDuration(availableDelayMs)}`
+          : waitMs > 0
+            ? `starts in ~${formatDuration(waitMs)}`
+            : "starting soon",
       className: availableDelayMs > 0
         ? "border-warning-border bg-warning-muted text-warning-foreground"
         : "border-primary/50 text-primary",

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -39,6 +39,7 @@ const DEFAULT_SETTING_VALUES = {
   batchWindowSeconds: 600,
   maxChangesPerRun: 20,
   maxConcurrentBabysitRuns: 3,
+  maxAgentRetryAttempts: 3,
   maxHealingAttemptsPerSession: 3,
   maxHealingAttemptsPerFingerprint: 2,
   maxConcurrentHealingRuns: 1,
@@ -1347,6 +1348,14 @@ export default function Settings() {
                 value={config?.maxConcurrentBabysitRuns ?? 3}
                 onChange={(v) => updateConfigMutation.mutate({ maxConcurrentBabysitRuns: v })}
                 defaultValue={DEFAULT_SETTING_VALUES.maxConcurrentBabysitRuns}
+                disabled={updateConfigMutation.isPending}
+              />
+              <SettingRow
+                label="Max agent retry attempts"
+                description="How many times failed work may re-run the agent before it parks for you. Network and GitHub failures retry regardless — they cost a request, not a run."
+                value={config?.maxAgentRetryAttempts ?? 3}
+                onChange={(v) => updateConfigMutation.mutate({ maxAgentRetryAttempts: v })}
+                defaultValue={DEFAULT_SETTING_VALUES.maxAgentRetryAttempts}
                 disabled={updateConfigMutation.isPending}
               />
             </div>

--- a/docs/plans/resilient-automation.md
+++ b/docs/plans/resilient-automation.md
@@ -1,0 +1,212 @@
+// PatchDeck + Unattended Failure Recovery Plan
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+# Unattended Failure Recovery
+
+## Goal
+
+PatchDeck runs without a human clearing errors. Every failure that *can* recover
+does so on its own; only failures that genuinely need a person park, stay
+visible, and auto-resume once the blocking condition clears.
+
+Success criteria (verifiable):
+
+1. A transient failure (GitHub 5xx, network reset, agent CLI timeout) never
+   leaves a job in the terminal `failed` state.
+2. An issue whose work job fails is picked up again automatically, and does not
+   block its repo's issue queue while it backs off.
+3. A PR does not stay in `status: "error"` when its work is still retrying.
+4. A release run that errors is retried automatically.
+5. Agent-auth / CLI-missing failures park with an operator warning and resume
+   automatically once the agent is available again.
+
+## Current Behaviour (why it stalls)
+
+All automation flows through one queue (`background_jobs`, kinds:
+`sync_watched_repos`, `babysit_pr`, `process_release_run`, `answer_pr_question`,
+`evaluate_issue`, `verify_issue`, `work_issue`, `generate_social_changelog`,
+`heal_deployment`). That makes the dispatcher the highest-leverage fix.
+
+| # | Surface | Code | Behaviour |
+|---|---------|------|-----------|
+| 1 | Dispatcher retry policy | `backgroundJobDispatcher.ts:340` | 3 attempts, flat 30s backoff, then terminal `failed`. A 90-second GitHub blip exhausts the whole budget. No error classification. |
+| 2 | Issue auto-work | `appRuntime.ts:360` | `workStatus` derives from the newest job. `failed` ⇒ the issue is excluded from auto-work *and* auto-evaluate permanently. |
+| 3 | Issue single-flight | `appRuntime.ts:356` | Any `queued`/`in_progress` job in a repo blocks every other issue in that repo. |
+| 4 | Issue work terminal-on-first-failure | `backgroundJobHandlers.ts:611` | Any thrown exception becomes `TerminalBackgroundJobError` — zero retries, even for a network error. |
+| 5 | PR `status: "error"` | `babysitter.ts:2815,2847,4698` | Set on sync failure, dependency preflight failure, exhausted conflict repair. Cleared only by a manual queue (`appRuntime.ts:2080`). |
+| 6 | Release runs | `releaseManager.ts:443` | `failRun` **swallows** the error: the job completes "successfully", the run sits in `error`, only `/api/releases/:id/retry` revives it. |
+| 7 | Failed activity panel | `DashboardErrorsPanel.tsx` | Terminal failures accumulate until *Clear failed*. |
+
+CI healing already self-heals: sessions are `superseded` when the head SHA
+changes (`ciHealingManager.ts:104`). Its per-session/per-fingerprint budgets are
+deliberate spend controls and stay as they are.
+
+## Decisions (confirmed with the user)
+
+- Retryable failures: exponential backoff, then park. Bounded, not infinite.
+- Human-required failures (agent auth, CLI missing, unknown agent): park,
+  surface as an operator warning, auto-resume when the condition clears.
+- Agent spend is a user setting: `maxAgentRetryAttempts` (global, default 3),
+  matching the existing `maxHealingAttemptsPerSession` knob. Per-repo override
+  is deliberately out of scope; `watchedRepoSchema` already carries per-repo
+  overrides if it is wanted later.
+
+### Free vs paid retries
+
+Retry cost is not uniform, and the setting only governs the paid half:
+
+- **Free** — `sync_watched_repos`, and any failure that happens before the agent
+  is invoked (GitHub 5xx, network reset, clone failure, rate-limit gate). These
+  retry generously and are *not* gated by the spend setting. This is most of
+  what strands automation today and it costs nothing.
+- **Paid** — `babysit_pr`, `work_issue`, `evaluate_issue`, `verify_issue`,
+  `heal_deployment`, `answer_pr_question`, `process_release_run` when the
+  failure indicates the agent actually ran.
+
+The split is derived from the failure class, not guessed per job: a `transient`
+failure is infrastructure and takes the free cap; anything else on an
+agent-invoking kind takes `maxAgentRetryAttempts`.
+
+A true rolling spend ceiling (max agent runs per hour, enforced before every
+invocation) was considered and deferred — `agentRuns` is PR-scoped today
+(`prId`, written only by `babysitter.ts`), so metering global spend needs
+accounting at every agent entry point. Tracked as a follow-up.
+
+## Design
+
+### A. `server/failureRecovery.ts` (new, pure, unit-testable)
+
+```ts
+export type FailureClass = "transient" | "retryable" | "blocked" | "terminal";
+export function classifyFailure(error: unknown): FailureClass;
+export function computeRetryDelayMs(attempt: number, klass: FailureClass): number;
+export function shouldParkAfterAttempt(attempt: number, klass: FailureClass): boolean;
+export const AGENT_INVOKING_JOB_KINDS: ReadonlySet<BackgroundJobKind>;
+```
+
+- `transient` — 5xx/408, `ECONNRESET`/`EAI_AGAIN`/`ETIMEDOUT`/`socket hang up`/
+  `fetch failed`, rate-limit and budget-reserve gates, lock contention.
+  Reuses the predicates already in `github.ts:806` and `rateLimitState.ts`.
+- `blocked` — `detectAgentUnavailability()` from `agentRunner.ts:74` (auth,
+  cli_missing, unknown_agent) plus repo permission denials.
+- `terminal` — explicit `TerminalBackgroundJobError` / `CancelBackgroundJobError`.
+- `retryable` — everything else (the safe default).
+
+Backoff: exponential with jitter, `30s → 1m → 2m → 5m → 15m → 30m → 1h`, capped
+at 1h. Attempt caps: `transient` 10, `retryable` 8. Roughly a 4-hour recovery
+window before parking — long enough to ride out any real outage.
+
+### B. Dispatcher: classified backoff (`backgroundJobDispatcher.ts`)
+
+Rewrite `resolveFailureAction` to return `{action, delayMs}`:
+
+- `CancelBackgroundJobError` → cancel (unchanged)
+- `DeferBackgroundJobError` → defer (unchanged)
+- `TerminalBackgroundJobError` → fail (parked)
+- otherwise classify → `retry` with `computeRetryDelayMs` while under the class
+  cap; `fail` (parked) once the cap is hit or the class is `blocked`.
+
+Backing-off jobs stay `queued` with a future `availableAt`, so `failed` comes to
+mean exactly "parked, needs a human". No schema change: the park sweep and the
+UI re-derive the class from `lastError` with the same classifier.
+
+### C. Issue queue: ignore backing-off jobs
+
+`issueWorkStatusFromJobs` (`appRuntime.ts:506`) also returns `workAvailableAt`.
+`planAutomaticIssueQueueActions` treats a `queued` job whose `availableAt` is in
+the future as **not** occupying the repo's single-flight slot, and re-derives
+such an issue as `idle` for candidate selection only when the queue entry is its
+own. Additive nullable `workAvailableAt` on the `Issue` schema; the enum is
+unchanged.
+
+Fixes symptom 2 and prevents the new regression where one backing-off issue
+would freeze its repo's queue for an hour.
+
+### D. Issue work handler: stop being terminal on the first exception
+
+`backgroundJobHandlers.ts:611` — classify instead. Only
+`!repairResult.accepted` (the agent explicitly rejected the work) stays
+`TerminalBackgroundJobError`. A thrown exception falls through to the
+dispatcher's classified retry.
+
+### E. PR error status tracks reality
+
+- The babysitter sets `status: "error"` only when the failure is `blocked` or
+  the job actually parked; a retryable failure keeps `watching` and records
+  `lastSyncError`.
+- Recovery sweep (below) resets `error → watching` for any PR whose newest job
+  is queued/leased — i.e. work is still in flight.
+- Dependency-preflight and terminal-conflict errors keep their existing
+  head-SHA-scoped self-clear.
+
+### F. Release runs retry
+
+`releaseManager.processReleaseRun` rethrows after `failRun` so the job retries
+under the dispatcher policy. `failRun` sets `status: "error"` only once the job
+has parked, so a mid-retry run shows `publishing`/`evaluating`, not `error`.
+`retryReleaseRun`'s existing reset path is unchanged.
+
+### G. Recovery sweep (`appRuntime` watcher tick, default 10 min)
+
+`planFailedJobRecovery(jobs, prs, now, policy)` — pure and unit-tested — returns
+the jobs to revive:
+
+- `blocked` jobs: re-probe the blocking condition (`commandExists` for
+  `cli_missing`; a cheap auth probe for `auth`). Re-queue when it clears.
+  Otherwise re-check hourly.
+- Parked `transient`/`retryable` jobs: one revival attempt per hour, giving up
+  once the job is older than `maxRecoveryAgeMs` (default 24h) — those stay in
+  the panel as a genuine human-required item.
+- PRs in `error` with live work → reset to `watching`.
+
+New storage method `requeueFailedBackgroundJob(id, availableAt)` on `IStorage`,
+`sqliteStorage`, and `memoryStorage`.
+
+### H. Dashboard honesty
+
+`DashboardErrorsPanel` currently shows only terminal failures — that stays
+correct and gets quieter by construction. Activity rows for backing-off jobs
+render "Retrying in 12m · attempt 3/10 · <error>" using the `attemptCount`,
+`availableAt`, and `lastError` fields already on `ActivityItem`. No schema
+change.
+
+## Work Breakdown
+
+| Step | Change | Verify |
+|------|--------|--------|
+| 1 | `failureRecovery.ts` + `failureRecovery.test.ts` | Unit tests for each class and the backoff curve |
+| 2 | Dispatcher classified backoff | `backgroundJobDispatcher.test.ts`: transient failure retries past attempt 3; blocked parks immediately |
+| 3 | Issue queue backing-off awareness | `appRuntime.test.ts`: backing-off issue does not block its repo; failed→revived issue is re-picked |
+| 4 | Issue work handler classification | `backgroundJobHandlers.test.ts`: thrown network error retries; explicit rejection is terminal |
+| 5 | PR error status accuracy | `babysitter.test.ts`: retryable sync failure leaves PR `watching` |
+| 6 | Release run rethrow | `releaseManager.test.ts`: errored run is retried; parks only after the cap |
+| 7 | Recovery sweep + storage method | `appRuntime.test.ts` + `storage.test.ts`: parked job revived once its cooldown elapses; blocked job revived once the CLI reappears |
+| 8 | Activity UI retry state | `client/src/lib` test + visual check |
+| 9 | `maxAgentRetryAttempts` config + Settings UI + MCP tool description | `defaultConfig.test.ts`, settings render test |
+| 10 | `npm run check` + `npm run test:all` | Green |
+
+## Outcome
+
+All ten steps landed. `npm run check`, `npx eslint .`, `npm run build`, and
+`npm run test:all` (784 tests) are green.
+
+## Risks
+
+- **Runaway agent spend.** More retries means more agent runs. Mitigated by:
+  the user-owned `maxAgentRetryAttempts` cap, the free/paid split (infrastructure
+  retries never invoke an agent), exponential backoff, the unchanged CI-healing
+  spend budgets, and the unchanged `maxConcurrentIssueWork` cap.
+- **Masking real breakage.** A repo that is genuinely broken now retries for 4h
+  before parking. The activity row shows attempt count and last error
+  throughout, so it is visible, just not blocking.
+- **Backing-off jobs holding dedupe keys.** `enqueueBackgroundJob` dedupes on
+  `queued`/`leased` (`sqliteStorage.ts:2827`), so a backing-off job now
+  suppresses a fresh enqueue for the same target. This is correct - it is the
+  same work - but a manual "run now" would look like a dead button. Resolved:
+  `promoteQueuedJob` pulls a future-dated queued job forward to now on the
+  manual PR and issue paths, and wakes the dispatcher.
+- **Concurrency budget held by backing-off work.** `activeWorkCount` counted
+  every queued job, so one issue backing off for an hour would have frozen all
+  issue work under `maxConcurrentIssueWork: 1`. Resolved in step 3: a queued job
+  scheduled for the future consumes neither the global budget nor its repo's
+  single-flight slot.

--- a/server/appRuntime.test.ts
+++ b/server/appRuntime.test.ts
@@ -759,6 +759,7 @@ function makePlanIssue(
     autoWorkEligible: overrides.autoWorkEligible ?? false,
     evaluationStatus: overrides.evaluationStatus ?? null,
     updatedAt: overrides.updatedAt ?? "2026-05-01T00:00:00.000Z",
+    workAvailableAt: overrides.workAvailableAt ?? null,
   };
 }
 
@@ -1438,4 +1439,72 @@ test("syncRepos defers the next sweep for a repo whose issue list is unchanged",
     eligibleMs >= before + 9 * 60_000,
     `expected a ~10min cooldown, got ${(eligibleMs - before) / 60_000}min`,
   );
+});
+
+test("planAutomaticIssueQueueActions keeps a repo moving while one issue backs off after a failure", () => {
+  // Goal: a work job that failed and is waiting out its retry delay is not running. It must not
+  // hold its repo's single-flight slot, or one flaky issue freezes the whole repo until the
+  // delay elapses — the exact stall this recovery work exists to remove.
+  const now = new Date("2026-05-01T12:00:00.000Z");
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true }],
+    issues: [
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 1,
+        workStatus: "queued",
+        workAvailableAt: "2026-05-01T12:30:00.000Z",
+      }),
+      makePlanIssue({ repo: "acme/widgets", number: 2, autoWorkEligible: true, evaluationStatus: "approved" }),
+    ],
+    now,
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+
+  assert.deepEqual(plan.work.map((entry) => entry.number), [2]);
+});
+
+test("planAutomaticIssueQueueActions still respects single-flight for a claimable queued job", () => {
+  // Guard the other side of the same rule: a job that is due now really is about to run, so the
+  // repo stays single-flight.
+  const now = new Date("2026-05-01T12:00:00.000Z");
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true }],
+    issues: [
+      makePlanIssue({
+        repo: "acme/widgets",
+        number: 1,
+        workStatus: "queued",
+        workAvailableAt: "2026-05-01T11:59:00.000Z",
+      }),
+      makePlanIssue({ repo: "acme/widgets", number: 2, autoWorkEligible: true, evaluationStatus: "approved" }),
+    ],
+    now,
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+
+  assert.deepEqual(plan.work, []);
+});
+
+test("planAutomaticIssueQueueActions treats in-progress work as occupying the repo slot", () => {
+  const plan = planAutomaticIssueQueueActions({
+    repoSettings: [{ repo: "acme/widgets", issueAutoEvaluate: true, issueAutoWork: true }],
+    issues: [
+      makePlanIssue({ repo: "acme/widgets", number: 1, workStatus: "in_progress" }),
+      makePlanIssue({ repo: "acme/widgets", number: 2, autoWorkEligible: true, evaluationStatus: "approved" }),
+    ],
+    now: new Date("2026-05-01T12:00:00.000Z"),
+    activeEvaluationTargets: new Set(),
+    activeWorkCount: 0,
+    maxConcurrentIssueEvaluations: 2,
+    maxConcurrentIssueWork: 1,
+  });
+
+  assert.deepEqual(plan.work, []);
 });

--- a/server/appRuntime.ts
+++ b/server/appRuntime.ts
@@ -33,6 +33,7 @@ import { getDefaultStorage } from "./storage";
 import { PRBabysitter } from "./babysitter";
 import { resolveRepoAgentRuntimeSettings, resolveRepoCodingAgent } from "./agentSettings";
 import { commandExists, detectAgentUnavailability, type AgentUnavailabilityKind, type CodingAgent } from "./agentRunner";
+import { planFailedJobRecovery } from "./failureRecovery";
 import { applyEvaluationDecision, applyFlagDecision } from "./feedbackLifecycle";
 import { applyManualFeedbackDecision } from "./manualFeedback";
 import { childLogger } from "./logger";
@@ -316,9 +317,10 @@ export type PlanAutomaticIssueQueueInput = {
   repoSettings: Pick<WatchedRepo, "repo" | "issueAutoEvaluate" | "issueAutoWork">[];
   issues: Pick<
     Issue,
-    "id" | "repo" | "number" | "author" | "isWorked" | "workStatus" | "workPrUrl" | "externalWorkPrUrl" | "autoWorkEligible" | "evaluationStatus" | "updatedAt"
+    "id" | "repo" | "number" | "author" | "isWorked" | "workStatus" | "workPrUrl" | "externalWorkPrUrl" | "autoWorkEligible" | "evaluationStatus" | "updatedAt" | "workAvailableAt"
   >[];
   activeEvaluationTargets: Set<string>;
+  now?: Date;
   activeWorkCount: number;
   maxConcurrentIssueEvaluations: number;
   maxConcurrentIssueWork: number;
@@ -329,6 +331,33 @@ export type PlanAutomaticIssueQueueActions = {
   evaluations: Array<{ repo: string; number: number; id: string }>;
   work: Array<{ repo: string; number: number; id: string }>;
 };
+
+/**
+ * Whether an issue's work job is holding a concurrency slot right now. A queued
+ * job that is backing off after a failure is not running and will not run for a
+ * while, so it must not freeze the rest of its repo's queue.
+ */
+function occupiesWorkSlot(
+  issue: Pick<Issue, "workStatus" | "workAvailableAt">,
+  nowMs: number,
+): boolean {
+  if (issue.workStatus === "in_progress") {
+    return true;
+  }
+  if (issue.workStatus !== "queued") {
+    return false;
+  }
+  return !isBackingOff(issue.workAvailableAt, nowMs);
+}
+
+/** A queue entry scheduled for the future is waiting out a retry delay. */
+function isBackingOff(availableAt: string | null | undefined, nowMs: number): boolean {
+  if (!availableAt) {
+    return false;
+  }
+  const parsed = Date.parse(availableAt);
+  return Number.isFinite(parsed) && parsed > nowMs;
+}
 
 export function planAutomaticIssueQueueActions(
   input: PlanAutomaticIssueQueueInput,
@@ -350,10 +379,11 @@ export function planAutomaticIssueQueueActions(
 
   // Auto-work sweep first: budget is scarcer. Preserve per-repo single-flight semantics —
   // at most one work job per repo at a time, regardless of global budget.
+  const nowMs = (input.now ?? new Date()).getTime();
   for (const repo of autoWorkRepos) {
     if (workBudget <= 0) break;
     const repoIssues = input.issues.filter((issue) => issue.repo === repo);
-    if (repoIssues.some((issue) => issue.workStatus === "queued" || issue.workStatus === "in_progress")) {
+    if (repoIssues.some((issue) => occupiesWorkSlot(issue, nowMs))) {
       continue;
     }
     const candidate = repoIssues
@@ -503,13 +533,19 @@ function getLatestBackgroundJob(jobs: BackgroundJob[]): BackgroundJob | undefine
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
 }
 
-function issueWorkStatusFromJobs(jobs: BackgroundJob[]): { workStatus: Issue["workStatus"]; workJobId: string | null; lastError: string | null } {
+function issueWorkStatusFromJobs(jobs: BackgroundJob[]): {
+  workStatus: Issue["workStatus"];
+  workJobId: string | null;
+  workAvailableAt: string | null;
+  lastError: string | null;
+} {
   const latest = getLatestBackgroundJob(jobs);
 
   if (!latest) {
     return {
       workStatus: "idle",
       workJobId: null,
+      workAvailableAt: null,
       lastError: null,
     };
   }
@@ -518,6 +554,7 @@ function issueWorkStatusFromJobs(jobs: BackgroundJob[]): { workStatus: Issue["wo
     return {
       workStatus: "in_progress",
       workJobId: latest.id,
+      workAvailableAt: null,
       lastError: null,
     };
   }
@@ -526,7 +563,10 @@ function issueWorkStatusFromJobs(jobs: BackgroundJob[]): { workStatus: Issue["wo
     return {
       workStatus: "queued",
       workJobId: latest.id,
-      lastError: null,
+      workAvailableAt: latest.availableAt,
+      // A queued job that already has attempts behind it is backing off after a
+      // failure, so keep the reason visible instead of blanking it.
+      lastError: latest.attemptCount > 0 ? latest.lastError : null,
     };
   }
 
@@ -534,6 +574,7 @@ function issueWorkStatusFromJobs(jobs: BackgroundJob[]): { workStatus: Issue["wo
     return {
       workStatus: "failed",
       workJobId: latest.id,
+      workAvailableAt: null,
       lastError: latest.lastError,
     };
   }
@@ -541,6 +582,7 @@ function issueWorkStatusFromJobs(jobs: BackgroundJob[]): { workStatus: Issue["wo
   return {
     workStatus: "idle",
     workJobId: null,
+    workAvailableAt: null,
     lastError: null,
   };
 }
@@ -1010,6 +1052,65 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     },
   });
 
+  /**
+   * Revive parked background jobs whose park interval has elapsed, and un-park
+   * PRs whose work is actually still in flight. Without this, a job that ran out
+   * of retries stays failed forever and its PR or issue is excluded from every
+   * later sweep until somebody clears it in the dashboard.
+   */
+  const recoverParkedWork = async () => {
+    const failedJobs = await storage.listBackgroundJobs({ status: "failed" });
+    const revivable = planFailedJobRecovery(failedJobs, Date.now());
+
+    for (const jobId of revivable) {
+      const now = new Date().toISOString();
+      const revived = await storage.requeueFailedBackgroundJob(jobId, now, now);
+      if (!revived) {
+        continue;
+      }
+
+      log.info(
+        { jobId, kind: revived.kind, targetId: revived.targetId },
+        "Revived parked background job for another recovery cycle",
+      );
+    }
+
+    if (revivable.length > 0) {
+      backgroundJobDispatcher.wake();
+    }
+
+    await clearStalePRErrorStatus();
+  };
+
+  /**
+   * A PR marked `error` by an earlier failed run should not stay that way while
+   * a job for it is queued or running — that combination is what made a human
+   * re-queue the PR by hand to get it moving again.
+   */
+  const clearStalePRErrorStatus = async () => {
+    const activeJobs = await storage.listBackgroundJobs({ kind: "babysit_pr" });
+    const activeTargets = new Set(
+      activeJobs
+        .filter((job) => job.status === "queued" || job.status === "leased")
+        .map((job) => job.targetId),
+    );
+    if (activeTargets.size === 0) {
+      return;
+    }
+
+    for (const targetId of Array.from(activeTargets)) {
+      const pr = await storage.getPR(targetId);
+      if (pr?.status !== "error") {
+        continue;
+      }
+
+      await storage.updatePR(pr.id, { status: "watching" });
+      await storage.addLog(pr.id, "info", "Cleared error state because PR work is queued again", {
+        phase: "watcher",
+      });
+    }
+  };
+
   let watcherTimer: NodeJS.Timeout | null = null;
   let watcherColdStartTimer: NodeJS.Timeout | null = null;
   let watcherIntervalMs = 0;
@@ -1025,6 +1126,11 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       if (config.autoPrs === false && config.autoIssues === false) {
         return;
       }
+
+      // Give parked work another cycle before anything else. This is what keeps
+      // automation running unattended: whatever blocked a job may well have been
+      // fixed since, and nothing else tells us that it was.
+      await recoverParkedWork();
 
       const rateLimit = getRateLimitState("core");
       if (rateLimit.limited && rateLimit.resetAt) {
@@ -1301,6 +1407,10 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       priority === undefined ? undefined : { priority },
     );
 
+    if (source === "manual") {
+      await promoteQueuedJob(job);
+    }
+
     await storage.addLog(targetId, "info", `${source === "automatic" ? "Queued automatic issue work" : "Queued manual issue work"} for ${issue.repoFullName}#${issue.number}`, {
       metadata: {
         repo: issue.repoFullName,
@@ -1396,6 +1506,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
       workStatus: workState.workStatus,
       workStage,
       workJobId: workState.workJobId,
+      workAvailableAt: workState.workAvailableAt,
       workAttemptCount: issueWorkAttemptCountFromJobs(issueJobs),
       workQueuedAt: latestJob?.createdAt ?? null,
       workCompletedAt: latestJob?.completedAt ?? null,
@@ -1756,15 +1867,22 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }
     const issues = Array.from(issuesById.values());
 
-    const isJobActive = (status: string) => status === "queued" || status === "leased";
+    // A job backing off after a failure is not consuming a runner, so it must not
+    // consume concurrency budget either — otherwise one retrying issue stalls all
+    // issue work until its delay elapses.
+    const planNow = new Date();
+    const isJobActive = (job: BackgroundJob) =>
+      job.status === "leased"
+      || (job.status === "queued" && !isBackingOff(job.availableAt, planNow.getTime()));
     const activeEvaluationTargets = new Set(
-      evaluationJobs.filter((job) => isJobActive(job.status)).map((job) => job.targetId),
+      evaluationJobs.filter(isJobActive).map((job) => job.targetId),
     );
-    const activeWorkCount = workJobs.filter((job) => isJobActive(job.status)).length;
+    const activeWorkCount = workJobs.filter(isJobActive).length;
 
     const plan = planAutomaticIssueQueueActions({
       repoSettings,
       issues,
+      now: planNow,
       activeEvaluationTargets,
       activeWorkCount,
       maxConcurrentIssueEvaluations: config.maxConcurrentIssueEvaluations,
@@ -2040,6 +2158,21 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
     }, interval);
   };
 
+  /**
+   * Enqueueing dedupes against an existing queued job, so a job that is backing
+   * off after a failure would swallow a deliberate "run this now" and look like
+   * the button did nothing. Pull it forward instead.
+   */
+  const promoteQueuedJob = async (job: BackgroundJob): Promise<void> => {
+    const now = new Date().toISOString();
+    if (job.status !== "queued" || job.availableAt <= now) {
+      return;
+    }
+
+    await storage.promoteBackgroundJob(job.id, now, now);
+    backgroundJobDispatcher.wake();
+  };
+
   const queueBabysitWithAgent = async (pr: PR, preferredAgent: Config["codingAgent"]) => {
     const job = await scheduleBackgroundJob(
       "babysit_pr",
@@ -2054,6 +2187,7 @@ export function createAppRuntime(dependencies: AppRuntimeDependencies = {}): App
         }),
       },
     );
+    await promoteQueuedJob(job);
     await storage.updatePR(pr.id, {
       workContract: markPRWorkQueuedContract(pr.workContract, {
         now: new Date(),

--- a/server/babysitter.test.ts
+++ b/server/babysitter.test.ts
@@ -8658,3 +8658,172 @@ test("isTrustedReviewer matches authors case-insensitively and ignores @ prefix"
   assert.equal(isTrustedReviewer("alice", ["octocat", "alice", "bob"]), true);
   assert.equal(isTrustedReviewer("eve", ["octocat", "alice", "bob"]), false);
 });
+
+test("babysitPR leaves the PR watching while the job still has retries left", async () => {
+  // Goal: a failing run used to park the PR in `error` and mark its feedback `failed`, so the
+  // only way forward was a human re-queueing it. While the background job still has attempts,
+  // the PR must stay workable so the retry picks it up on its own.
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  const pullSummary = makePullSummary(pr);
+  let applyCalled = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [existingItem],
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+    checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => {
+        throw new Error("GitHub follow-up failed");
+      },
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: true,
+        reason: "Comment requires a code change",
+      }),
+      applyFixesWithAgent: async ({ onStdoutChunk, onStderrChunk }) => {
+        applyCalled = true;
+        onStdoutChunk?.("agent stdout line\n");
+        onStderrChunk?.("agent stderr line\n");
+        return {
+          code: 0,
+          stdout: "agent stdout line\n",
+          stderr: "agent stderr line\n",
+        };
+      },
+      runCommand: makeGitRunCommand({
+        localHeadSha: "def456",
+        remoteHeadSha: "def456",
+      }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex", { jobAttemptCount: 0 });
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(applyCalled, true);
+  assert.equal(updated?.status, "watching", "a retryable failure must not park the PR");
+  assert.ok(
+    updated?.feedbackItems.every((item) => item.status !== "failed"),
+    "feedback must stay workable so the retry can pick it up",
+  );
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("GitHub follow-up failed")));
+  assert.ok(logs.some((log) => log.phase === "cleanup" && log.message.includes("Worktree cleanup complete")));
+
+  delete process.env.CODEFACTORY_HOME;
+});
+
+test("babysitPR parks the PR once the job is out of retries", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ autoUpdateDocs: false });
+  const existingItem = makeFeedbackItem();
+  const pr = await storage.addPR({
+    number: 106,
+    title: "Verbose PR",
+    repo: "alex-morgan-o/lolodex",
+    branch: "feature/verbose",
+    author: "octocat",
+    url: "https://github.com/alex-morgan-o/lolodex/pull/106",
+    status: "watching",
+    feedbackItems: [existingItem],
+    accepted: 0,
+    rejected: 0,
+    flagged: 0,
+    testsPassed: null,
+    lintPassed: null,
+    lastChecked: null,
+  });
+
+  const worktreeRoot = await mkdtemp(path.join(os.tmpdir(), "codefactory-home-"));
+  process.env.CODEFACTORY_HOME = worktreeRoot;
+  const pullSummary = makePullSummary(pr);
+  let applyCalled = false;
+
+  const babysitter = new PRBabysitter(
+    storage,
+    {
+      buildOctokit: async () => ({}) as never,
+      fetchFeedbackItemsForPR: async () => [existingItem],
+      fetchPullSummary: async () => pullSummary,
+      listFailingStatuses: async () => [],
+    checkCISettled: async () => true,
+      listOpenPullsForRepo: async () => [],
+      postFollowUpForFeedbackItem: async () => {
+        throw new Error("GitHub follow-up failed");
+      },
+      resolveReviewThread: async () => undefined,
+      resolveGitHubAuthToken: async () => "test-token",
+      addReactionToComment: async () => {},
+      postStatusReplyForFeedbackItem: async () => null,
+      updateStatusReply: async () => {},
+    },
+    {
+      resolveAgent: async () => "codex",
+      ciPollIntervalMs: 0,
+      evaluateFixNecessityWithAgent: async () => ({
+        needsFix: true,
+        reason: "Comment requires a code change",
+      }),
+      applyFixesWithAgent: async ({ onStdoutChunk, onStderrChunk }) => {
+        applyCalled = true;
+        onStdoutChunk?.("agent stdout line\n");
+        onStderrChunk?.("agent stderr line\n");
+        return {
+          code: 0,
+          stdout: "agent stdout line\n",
+          stderr: "agent stderr line\n",
+        };
+      },
+      runCommand: makeGitRunCommand({
+        localHeadSha: "def456",
+        remoteHeadSha: "def456",
+      }),
+    },
+  );
+
+  await babysitter.babysitPR(pr.id, "codex", { jobAttemptCount: 3 });
+
+  const updated = await storage.getPR(pr.id);
+  const logs = await storage.getLogs(pr.id);
+
+  assert.equal(applyCalled, true);
+  assert.equal(updated?.status, "error", "the last attempt still surfaces the failure");
+  assert.ok(logs.some((log) => log.phase === "run" && log.message.includes("GitHub follow-up failed")));
+  assert.ok(logs.some((log) => log.phase === "cleanup" && log.message.includes("Worktree cleanup complete")));
+
+  delete process.env.CODEFACTORY_HOME;
+});

--- a/server/babysitter.ts
+++ b/server/babysitter.ts
@@ -55,6 +55,7 @@ import { classifyCIFailures, type ClassifiedCIFailure } from "./ciFailureClassif
 import { isFailingCheckSnapshot } from "./ciCheckIngestor";
 import { runCIHealingRepairAttempt } from "./ciHealingAgent";
 import { childLogger } from "./logger";
+import { classifyFailure, resolveMaxAttempts } from "./failureRecovery";
 import { getCodeFactoryPaths } from "./paths";
 import { isResourceBudgetBelowReserve } from "./rateLimitState";
 import { runWithRequestPriority } from "./requestPriority";
@@ -2112,10 +2113,40 @@ export class PRBabysitter {
     return true;
   }
 
+  /**
+   * Whether the background job driving this run still has attempts left. Runs
+   * started outside the queue (manual, in tests) report false so their failures
+   * surface immediately as they always have.
+   */
+  private async willRetryBabysitFailure(
+    error: unknown,
+    attemptCount: number | undefined,
+  ): Promise<boolean> {
+    if (attemptCount === undefined) {
+      return false;
+    }
+
+    if (error instanceof TerminalBabysitterError) {
+      return false;
+    }
+
+    try {
+      const config = await this.storage.getConfig();
+      return attemptCount < resolveMaxAttempts({
+        kind: "babysit_pr",
+        failureClass: classifyFailure(error),
+        maxAgentRetryAttempts: config.maxAgentRetryAttempts,
+      });
+    } catch {
+      return false;
+    }
+  }
+
   async runQueuedBabysitPR(
     prId: string,
     preferredAgent: CodingAgent,
     agentSettings?: AgentRuntimeSettings,
+    jobAttemptCount?: number,
   ): Promise<void> {
     const interruptedRun = (await this.storage.listAgentRuns({ status: "running", prId }))
       .slice()
@@ -2126,6 +2157,7 @@ export class PRBabysitter {
         agentSettings,
         allowDuringDrain: true,
         rethrowOnFailure: true,
+        jobAttemptCount,
       });
       return;
     }
@@ -2148,6 +2180,7 @@ export class PRBabysitter {
         agentSettings,
         allowDuringDrain: true,
         rethrowOnFailure: true,
+        jobAttemptCount,
       });
       return;
     }
@@ -2161,6 +2194,7 @@ export class PRBabysitter {
       agentSettings,
       allowDuringDrain: true,
       rethrowOnFailure: true,
+      jobAttemptCount,
     });
   }
 
@@ -3062,6 +3096,8 @@ export class PRBabysitter {
       agentSettings?: AgentRuntimeSettings;
       allowDuringDrain?: boolean;
       rethrowOnFailure?: boolean;
+      /** Attempts already made by the background job driving this run, when there is one. */
+      jobAttemptCount?: number;
     },
   ): Promise<void> {
     const runId = options?.runId || randomUUID();
@@ -5480,6 +5516,10 @@ export class PRBabysitter {
       const currentPr = await this.storage.getPR(prId);
       const isGitHubError = error instanceof GitHubIntegrationError;
       const isNonCritical = isGitHubError && branchMoved;
+      // The job queue may still retry this run. If it will, leave the PR and its
+      // feedback in a working state — marking them failed here is what used to
+      // force a human to re-queue the PR by hand.
+      const willRetry = await this.willRetryBabysitFailure(error, options?.jobAttemptCount);
       let finalMessage = message;
       let rethrowError: unknown = error;
 
@@ -5497,6 +5537,7 @@ export class PRBabysitter {
 
         const shouldRunCodeOwnerFallback = Boolean(
           options?.rethrowOnFailure
+          && !willRetry
           && !recoveryMode
           && !forcedFixPrompt
           && !isNonCritical
@@ -5558,7 +5599,9 @@ export class PRBabysitter {
           }
         }
 
-        if (followUpTasks.length > 0) {
+        const nextStatus = isNonCritical || willRetry ? "watching" : "error";
+
+        if (followUpTasks.length > 0 && !willRetry) {
           const affectedIds = new Set(followUpTasks.map((item) => item.id));
           const updatedItems = currentPr.feedbackItems.map((item) => {
             if (!affectedIds.has(item.id)) return item;
@@ -5573,12 +5616,12 @@ export class PRBabysitter {
             accepted: updatedCounters.accepted,
             rejected: updatedCounters.rejected,
             flagged: updatedCounters.flagged,
-            status: isNonCritical ? "watching" : "error",
+            status: nextStatus,
             lastChecked: this.now().toISOString(),
           });
         } else {
           await this.storage.updatePR(currentPr.id, {
-            status: isNonCritical ? "watching" : "error",
+            status: nextStatus,
             lastChecked: this.now().toISOString(),
           });
         }

--- a/server/backgroundJobDispatcher.test.ts
+++ b/server/backgroundJobDispatcher.test.ts
@@ -523,3 +523,142 @@ test("BackgroundJobDispatcher fails handler errors after retry attempts are exha
     dispatcher.stop();
   }
 });
+
+test("BackgroundJobDispatcher keeps retrying infrastructure failures past the agent spend cap", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ maxAgentRetryAttempts: 1 });
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", {
+    prId: "pr-1",
+  });
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    retryBackoffMs: 0,
+    handlers: {
+      babysit_pr: async () => {
+        attempts += 1;
+        throw new Error("connect ECONNRESET 140.82.121.6:443");
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 1_000);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(attempts, 10, "a network failure retries on the free budget, not the agent budget");
+    assert.equal(stored?.attemptCount, 10);
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("BackgroundJobDispatcher parks agent availability failures without burning retries", async () => {
+  const storage = new MemStorage();
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("babysit_pr", "pr-1", "babysit_pr:pr-1", {
+    prId: "pr-1",
+  });
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    retryBackoffMs: 0,
+    handlers: {
+      babysit_pr: async () => {
+        attempts += 1;
+        throw new Error("Claude apply failed: authentication failed");
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 500);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(attempts, 1, "retrying an expired credential cannot help");
+    assert.equal(stored?.status, "failed");
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("BackgroundJobDispatcher caps agent-invoking retries with the user's spend setting", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ maxAgentRetryAttempts: 2 });
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("work_issue", "owner/repo#7", "work_issue:owner/repo#7", {});
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    retryBackoffMs: 0,
+    handlers: {
+      work_issue: async () => {
+        attempts += 1;
+        throw new Error("agent produced no usable patch");
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 500);
+
+    assert.equal(attempts, 2);
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("BackgroundJobDispatcher does not apply the agent spend cap to api-only work", async () => {
+  const storage = new MemStorage();
+  await storage.updateConfig({ maxAgentRetryAttempts: 1 });
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue("sync_watched_repos", "all", "sync_watched_repos:all", {});
+
+  let attempts = 0;
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    retryBackoffMs: 0,
+    handlers: {
+      sync_watched_repos: async () => {
+        attempts += 1;
+        throw new Error("repo sweep hit an unexpected state");
+      },
+    },
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 1_000);
+
+    assert.equal(attempts, 8, "syncing costs a GitHub request, not an agent run");
+  } finally {
+    dispatcher.stop();
+  }
+});

--- a/server/backgroundJobDispatcher.ts
+++ b/server/backgroundJobDispatcher.ts
@@ -2,7 +2,9 @@ import { randomUUID } from "crypto";
 import type { BackgroundJob, BackgroundJobKind } from "@shared/schema";
 import type { IStorage } from "./storage";
 import { BackgroundJobQueue } from "./backgroundJobQueue";
+import { classifyFailure, computeRetryDelayMs, resolveMaxAttempts, type FailureClass } from "./failureRecovery";
 import { childLogger } from "./logger";
+import { DEFAULT_CONFIG } from "./defaultConfig";
 
 const log = childLogger("jobs");
 const DRAIN_ALLOWED_KINDS: ReadonlySet<BackgroundJobKind> = new Set<BackgroundJobKind>(["sync_watched_repos"]);
@@ -45,8 +47,8 @@ export class BackgroundJobDispatcher {
   private readonly pollIntervalMs: number;
   private readonly leaseMs: number;
   private readonly heartbeatIntervalMs: number;
-  private readonly maxAttempts: number;
-  private readonly retryBackoffMs: number;
+  private readonly maxAttempts: number | null;
+  private readonly retryBackoffMs: number | null;
   private readonly now: () => Date;
   private readonly onError: (error: unknown) => void;
   private readonly onReclaimedJobs: (jobs: BackgroundJob[]) => void;
@@ -79,8 +81,10 @@ export class BackgroundJobDispatcher {
     this.pollIntervalMs = params.pollIntervalMs ?? 1_000;
     this.leaseMs = params.leaseMs ?? 30_000;
     this.heartbeatIntervalMs = params.heartbeatIntervalMs ?? 10_000;
-    this.maxAttempts = Math.max(1, params.maxAttempts ?? 3);
-    this.retryBackoffMs = Math.max(0, params.retryBackoffMs ?? 30_000);
+    // Left unset in production so the classified retry policy applies. Tests
+    // pin them to keep retries instant and bounded.
+    this.maxAttempts = params.maxAttempts === undefined ? null : Math.max(1, params.maxAttempts);
+    this.retryBackoffMs = params.retryBackoffMs === undefined ? null : Math.max(0, params.retryBackoffMs);
     this.now = params.now ?? (() => new Date());
     this.onError = params.onError ?? ((error) => {
       log.warn(
@@ -276,7 +280,7 @@ export class BackgroundJobDispatcher {
     error: unknown,
   ): Promise<void> {
     const now = this.now();
-    const action = this.resolveFailureAction(job, error);
+    const { action, failureClass } = await this.resolveFailureAction(job, error);
 
     try {
       switch (action) {
@@ -297,16 +301,37 @@ export class BackgroundJobDispatcher {
             availableAt: error instanceof DeferBackgroundJobError ? error.availableAt : now,
           });
           return;
-        case "retry":
+        case "retry": {
+          const delayMs = this.retryBackoffMs ?? computeRetryDelayMs(job.attemptCount);
+          log.info(
+            {
+              jobId: job.id,
+              kind: job.kind,
+              attempt: job.attemptCount,
+              failureClass,
+              delayMs,
+            },
+            "Background job retrying after failure",
+          );
           await this.queue.retry({
             jobId: job.id,
             leaseToken,
             error: summarizeError(error),
             now,
-            availableAt: new Date(now.getTime() + this.retryBackoffMs),
+            availableAt: new Date(now.getTime() + delayMs),
           });
           return;
+        }
         case "fail":
+          log.warn(
+            {
+              jobId: job.id,
+              kind: job.kind,
+              attempt: job.attemptCount,
+              failureClass,
+            },
+            "Background job parked; automation needs a human for this one",
+          );
           await this.queue.fail({
             jobId: job.id,
             leaseToken,
@@ -327,17 +352,55 @@ export class BackgroundJobDispatcher {
     }
   }
 
-  private resolveFailureAction(job: BackgroundJob, error: unknown): "cancel" | "defer" | "retry" | "fail" {
+  /**
+   * Decide what happens to a failed job. Retry budget depends on why it failed:
+   * infrastructure blips retry generously because they cost a request, while an
+   * unclassified failure on a job kind that can invoke a coding agent is capped
+   * by the user's `maxAgentRetryAttempts` spend setting. Failures a human has to
+   * clear (expired agent auth, missing CLI) park immediately — retrying them
+   * only burns time.
+   */
+  private async resolveFailureAction(
+    job: BackgroundJob,
+    error: unknown,
+  ): Promise<{ action: "cancel" | "defer" | "retry" | "fail"; failureClass: FailureClass | null }> {
     if (error instanceof CancelBackgroundJobError) {
-      return "cancel";
+      return { action: "cancel", failureClass: "terminal" };
     }
     if (error instanceof DeferBackgroundJobError) {
-      return "defer";
+      return { action: "defer", failureClass: null };
     }
     if (error instanceof TerminalBackgroundJobError) {
-      return "fail";
+      return { action: "fail", failureClass: "terminal" };
     }
-    return job.attemptCount < this.maxAttempts ? "retry" : "fail";
+
+    const failureClass = classifyFailure(error);
+    const policyAttempts = resolveMaxAttempts({
+      kind: job.kind,
+      failureClass,
+      maxAgentRetryAttempts: await this.resolveMaxAgentRetryAttempts(),
+    });
+    const maxAttempts = this.maxAttempts === null
+      ? policyAttempts
+      : Math.min(this.maxAttempts, policyAttempts);
+
+    return {
+      action: job.attemptCount < maxAttempts ? "retry" : "fail",
+      failureClass,
+    };
+  }
+
+  private async resolveMaxAgentRetryAttempts(): Promise<number> {
+    try {
+      const config = await this.storage.getConfig();
+      return config.maxAgentRetryAttempts;
+    } catch (error) {
+      log.warn(
+        { err: error instanceof Error ? error.message : String(error) },
+        "Could not read agent retry setting; using the default",
+      );
+      return DEFAULT_CONFIG.maxAgentRetryAttempts;
+    }
   }
 }
 

--- a/server/backgroundJobHandlers.test.ts
+++ b/server/backgroundJobHandlers.test.ts
@@ -831,10 +831,167 @@ test("process_release_run handler delegates to ReleaseManager for active rows", 
         processedIds.push(id);
         return releaseRun;
       },
+      markReleaseRunFailed: async () => releaseRun,
     },
   });
 
   await handlers.process_release_run!(job);
 
   assert.deepEqual(processedIds, [releaseRun.id]);
+});
+
+test("work_issue handler retries a thrown repair failure instead of stranding the issue", async () => {
+  // Goal: a thrown error used to be terminal, so one bad run left the issue excluded from
+  // auto-work until a human cleared it. It should now retry under the shared policy, and the
+  // GitHub "failed" notice should fire once — when the job actually runs out of attempts.
+  const storage = new MemStorage();
+  await storage.updateConfig({
+    watchedRepos: ["acme/widgets"],
+    codingAgent: "claude",
+    postGitHubProgressReplies: true,
+    maxAgentRetryAttempts: 2,
+  });
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "work_issue",
+    "acme/widgets#17",
+    "work_issue:acme/widgets#17",
+    {
+      repo: "acme/widgets",
+      issueNumber: 17,
+      issueTitle: "Fix the toggle",
+      issueUrl: "https://github.com/acme/widgets/issues/17",
+      baseBranch: "main",
+    },
+  );
+  const commentsCreated: Array<Record<string, unknown>> = [];
+  let repairCalls = 0;
+  const octokit = {
+    issues: {
+      get: async () => ({
+        data: {
+          number: 17,
+          title: "Fix the toggle",
+          body: "The toggle is stuck",
+          html_url: "https://github.com/acme/widgets/issues/17",
+          user: { login: "alice" },
+          labels: [{ name: "bug" }],
+          assignees: [],
+          comments: 2,
+          created_at: "2026-05-03T17:00:00.000Z",
+          updated_at: "2026-05-03T18:00:00.000Z",
+        },
+      }),
+      createComment: async (params: Record<string, unknown>) => {
+        commentsCreated.push(params);
+        return { data: { id: 123 } };
+      },
+    },
+  };
+
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    retryBackoffMs: 0,
+    handlers: createBackgroundJobHandlers({
+      storage,
+      deps: {
+        buildOctokitFn: async () => octokit as never,
+        resolveGitHubAuthTokenFn: async () => "gho_token",
+        runIssueWorkRepairFn: async () => {
+          repairCalls += 1;
+          throw new Error("worktree checkout exploded");
+        },
+      },
+    }),
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 1_000);
+
+    const stored = await storage.getBackgroundJob(job.id);
+    assert.equal(repairCalls, 2, "the failure should be retried up to the agent spend cap");
+    assert.equal(stored?.attemptCount, 2);
+
+    const failureNotices = commentsCreated.filter((params) => /Issue work failed/.test(String(params.body)));
+    assert.equal(failureNotices.length, 1, "only announce failure once the job is out of attempts");
+  } finally {
+    dispatcher.stop();
+  }
+});
+
+test("process_release_run handler retries before parking the run as errored", async () => {
+  // Goal: ReleaseManager used to swallow the error and leave the run in `error`, so only the
+  // manual retry endpoint could revive it. The run should only be marked failed once the
+  // dispatcher is out of attempts.
+  const storage = new MemStorage();
+  await storage.updateConfig({ maxAgentRetryAttempts: 2 });
+  const releaseRun = await storage.createReleaseRun({
+    repo: "acme/widgets",
+    baseBranch: "main",
+    triggerPrNumber: 42,
+    triggerPrTitle: "feat: add widget",
+    triggerPrUrl: "https://github.com/acme/widgets/pull/42",
+    triggerMergeSha: "merge-sha",
+    triggerMergedAt: "2026-04-02T12:00:00.000Z",
+    status: "detected",
+    decisionReason: null,
+    recommendedBump: null,
+    proposedVersion: null,
+    releaseTitle: null,
+    releaseNotes: null,
+    includedPrs: [],
+    targetSha: "merge-sha",
+    githubReleaseId: null,
+    githubReleaseUrl: null,
+    error: null,
+    completedAt: null,
+  });
+  const queue = new BackgroundJobQueue(storage);
+  const job = await queue.enqueue(
+    "process_release_run",
+    releaseRun.id,
+    `process_release_run:${releaseRun.id}`,
+    {},
+  );
+
+  let processCalls = 0;
+  const markedFailed: string[] = [];
+  const dispatcher = new BackgroundJobDispatcher({
+    storage,
+    queue,
+    workerId: "dispatcher-1",
+    pollIntervalMs: 5,
+    leaseMs: 30_000,
+    heartbeatIntervalMs: 10,
+    retryBackoffMs: 0,
+    handlers: createBackgroundJobHandlers({
+      storage,
+      releaseManager: {
+        processReleaseRun: async () => {
+          processCalls += 1;
+          throw new Error("release notes agent returned nothing usable");
+        },
+        markReleaseRunFailed: async (id) => {
+          markedFailed.push(id);
+          return releaseRun;
+        },
+      },
+    }),
+  });
+
+  try {
+    await dispatcher.start();
+    await waitForCondition(async () => (await storage.getBackgroundJob(job.id))?.status === "failed", 1_000);
+
+    assert.equal(processCalls, 2, "the run should be retried before it is shown as errored");
+    assert.deepEqual(markedFailed, [releaseRun.id], "mark it errored exactly once, at the end");
+  } finally {
+    dispatcher.stop();
+  }
 });

--- a/server/backgroundJobHandlers.ts
+++ b/server/backgroundJobHandlers.ts
@@ -4,6 +4,7 @@ import type { CodingAgent } from "./agentRunner";
 import { resolveRepoAgentRuntimeSettings, resolveRepoCodingAgent } from "./agentSettings";
 import { TerminalBabysitterError, type PRBabysitter } from "./babysitter";
 import { CancelBackgroundJobError, DeferBackgroundJobError, TerminalBackgroundJobError, type BackgroundJobHandlers } from "./backgroundJobDispatcher";
+import { classifyFailure, resolveMaxAttempts } from "./failureRecovery";
 import { buildBackgroundJobDedupeKey, type ScheduleBackgroundJob } from "./backgroundJobQueue";
 import { buildActivityPayload } from "./activityPayload";
 import { createAdapter } from "./deploymentAdapters";
@@ -99,7 +100,7 @@ function resolvePassiveMonitorDefer(): { reason: string; availableAt: Date } | n
 export function createBackgroundJobHandlers(params: {
   storage: IStorage;
   babysitter?: Pick<PRBabysitter, "runQueuedBabysitPR" | "syncAndBabysitTrackedRepos">;
-  releaseManager?: Pick<ReleaseManager, "processReleaseRun">;
+  releaseManager?: Pick<ReleaseManager, "processReleaseRun" | "markReleaseRunFailed">;
   deploymentHealingManager?: DeploymentHealingManager;
   questionAnswerer?: typeof answerPRQuestion;
   scheduleBackgroundJob?: ScheduleBackgroundJob;
@@ -293,7 +294,7 @@ export function createBackgroundJobHandlers(params: {
           ?? resolveRepoCodingAgent(config, repoSettings);
         const agentSettings = resolveRepoAgentRuntimeSettings(config, repoSettings);
         try {
-          await babysitter.runQueuedBabysitPR(pr.id, preferredAgent, agentSettings);
+          await babysitter.runQueuedBabysitPR(pr.id, preferredAgent, agentSettings, job.attemptCount);
         } catch (error) {
           if (error instanceof TerminalBabysitterError) {
             throw new TerminalBackgroundJobError(error.message);
@@ -581,6 +582,34 @@ export function createBackgroundJobHandlers(params: {
           subtasks: subtasks.length >= 2 ? subtasks : undefined,
         });
       } catch (error) {
+        // A thrown error here used to be terminal, so a single network blip
+        // stranded the issue until someone cleared it by hand. Let the shared
+        // policy decide, and only announce failure on GitHub once the job is
+        // actually out of attempts.
+        const message = error instanceof Error ? error.message : String(error);
+        const failureClass = classifyFailure(error);
+        const willRetry = job.attemptCount < resolveMaxAttempts({
+          kind: job.kind,
+          failureClass,
+          maxAgentRetryAttempts: config.maxAgentRetryAttempts,
+        });
+
+        if (willRetry) {
+          await addIssueWorkStageLog(
+            targetId,
+            "working",
+            `Issue work attempt ${job.attemptCount} failed for ${issue.repoFullName}#${issue.number}; retrying`,
+            {
+              ...baseMetadata,
+              error: message,
+              failureClass,
+              attempt: job.attemptCount,
+            },
+            "warn",
+          );
+          throw error;
+        }
+
         if (progressRepliesEnabled) {
           await postIssueWorkStatusComment(
             octokit,
@@ -592,7 +621,7 @@ export function createBackgroundJobHandlers(params: {
               issueTitle: issue.title,
               issueUrl: issue.url,
               stage: "failed",
-              detail: error instanceof Error ? error.message : String(error),
+              detail: message,
             }),
             targetId,
             "failed",
@@ -604,11 +633,12 @@ export function createBackgroundJobHandlers(params: {
           `Issue work failed for ${issue.repoFullName}#${issue.number}`,
           {
             ...baseMetadata,
-            error: error instanceof Error ? error.message : String(error),
+            error: message,
+            failureClass,
           },
           "error",
         );
-        throw new TerminalBackgroundJobError(error instanceof Error ? error.message : String(error));
+        throw new TerminalBackgroundJobError(message);
       }
 
       if (!repairResult.accepted) {
@@ -868,7 +898,23 @@ export function createBackgroundJobHandlers(params: {
           return;
         }
 
-        await releaseManager.processReleaseRun(releaseRun.id);
+        try {
+          await releaseManager.processReleaseRun(releaseRun.id, { markErrorOnFailure: false });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const failureClass = classifyFailure(error);
+          const config = await storage.getConfig();
+          const willRetry = job.attemptCount < resolveMaxAttempts({
+            kind: job.kind,
+            failureClass,
+            maxAgentRetryAttempts: config.maxAgentRetryAttempts,
+          });
+
+          if (!willRetry) {
+            await releaseManager.markReleaseRunFailed(releaseRun.id, message);
+          }
+          throw error;
+        }
       }
       : undefined,
 

--- a/server/defaultConfig.ts
+++ b/server/defaultConfig.ts
@@ -31,6 +31,7 @@ export const DEFAULT_CONFIG: Config = {
   deploymentCheckDelayMs: 120000,
   deploymentCheckTimeoutMs: 900000,
   deploymentCheckPollIntervalMs: 60000,
+  maxAgentRetryAttempts: 3,
   maxConcurrentIssueEvaluations: 2,
   maxConcurrentIssueWork: 1,
   maxConcurrentBabysitRuns: 3,

--- a/server/failureRecovery.test.ts
+++ b/server/failureRecovery.test.ts
@@ -1,0 +1,188 @@
+// PatchDeck + Failure classification and retry policy tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AGENT_INVOKING_JOB_KINDS,
+  classifyFailure,
+  computeRetryDelayMs,
+  planFailedJobRecovery,
+  resolveMaxAttempts,
+} from "./failureRecovery";
+
+test("classifies network and GitHub infrastructure failures as transient", () => {
+  const transient = [
+    new Error("connect ECONNRESET 140.82.121.6:443"),
+    new Error("request to https://api.github.com failed, reason: socket hang up"),
+    new Error("fetch failed"),
+    new Error("GitHub sync failed with status 503"),
+    new Error("You have exceeded a secondary rate limit"),
+    new Error("GitHub core budget is in the reserve band; deferring low-priority request"),
+  ];
+
+  for (const error of transient) {
+    assert.equal(classifyFailure(error), "transient", error.message);
+  }
+});
+
+test("classifies agent availability failures as blocked", () => {
+  const blocked = [
+    new Error("Claude apply failed: authentication failed"),
+    new Error("codex cli is not installed"),
+    new Error("spawn claude ENOENT"),
+    new Error("Bad credentials"),
+    new Error("Resource not accessible by integration"),
+  ];
+
+  for (const error of blocked) {
+    assert.equal(classifyFailure(error), "blocked", error.message);
+  }
+});
+
+test("defaults unrecognized failures to retryable", () => {
+  assert.equal(classifyFailure(new Error("worktree checkout produced no changes")), "retryable");
+  assert.equal(classifyFailure("something odd happened"), "retryable");
+  assert.equal(classifyFailure(new Error("")), "retryable");
+});
+
+test("a network timeout is not mistaken for an expired credential", () => {
+  assert.equal(classifyFailure(new Error("Claude apply failed: ETIMEDOUT")), "transient");
+});
+
+test("blocked and terminal failures are never retried", () => {
+  for (const failureClass of ["blocked", "terminal"] as const) {
+    assert.equal(
+      resolveMaxAttempts({ kind: "babysit_pr", failureClass, maxAgentRetryAttempts: 3 }),
+      0,
+    );
+  }
+});
+
+test("transient retries are generous and not governed by the agent spend cap", () => {
+  const attempts = resolveMaxAttempts({
+    kind: "babysit_pr",
+    failureClass: "transient",
+    maxAgentRetryAttempts: 1,
+  });
+
+  assert.equal(attempts, 10);
+});
+
+test("the agent spend cap governs unclassified failures on agent-invoking kinds", () => {
+  assert.equal(
+    resolveMaxAttempts({ kind: "work_issue", failureClass: "retryable", maxAgentRetryAttempts: 3 }),
+    3,
+  );
+  assert.equal(
+    resolveMaxAttempts({ kind: "work_issue", failureClass: "retryable", maxAgentRetryAttempts: 7 }),
+    7,
+  );
+  assert.equal(
+    resolveMaxAttempts({ kind: "work_issue", failureClass: "retryable", maxAgentRetryAttempts: 0 }),
+    1,
+    "a zero cap still allows the attempt already made to be the last one",
+  );
+});
+
+test("the agent spend cap does not throttle api-only job kinds", () => {
+  assert.ok(!AGENT_INVOKING_JOB_KINDS.has("sync_watched_repos"));
+  assert.equal(
+    resolveMaxAttempts({
+      kind: "sync_watched_repos",
+      failureClass: "retryable",
+      maxAgentRetryAttempts: 1,
+    }),
+    8,
+  );
+});
+
+test("backoff grows exponentially and caps at an hour", () => {
+  const noJitter = { random: () => 0.5 };
+
+  assert.equal(computeRetryDelayMs(1, noJitter), 30_000);
+  assert.equal(computeRetryDelayMs(2, noJitter), 60_000);
+  assert.equal(computeRetryDelayMs(3, noJitter), 120_000);
+  assert.equal(computeRetryDelayMs(4, noJitter), 240_000);
+  assert.equal(computeRetryDelayMs(10, noJitter), 3_600_000);
+  assert.equal(computeRetryDelayMs(50, noJitter), 3_600_000);
+});
+
+test("backoff jitter stays within twenty percent and never goes negative", () => {
+  assert.equal(computeRetryDelayMs(2, { random: () => 0 }), 48_000);
+  assert.equal(computeRetryDelayMs(2, { random: () => 1 }), 72_000);
+  assert.ok(computeRetryDelayMs(0, { random: () => 0 }) >= 1_000);
+});
+
+test("planFailedJobRecovery leaves freshly parked jobs alone", () => {
+  const nowMs = Date.parse("2026-05-01T12:00:00.000Z");
+  const revivable = planFailedJobRecovery(
+    [{
+      id: "job-1",
+      status: "failed",
+      lastError: "agent run failed",
+      createdAt: "2026-05-01T11:00:00.000Z",
+      updatedAt: "2026-05-01T11:50:00.000Z",
+    }],
+    nowMs,
+  );
+
+  assert.deepEqual(revivable, []);
+});
+
+test("planFailedJobRecovery gives a parked job another cycle once its interval elapses", () => {
+  const nowMs = Date.parse("2026-05-01T12:00:00.000Z");
+  const revivable = planFailedJobRecovery(
+    [{
+      id: "job-1",
+      status: "failed",
+      lastError: "codex cli is not installed",
+      createdAt: "2026-05-01T10:00:00.000Z",
+      updatedAt: "2026-05-01T10:30:00.000Z",
+    }],
+    nowMs,
+  );
+
+  assert.deepEqual(revivable, ["job-1"]);
+});
+
+test("planFailedJobRecovery stops cycling a job that has been failing for a day", () => {
+  const nowMs = Date.parse("2026-05-03T12:00:00.000Z");
+  const revivable = planFailedJobRecovery(
+    [{
+      id: "job-1",
+      status: "failed",
+      lastError: "authentication failed",
+      createdAt: "2026-05-01T09:00:00.000Z",
+      updatedAt: "2026-05-03T10:00:00.000Z",
+    }],
+    nowMs,
+  );
+
+  assert.deepEqual(revivable, [], "at that point it really does need a person");
+});
+
+test("planFailedJobRecovery ignores jobs that are not parked", () => {
+  const nowMs = Date.parse("2026-05-01T12:00:00.000Z");
+  const revivable = planFailedJobRecovery(
+    [
+      {
+        id: "queued",
+        status: "queued",
+        lastError: null,
+        createdAt: "2026-05-01T09:00:00.000Z",
+        updatedAt: "2026-05-01T09:00:00.000Z",
+      },
+      {
+        id: "canceled",
+        status: "canceled",
+        lastError: "PR no longer exists",
+        createdAt: "2026-05-01T09:00:00.000Z",
+        updatedAt: "2026-05-01T09:00:00.000Z",
+      },
+    ],
+    nowMs,
+  );
+
+  assert.deepEqual(revivable, []);
+});

--- a/server/failureRecovery.ts
+++ b/server/failureRecovery.ts
@@ -1,0 +1,207 @@
+// PatchDeck + Background job failure classification and retry policy
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import type { BackgroundJobKind } from "@shared/schema";
+import { detectAgentUnavailability } from "./agentRunner";
+
+/**
+ * How a background job failure should be treated by the retry policy.
+ *
+ * - `transient`  infrastructure blipped (network, GitHub 5xx, rate limit).
+ *                Retrying costs nothing but a request, so retry generously.
+ * - `retryable`  unclassified. Retry, but on an agent-invoking job this is the
+ *                path that can spend money, so the user-owned attempt cap applies.
+ * - `blocked`    a human has to act (agent auth expired, CLI missing, access
+ *                denied). Retrying cannot fix it; park and surface it.
+ * - `terminal`   the work is no longer meaningful (target deleted, payload
+ *                invalid). Do not retry.
+ */
+export type FailureClass = "transient" | "retryable" | "blocked" | "terminal";
+
+/** Job kinds whose retry can invoke a paid coding agent. */
+export const AGENT_INVOKING_JOB_KINDS: ReadonlySet<BackgroundJobKind> = new Set<BackgroundJobKind>([
+  "babysit_pr",
+  "work_issue",
+  "evaluate_issue",
+  "verify_issue",
+  "heal_deployment",
+  "answer_pr_question",
+  "process_release_run",
+  "generate_social_changelog",
+]);
+
+const TRANSIENT_PATTERNS: RegExp[] = [
+  /\b(ECONNRESET|ECONNREFUSED|EAI_AGAIN|ETIMEDOUT|ESOCKETTIMEDOUT|EPIPE|ENETUNREACH)\b/i,
+  /\bsocket hang up\b/i,
+  /\bnetwork error\b/i,
+  /\bfetch failed\b/i,
+  /\brequest timed out\b/i,
+  /\bhttp (?:408|500|502|503|504)\b/i,
+  /\bstatus (?:408|500|502|503|504)\b/i,
+  /\b(?:bad gateway|service unavailable|gateway timeout)\b/i,
+  /\brate limit\b/i,
+  /\bsecondary rate limit\b/i,
+  /\babuse detection\b/i,
+  /\bbudget is in the reserve band\b/i,
+  /\bserver error\b/i,
+];
+
+/** Blocking conditions that are not agent-availability failures. */
+const BLOCKED_PATTERNS: RegExp[] = [
+  /\bresource not accessible\b/i,
+  /\bmust have admin rights\b/i,
+  /\bsaml enforcement\b/i,
+  /\bbad credentials\b/i,
+  /\brepository not found\b/i,
+];
+
+const DEFAULT_TRANSIENT_MAX_ATTEMPTS = 10;
+const DEFAULT_RETRYABLE_MAX_ATTEMPTS = 8;
+const BASE_RETRY_DELAY_MS = 30_000;
+const MAX_RETRY_DELAY_MS = 3_600_000;
+const JITTER_FRACTION = 0.2;
+
+function toMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}
+
+function matchesAny(message: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(message));
+}
+
+/**
+ * Classify a failure so the dispatcher can decide between retrying, parking,
+ * and dropping the job. Order matters: infrastructure symptoms win over the
+ * agent-availability patterns, so a network timeout is never mistaken for an
+ * expired credential.
+ */
+export function classifyFailure(error: unknown): FailureClass {
+  const message = toMessage(error).trim();
+  if (message.length === 0) {
+    return "retryable";
+  }
+
+  if (matchesAny(message, TRANSIENT_PATTERNS)) {
+    return "transient";
+  }
+
+  if (detectAgentUnavailability(message) !== null) {
+    return "blocked";
+  }
+
+  if (matchesAny(message, BLOCKED_PATTERNS)) {
+    return "blocked";
+  }
+
+  return "retryable";
+}
+
+/**
+ * Attempts allowed before a job parks. Only the paid path — an unclassified
+ * failure on a job kind that can invoke an agent — is governed by the user's
+ * spend setting. Infrastructure retries cost a request, not a run, so they are
+ * deliberately not capped by it.
+ */
+export function resolveMaxAttempts(params: {
+  kind: BackgroundJobKind;
+  failureClass: FailureClass;
+  maxAgentRetryAttempts: number;
+}): number {
+  const { kind, failureClass, maxAgentRetryAttempts } = params;
+
+  if (failureClass === "blocked" || failureClass === "terminal") {
+    return 0;
+  }
+
+  if (failureClass === "transient") {
+    return DEFAULT_TRANSIENT_MAX_ATTEMPTS;
+  }
+
+  if (AGENT_INVOKING_JOB_KINDS.has(kind)) {
+    return Math.max(1, Math.floor(maxAgentRetryAttempts));
+  }
+
+  return DEFAULT_RETRYABLE_MAX_ATTEMPTS;
+}
+
+/**
+ * Exponential backoff with jitter, capped at an hour. `attempt` is the number
+ * of attempts already made, so the first retry waits the base delay.
+ */
+export function computeRetryDelayMs(
+  attempt: number,
+  options: { random?: () => number } = {},
+): number {
+  const exponent = Math.max(0, Math.floor(attempt) - 1);
+  const raw = BASE_RETRY_DELAY_MS * Math.pow(2, Math.min(exponent, 20));
+  const capped = Math.min(raw, MAX_RETRY_DELAY_MS);
+  const random = options.random ?? Math.random;
+  const jitter = capped * JITTER_FRACTION * (random() * 2 - 1);
+  return Math.max(1_000, Math.round(capped + jitter));
+}
+
+const DEFAULT_PARK_RETRY_INTERVAL_MS = 3_600_000;
+const DEFAULT_MAX_RECOVERY_AGE_MS = 86_400_000;
+
+export type FailedJobRecoveryPolicy = {
+  /** How long a parked job waits before automation gives it another cycle. */
+  retryIntervalMs?: number;
+  /** Stop reviving a job that has been failing for longer than this. */
+  maxRecoveryAgeMs?: number;
+};
+
+export type RecoverableJob = {
+  id: string;
+  status: string;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * Pick the parked jobs worth another cycle.
+ *
+ * Parking is not meant to be permanent. Most blocking conditions — an expired
+ * credential, a CLI that was not on PATH, a repo that was briefly unreachable —
+ * get fixed out of band, and nothing tells us when. Re-running the job on a long
+ * interval *is* the probe: if the condition still holds it re-parks after a
+ * single cheap attempt, and if it cleared the work simply resumes.
+ *
+ * Jobs that have been failing for longer than `maxRecoveryAgeMs` stop cycling
+ * and stay parked, because at that point it really is something a person needs
+ * to look at.
+ */
+export function planFailedJobRecovery(
+  jobs: RecoverableJob[],
+  nowMs: number,
+  policy: FailedJobRecoveryPolicy = {},
+): string[] {
+  const retryIntervalMs = policy.retryIntervalMs ?? DEFAULT_PARK_RETRY_INTERVAL_MS;
+  const maxRecoveryAgeMs = policy.maxRecoveryAgeMs ?? DEFAULT_MAX_RECOVERY_AGE_MS;
+
+  return jobs
+    .filter((job) => {
+      if (job.status !== "failed") {
+        return false;
+      }
+
+      const parkedAt = Date.parse(job.updatedAt);
+      if (!Number.isFinite(parkedAt) || nowMs - parkedAt < retryIntervalMs) {
+        return false;
+      }
+
+      const firstSeenAt = Date.parse(job.createdAt);
+      if (Number.isFinite(firstSeenAt) && nowMs - firstSeenAt > maxRecoveryAgeMs) {
+        return false;
+      }
+
+      return true;
+    })
+    .map((job) => job.id);
+}

--- a/server/memoryStorage.ts
+++ b/server/memoryStorage.ts
@@ -761,6 +761,48 @@ export class MemStorage implements IStorage {
     return this.cloneBackgroundJob(updated);
   }
 
+  async promoteBackgroundJob(
+    id: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    const existing = this.backgroundJobs.get(id);
+    if (!existing || existing.status !== "queued" || existing.availableAt <= availableAt) {
+      return undefined;
+    }
+
+    const updated = applyBackgroundJobUpdate(existing, { availableAt, updatedAt });
+    this.backgroundJobs.set(id, updated);
+    return this.cloneBackgroundJob(updated);
+  }
+
+  async requeueFailedBackgroundJob(
+    id: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    const existing = this.backgroundJobs.get(id);
+    if (!existing || existing.status !== "failed") {
+      return undefined;
+    }
+
+    const updated = applyBackgroundJobUpdate(existing, {
+      status: "queued",
+      availableAt,
+      leaseOwner: null,
+      leaseToken: null,
+      leaseExpiresAt: null,
+      heartbeatAt: null,
+      // A fresh attempt budget: the park interval has elapsed, so this is a new
+      // recovery cycle rather than a continuation of the exhausted one.
+      attemptCount: 0,
+      completedAt: null,
+      updatedAt,
+    });
+    this.backgroundJobs.set(id, updated);
+    return this.cloneBackgroundJob(updated);
+  }
+
   async retryBackgroundJob(
     id: string,
     leaseToken: string,

--- a/server/releaseManager.ts
+++ b/server/releaseManager.ts
@@ -300,7 +300,17 @@ export class ReleaseManager {
     return reset;
   }
 
-  async processReleaseRun(id: string): Promise<ReleaseRun | undefined> {
+  /**
+   * `markErrorOnFailure: false` leaves the run in its working state and rethrows,
+   * so the caller (the background job dispatcher) can retry before the run is
+   * shown to the user as errored. Errors used to be swallowed here, which left
+   * the run parked in `error` with a manual retry as the only way out.
+   */
+  async processReleaseRun(
+    id: string,
+    options: { markErrorOnFailure?: boolean } = {},
+  ): Promise<ReleaseRun | undefined> {
+    const markErrorOnFailure = options.markErrorOnFailure ?? true;
     const initial = await this.storage.getReleaseRun(id);
     if (!initial) {
       return undefined;
@@ -440,6 +450,9 @@ export class ReleaseManager {
 
         return published ?? undefined;
       } catch (error) {
+        if (!markErrorOnFailure) {
+          throw error;
+        }
         return this.failRun(id, summarizeError(error));
       } finally {
         this.inProgress.delete(id);
@@ -472,6 +485,11 @@ export class ReleaseManager {
     }
 
     return Array.from(deduped.values()).sort((a, b) => a.mergedAt.localeCompare(b.mergedAt));
+  }
+
+  /** Park a run as errored once the dispatcher has given up retrying it. */
+  async markReleaseRunFailed(id: string, error: string): Promise<ReleaseRun | undefined> {
+    return this.failRun(id, error);
   }
 
   private async failRun(id: string, error: string): Promise<ReleaseRun | undefined> {

--- a/server/sqliteStorage.ts
+++ b/server/sqliteStorage.ts
@@ -90,6 +90,7 @@ type ConfigRow = {
   github_comment_app_name: string;
   post_github_progress_replies: number;
   auto_heal_ci: number;
+  max_agent_retry_attempts: number;
   max_healing_attempts_per_session: number;
   max_healing_attempts_per_fingerprint: number;
   max_concurrent_healing_runs: number;
@@ -587,6 +588,7 @@ export class SqliteStorage implements IStorage {
         github_comment_app_name TEXT NOT NULL DEFAULT 'patchdeck',
         post_github_progress_replies INTEGER NOT NULL DEFAULT 0,
         auto_heal_ci INTEGER NOT NULL DEFAULT 0,
+        max_agent_retry_attempts INTEGER NOT NULL DEFAULT 3,
         max_healing_attempts_per_session INTEGER NOT NULL DEFAULT 3,
         max_healing_attempts_per_fingerprint INTEGER NOT NULL DEFAULT 2,
         max_concurrent_healing_runs INTEGER NOT NULL DEFAULT 1,
@@ -953,6 +955,7 @@ export class SqliteStorage implements IStorage {
     this.ensureColumn("config", "github_comment_app_name", "TEXT NOT NULL DEFAULT 'patchdeck'");
     this.ensureColumn("config", "post_github_progress_replies", "INTEGER NOT NULL DEFAULT 0");
     this.ensureColumn("config", "auto_heal_ci", "INTEGER NOT NULL DEFAULT 0");
+    this.ensureColumn("config", "max_agent_retry_attempts", "INTEGER NOT NULL DEFAULT 3");
     this.ensureColumn("config", "max_healing_attempts_per_session", "INTEGER NOT NULL DEFAULT 3");
     this.ensureColumn("config", "max_healing_attempts_per_fingerprint", "INTEGER NOT NULL DEFAULT 2");
     this.ensureColumn("config", "max_concurrent_healing_runs", "INTEGER NOT NULL DEFAULT 1");
@@ -1088,6 +1091,7 @@ export class SqliteStorage implements IStorage {
         row.post_github_progress_replies ?? Number(DEFAULT_CONFIG.postGitHubProgressReplies),
       ),
       autoHealCI: Boolean(row.auto_heal_ci ?? Number(DEFAULT_CONFIG.autoHealCI)),
+      maxAgentRetryAttempts: row.max_agent_retry_attempts ?? DEFAULT_CONFIG.maxAgentRetryAttempts,
       maxHealingAttemptsPerSession: row.max_healing_attempts_per_session ?? DEFAULT_CONFIG.maxHealingAttemptsPerSession,
       maxHealingAttemptsPerFingerprint: row.max_healing_attempts_per_fingerprint ?? DEFAULT_CONFIG.maxHealingAttemptsPerFingerprint,
       maxConcurrentHealingRuns: row.max_concurrent_healing_runs ?? DEFAULT_CONFIG.maxConcurrentHealingRuns,
@@ -1142,6 +1146,7 @@ export class SqliteStorage implements IStorage {
           github_comment_app_name,
           post_github_progress_replies,
           auto_heal_ci,
+          max_agent_retry_attempts,
           max_healing_attempts_per_session,
           max_healing_attempts_per_fingerprint,
           max_concurrent_healing_runs,
@@ -1156,7 +1161,7 @@ export class SqliteStorage implements IStorage {
           trusted_reviewers_json,
           priority_issue_authors_json,
           ignored_bots_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           github_token = excluded.github_token,
           github_tokens_json = excluded.github_tokens_json,
@@ -1182,6 +1187,7 @@ export class SqliteStorage implements IStorage {
           github_comment_app_name = excluded.github_comment_app_name,
           post_github_progress_replies = excluded.post_github_progress_replies,
           auto_heal_ci = excluded.auto_heal_ci,
+          max_agent_retry_attempts = excluded.max_agent_retry_attempts,
           max_healing_attempts_per_session = excluded.max_healing_attempts_per_session,
           max_healing_attempts_per_fingerprint = excluded.max_healing_attempts_per_fingerprint,
           max_concurrent_healing_runs = excluded.max_concurrent_healing_runs,
@@ -1222,6 +1228,7 @@ export class SqliteStorage implements IStorage {
         config.githubCommentAppName,
         Number(config.postGitHubProgressReplies),
         Number(config.autoHealCI),
+        config.maxAgentRetryAttempts,
         config.maxHealingAttemptsPerSession,
         config.maxHealingAttemptsPerFingerprint,
         config.maxConcurrentHealingRuns,
@@ -2036,7 +2043,7 @@ export class SqliteStorage implements IStorage {
              poll_interval_ms, max_changes_per_run, auto_resolve_merge_conflicts, auto_create_releases,
              auto_update_docs, auto_prs, auto_issues, include_repository_links_in_github_comments, github_comment_app_name,
              post_github_progress_replies,
-             auto_heal_ci, max_healing_attempts_per_session,
+             auto_heal_ci, max_agent_retry_attempts, max_healing_attempts_per_session,
              max_healing_attempts_per_fingerprint, max_concurrent_healing_runs, healing_cooldown_ms,
              auto_heal_deployments, deployment_check_delay_ms, deployment_check_timeout_ms,
              deployment_check_poll_interval_ms, max_concurrent_issue_evaluations, max_concurrent_issue_work,
@@ -3000,6 +3007,97 @@ export class SqliteStorage implements IStorage {
 
   async failBackgroundJob(id: string, leaseToken: string, error: string, completedAt: string): Promise<BackgroundJob | undefined> {
     return this.finalizeBackgroundJob(id, leaseToken, "failed", error, completedAt);
+  }
+
+  async promoteBackgroundJob(
+    id: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    return this.withWriteTransaction(() => {
+      const current = this.get<BackgroundJobRow>(`
+        SELECT id, kind, target_id, dedupe_key, status, priority, available_at,
+               lease_owner, lease_token, lease_expires_at, heartbeat_at, attempt_count,
+               last_error, payload_json, created_at, updated_at, completed_at
+        FROM background_jobs
+        WHERE id = ? AND status = 'queued' AND available_at > ?
+      `, id, availableAt);
+
+      if (!current) {
+        return undefined;
+      }
+
+      const updated = applyBackgroundJobUpdate(this.parseBackgroundJobRow(current), {
+        availableAt,
+        updatedAt,
+      });
+
+      this.run(`
+        UPDATE background_jobs
+        SET available_at = ?, updated_at = ?
+        WHERE id = ? AND status = 'queued'
+      `,
+        updated.availableAt,
+        updated.updatedAt,
+        id,
+      );
+
+      return updated;
+    });
+  }
+
+  async requeueFailedBackgroundJob(
+    id: string,
+    availableAt: string,
+    updatedAt: string,
+  ): Promise<BackgroundJob | undefined> {
+    return this.withWriteTransaction(() => {
+      const current = this.get<BackgroundJobRow>(`
+        SELECT id, kind, target_id, dedupe_key, status, priority, available_at,
+               lease_owner, lease_token, lease_expires_at, heartbeat_at, attempt_count,
+               last_error, payload_json, created_at, updated_at, completed_at
+        FROM background_jobs
+        WHERE id = ? AND status = 'failed'
+      `, id);
+
+      if (!current) {
+        return undefined;
+      }
+
+      const updated = applyBackgroundJobUpdate(this.parseBackgroundJobRow(current), {
+        status: "queued",
+        availableAt,
+        leaseOwner: null,
+        leaseToken: null,
+        leaseExpiresAt: null,
+        heartbeatAt: null,
+        // A fresh attempt budget: the park interval has elapsed, so this is a new
+        // recovery cycle rather than a continuation of the exhausted one.
+        attemptCount: 0,
+        completedAt: null,
+        updatedAt,
+      });
+
+      this.run(`
+        UPDATE background_jobs
+        SET status = 'queued',
+            available_at = ?,
+            lease_owner = NULL,
+            lease_token = NULL,
+            lease_expires_at = NULL,
+            heartbeat_at = NULL,
+            attempt_count = 0,
+            completed_at = NULL,
+            updated_at = ?
+        WHERE id = ? AND status = 'failed'
+      `,
+        updated.availableAt,
+        updated.updatedAt,
+        id,
+      );
+
+      return updated;
+    });
   }
 
   async retryBackgroundJob(

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1359,3 +1359,85 @@ test("MemStorage repo sync state matches the SqliteStorage contract", async () =
     { repo: "o/r", kind: "prs", lastSyncedAt: "t1", nextEligibleAt: null },
   ]);
 });
+
+test("both storages requeue a parked background job with a fresh attempt budget", async () => {
+  // Goal: parking must be reversible without a human. Reviving resets the attempt count so the
+  // job gets a full recovery cycle rather than failing again on its first tick.
+  const root = await mkdtemp(path.join(os.tmpdir(), "codefactory-storage-"));
+  const sqlite = new SqliteStorage(root);
+  const memory = new MemStorage();
+
+  try {
+    for (const storage of [sqlite, memory]) {
+      const job = await storage.enqueueBackgroundJob({
+        kind: "babysit_pr",
+        targetId: "pr-1",
+        dedupeKey: "babysit_pr:pr-1",
+        payload: { prId: "pr-1" },
+        availableAt: "2026-04-02T10:00:00.000Z",
+      });
+
+      const claimed = await storage.claimNextBackgroundJob({
+        workerId: "worker-1",
+        leaseToken: "lease-1",
+        leaseExpiresAt: "2026-04-02T10:00:30.000Z",
+        now: "2026-04-02T10:00:00.000Z",
+      });
+      assert.equal(claimed?.id, job.id);
+
+      await storage.failBackgroundJob(job.id, "lease-1", "agent run failed", "2026-04-02T10:00:20.000Z");
+
+      const revived = await storage.requeueFailedBackgroundJob(
+        job.id,
+        "2026-04-02T11:00:00.000Z",
+        "2026-04-02T11:00:00.000Z",
+      );
+
+      assert.equal(revived?.status, "queued");
+      assert.equal(revived?.attemptCount, 0);
+      assert.equal(revived?.leaseToken, null);
+      assert.equal(revived?.availableAt, "2026-04-02T11:00:00.000Z");
+
+      const reclaimable = await storage.claimNextBackgroundJob({
+        workerId: "worker-2",
+        leaseToken: "lease-2",
+        leaseExpiresAt: "2026-04-02T11:00:30.000Z",
+        now: "2026-04-02T11:00:00.000Z",
+      });
+      assert.equal(reclaimable?.id, job.id, "a revived job must be claimable again");
+
+      const missing = await storage.requeueFailedBackgroundJob(
+        "does-not-exist",
+        "2026-04-02T11:00:00.000Z",
+        "2026-04-02T11:00:00.000Z",
+      );
+      assert.equal(missing, undefined);
+
+      // A job backing off into the future must be pullable forward, so a manual
+      // "run now" is not silently swallowed by queue dedupe.
+      const backingOff = await storage.enqueueBackgroundJob({
+        kind: "work_issue",
+        targetId: "acme/widgets#3",
+        dedupeKey: "work_issue:acme/widgets#3",
+        payload: {},
+        availableAt: "2026-04-02T13:00:00.000Z",
+      });
+
+      const promoted = await storage.promoteBackgroundJob(
+        backingOff.id,
+        "2026-04-02T12:00:00.000Z",
+        "2026-04-02T12:00:00.000Z",
+      );
+      assert.equal(promoted?.availableAt, "2026-04-02T12:00:00.000Z");
+
+      const alreadyDue = await storage.promoteBackgroundJob(
+        backingOff.id,
+        "2026-04-02T12:30:00.000Z",
+        "2026-04-02T12:30:00.000Z",
+      );
+      assert.equal(alreadyDue, undefined, "never push a claimable job further out");
+    }
+  } finally {
+    sqlite.close();
+  }
+});

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -201,6 +201,8 @@ export interface IStorage {
   cancelBackgroundJob(id: string, leaseToken: string, error: string | null, completedAt: string): Promise<BackgroundJob | undefined>;
   requeueExpiredBackgroundJobs(now: string): Promise<number>;
   clearFailedBackgroundJobs(filters?: { kind?: BackgroundJobKind; targetId?: string }): Promise<number>;
+  requeueFailedBackgroundJob(id: string, availableAt: string, updatedAt: string): Promise<BackgroundJob | undefined>;
+  promoteBackgroundJob(id: string, availableAt: string, updatedAt: string): Promise<BackgroundJob | undefined>;
 
   // Social media changelogs
   getSocialChangelogs(): Promise<SocialChangelog[]>;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -313,6 +313,8 @@ export const issueSchema = z.object({
   workStatus: issueWorkStatusEnum,
   workStage: issueWorkStageEnum.optional(),
   workJobId: z.string().nullable(),
+  /** When a retrying work job becomes claimable again. Null unless it is backing off. */
+  workAvailableAt: z.string().nullable().optional(),
   workAttemptCount: z.number().int().nonnegative().optional(),
   workQueuedAt: z.string().nullable().optional(),
   workCompletedAt: z.string().nullable().optional(),
@@ -728,6 +730,7 @@ export const configSchema = z.object({
   deploymentCheckDelayMs: z.number(),
   deploymentCheckTimeoutMs: z.number(),
   deploymentCheckPollIntervalMs: z.number(),
+  maxAgentRetryAttempts: z.number().int().nonnegative().default(3),
   maxConcurrentIssueEvaluations: z.number().int().positive().default(2),
   maxConcurrentIssueWork: z.number().int().positive().default(1),
   maxConcurrentBabysitRuns: z.number().int().positive().default(3),


### PR DESCRIPTION
## Summary

Automation parked on the first real failure and stayed parked until someone cleared it in the dashboard. The root cause was `backgroundJobDispatcher.ts:340` — three attempts on a flat 30s backoff with no error classification, so a 90-second GitHub blip exhausted the whole budget and marked the job terminally `failed`.

Failures are now classified (`transient` / `retryable` / `blocked` / `terminal`) and retried with exponential backoff (30s → 1h). Retry budget follows cost:

- **Infrastructure failures** (5xx, `ECONNRESET`, rate limits) retry generously — 10 attempts over ~4h. They cost a request, not an agent run, so the spend setting does not gate them.
- **Unclassified failures on agent-invoking job kinds** are capped by a new user setting, `maxAgentRetryAttempts` (default 3), in Settings beside the other automation knobs.
- **Blocked failures** (expired agent credentials, missing CLI) park immediately, since retrying cannot fix them. A recovery sweep on the watcher tick gives parked work another cycle roughly hourly so it resumes on its own once the condition clears, and gives up after 24h.

Retries alone would not have made this unattended. Five separate surfaces stranded work regardless of retry policy, and are fixed here:

1. `backgroundJobHandlers.ts:611` treated **any** thrown error in issue work as terminal, so one network blip excluded that issue from auto-work *and* auto-evaluate permanently.
2. A backing-off job held both its repo's single-flight slot and the global `maxConcurrentIssueWork` budget (default 1), so one retrying issue would have frozen all issue work for an hour. This was a regression the retry change would otherwise have introduced.
3. A failing run marked the PR `error` and its feedback `failed` even with attempts remaining, forcing a manual re-queue.
4. `releaseManager.ts:443` swallowed errors entirely — the job completed "successfully" while the run sat in `error`, reachable only via `/api/releases/:id/retry`.
5. Queue dedupe would have absorbed a manual "run now" into a backing-off job, making the button look dead. Such jobs are now pulled forward.

Activity rows render retrying work as `retrying (attempt N) - retry in ~Xm - <error>`, so a backoff no longer looks identical to a stall.

CI healing budgets (`maxHealingAttemptsPerSession` / `PerFingerprint`) are deliberately unchanged — they are spend controls rather than stalls, and sessions already self-heal by being superseded on a new head SHA (`ciHealingManager.ts:104`).

Design notes and rejected alternatives are in `docs/plans/resilient-automation.md`.

### Behavior change to be aware of

Sustained failure now costs more agent spend than "fail after 90s" did: worst case is roughly `maxAgentRetryAttempts` runs per recovery cycle, one cycle per hour, for 24 hours. Setting `maxAgentRetryAttempts` to 1 tightens that without affecting infrastructure recovery.

## Verification

- `npm run check` — clean
- `npx eslint .` — clean
- `npm run build` — succeeds
- `npm run test:all` — 784 tests, 0 failures

New coverage: `server/failureRecovery.test.ts` (classification, backoff curve, free-vs-paid caps, park recovery), dispatcher tests for classified retry and immediate parking, `planAutomaticIssueQueueActions` tests for backing-off jobs, a `work_issue` retry test, a `process_release_run` retry test, babysitter tests for PR status on retryable vs final failure, storage parity tests for the two new job methods, and an activity-queue test for the retry label.

## Related Issue
- None