### PR TITLE
ci: stop grouping major bumps and let release PRs run their checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,16 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # Only minor and patch updates are safe to batch. Grouping majors here
+      # once produced a single PR carrying ten breaking upgrades (tailwindcss 4,
+      # zod 4, typescript 7 and more), which could not be reviewed or landed as
+      # one unit. Majors now arrive as individual PRs.
       npm-dependencies:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,13 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
+        with:
+          # GitHub does not start workflow runs for pull requests opened with the
+          # default GITHUB_TOKEN, so the required lint-and-test check never ran on
+          # release PRs and every one of them sat permanently BLOCKED. A PAT makes
+          # the PR look author-created, which starts the checks. Falls back to the
+          # default token so the workflow still runs if the secret is absent.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   publish-npm:
     needs: release-please


### PR DESCRIPTION
## Summary

Two configuration bugs were generating pull requests that could never merge. Both surfaced while clearing the current PR backlog.

**Dependabot grouped every npm update under one `*` pattern.** That produced #175: a single PR carrying ten major-version bumps. Three of them broke the build independently — `typescript` 5→7 (no released `typescript-eslint` supports TS 7; 8.67.0 still caps at `<6.1.0`, so `npm ci` failed peer resolution before any test ran), `tailwindcss` 3→4 (PostCSS plugin moved to `@tailwindcss/postcss`, config format changed), and `zod` 3→4 (`.default({})` no longer typechecks against the PR work contract schema in `shared/schema.ts`). A batch like that is not reviewable or landable as one unit. The group now batches only `minor` and `patch`; majors arrive as individual PRs that can be migrated one at a time.

**release-please ran with the default `GITHUB_TOKEN`.** GitHub does not start workflow runs for pull requests opened with that token, so the required `lint-and-test` check never ran on a release PR — leaving every one of them permanently `BLOCKED`. #147 had been sitting in that state and needed an empty commit to nudge CI. Passing a PAT makes the PR author-created from Actions' point of view, which starts the checks normally.

### Action required before this takes effect

The release-please half needs a repository secret named `RELEASE_PLEASE_TOKEN` — a PAT with `contents: write` and `pull-requests: write`. The expression is written as `secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN`, so the workflow keeps working unchanged until the secret exists; it simply keeps the old behavior until then.

## Verification

- Both YAML files parse (`yaml.safe_load`).
- Config-only change: no application code touched, so the existing suites are unaffected.
- The dependabot grouping change takes effect on its next scheduled run.

## Related Issue
- None