### PR TITLE
fix: report issue work timeout cause

### DIFF
--- a/server/issueWorkAgent.test.ts
+++ b/server/issueWorkAgent.test.ts
@@ -156,6 +156,58 @@ test("runIssueWorkRepair commits, pushes, and verifies the issue branch", async 
   assert.match(extractIssueWorkSummary("ISSUE_WORK_SUMMARY: fixed the toggle"), /fixed the toggle/);
 });
 
+test("runIssueWorkRepair reports a Codex timeout instead of a models cache warning", async () => {
+  const result = await runIssueWorkRepair({
+    repo: "acme/widgets",
+    issueNumber: 17,
+    issueTitle: "Fix the toggle",
+    issueUrl: "https://github.com/acme/widgets/issues/17",
+    issueBody: "The toggle is stuck",
+    labels: ["bug"],
+    author: "alice",
+    baseBranch: "main",
+    repoCloneUrl: "https://github.com/acme/widgets.git",
+    agent: "codex",
+    dependencies: {
+      preparePrWorktree: async () => ({
+        repoCacheDir: "/tmp/repo-cache",
+        worktreePath: "/tmp/worktree",
+      }),
+      removePrWorktree: async () => undefined,
+      applyFixesWithAgent: async () => ({
+        code: 124,
+        stdout: "",
+        stderr: [
+          "Reading additional input from stdin...",
+          "ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5",
+          "OpenAI Codex v0.146.1",
+          "Command timed out after 5400000ms",
+        ].join("\n"),
+        timedOut: true,
+      }),
+      readFile: async () => {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      },
+      runCommand: async (command: string, args: string[]) => {
+        if (command !== "git") {
+          throw new Error(`Unexpected command: ${command}`);
+        }
+        if (args[2] === "checkout" && args[3] === "-b") {
+          return { stdout: "", stderr: "", code: 0 };
+        }
+        if (args[0] === "config" && args[1] === "--get") {
+          return { stdout: "set\n", stderr: "", code: 0 };
+        }
+        throw new Error(`Unexpected git args: ${args.join(" ")}`);
+      },
+    },
+  });
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.rejectionReason, "agent failed (124): Command timed out after 5400000ms");
+  assert.doesNotMatch(result.rejectionReason ?? "", /models cache/i);
+});
+
 const SAMPLE_SUBTASKS: IssueSubtask[] = [
   { id: "bug-1", title: "Verifier exit code inverted", summary: "Treats 0 as the only pass.", status: "pending" },
   { id: "bug-2", title: "Preference overrides plan", summary: "Falls back to preference silently.", status: "pending" },

--- a/server/issueWorkAgent.ts
+++ b/server/issueWorkAgent.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import type { AgentRuntimeSettings, CodingAgent, CommandResult } from "./agentRunner";
-import { applyFixesWithAgent, runCommand, summarizeCommandResult } from "./agentRunner";
+import { applyFixesWithAgent, runCommand, summarizeAgentCommandFailure } from "./agentRunner";
 import { preparePrWorktree, removePrWorktree } from "./repoWorkspace";
 import type { IssueSubtask, IssueSubtaskStatus } from "@shared/schema";
 import path from "node:path";
@@ -490,7 +490,7 @@ export async function runIssueWorkRepair(
     if (agentResult.code !== 0) {
       return {
         accepted: false,
-        rejectionReason: summarizeCommandResult(agentResult, `agent failed (${agentResult.code})`),
+        rejectionReason: `agent failed (${agentResult.code}): ${summarizeAgentCommandFailure(agentResult)}`,
         summary: extractIssueWorkSummary(agentResult.stdout),
         fixBranch,
         agentResult,


### PR DESCRIPTION
## Summary

- use the agent-aware failure summarizer for failed issue work
- surface the terminal timeout instead of early Codex startup/cache warnings
- add regression coverage for the reported base_instructions cache warning followed by exit 124

## Root cause

Codex continued running after the models-cache parse warning. Patchdeck later timed it out, but issue work displayed the beginning of raw stderr and hid the appended timeout reason at the end.

## Verification

- node --import tsx --test --test-name-pattern='reports a Codex timeout instead of a models cache warning' server/issueWorkAgent.test.ts
- node --import tsx --test server/agentRunner.test.ts server/issueWorkAgent.test.ts
- npm run test (701 passed)
- npm run check
- node --experimental-test-coverage --import tsx --test server/agentRunner.test.ts server/issueWorkAgent.test.ts (issueWorkAgent.ts: 92.42% lines, 74.42% branches)
