### PR TITLE
fix(site): correct canonical URLs and dev CSS build

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -61,8 +61,15 @@ project from the `jeremymcs/patchdeck` repository and set:
 
 ### One thing to change after the domain is set
 
-The canonical URL currently points at `https://patchdeck.vercel.app/`. Once the
-real domain is attached, update it in three places:
+The canonical URL points at `https://patchdeck-eta.vercel.app/`, the alias Vercel
+assigned this project.
+
+> Do not "correct" this to `patchdeck.vercel.app`. That hostname is taken by an
+> unrelated project ("PatchDeck — Visual Network Designer") and is not ours;
+> pointing the canonical, OG image or sitemap at it would hand our SEO and link
+> previews to a stranger's site.
+
+Once a real domain is attached, update it in three places:
 
 - `index.html` — `<link rel="canonical">`, the `og:url` / `og:image` /
   `twitter:image` meta tags, and the `url` field in the JSON-LD block

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -47,10 +47,26 @@ fs.rmSync(DIST, { recursive: true, force: true });
 copyStatic();
 
 if (watch) {
+  // Build the stylesheet once up front. dist/ was just cleared, and the watcher
+  // below may take a moment (or fail) to produce it — without this the page
+  // serves with a 404 on styles.css.
+  const initial = spawnSync(tailwindBin, cssArgs, { stdio: "inherit" });
+  if (initial.status !== 0) process.exit(initial.status ?? 1);
+
   fs.watch(path.join(ROOT, "index.html"), () => copyStatic());
   fs.watch(PUBLIC, { recursive: true }, () => copyStatic());
-  spawn(tailwindBin, [...cssArgs, "--watch"], { stdio: "inherit" });
-  console.log("watching — dist/ is live");
+
+  // stdin must be an open pipe we never write to or close. The Tailwind CLI
+  // watcher shuts down the moment stdin reaches EOF, which is what both
+  // "inherit" (when detached) and "ignore" (/dev/null) hand it immediately.
+  const watcher = spawn(tailwindBin, [...cssArgs, "--watch"], {
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+  watcher.on("exit", (code) => {
+    console.error(`tailwind --watch exited (${code}); css is no longer rebuilding`);
+  });
+
+  console.log("watching — dist/ is live on the files it has built");
 } else {
   const result = spawnSync(tailwindBin, [...cssArgs, "--minify"], { stdio: "inherit" });
   if (result.status !== 0) process.exit(result.status ?? 1);

--- a/site/index.html
+++ b/site/index.html
@@ -9,22 +9,22 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>PatchDeck — Keep your pull requests moving</title>
 <meta name="description" content="PatchDeck is a local-first workbench for GitHub pull requests and issues. It watches your repos, triages review feedback and failing checks, then runs your local coding agent in an isolated worktree to fix what needs fixing." />
-<link rel="canonical" href="https://patchdeck.vercel.app/" />
+<link rel="canonical" href="https://patchdeck-eta.vercel.app/" />
 <meta name="theme-color" content="#08090C" />
 
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="PatchDeck" />
 <meta property="og:title" content="PatchDeck — Keep your pull requests moving" />
 <meta property="og:description" content="A local-first workbench that watches your GitHub repos, triages review feedback and failing checks, then dispatches your local coding agent to fix them." />
-<meta property="og:url" content="https://patchdeck.vercel.app/" />
-<meta property="og:image" content="https://patchdeck.vercel.app/assets/og.png" />
+<meta property="og:url" content="https://patchdeck-eta.vercel.app/" />
+<meta property="og:image" content="https://patchdeck-eta.vercel.app/assets/og.png" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 <meta property="og:image:alt" content="The PatchDeck dashboard showing watched repositories, open pull requests, and live agent activity." />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="PatchDeck — Keep your pull requests moving" />
 <meta name="twitter:description" content="A local-first workbench that watches your GitHub repos, triages review feedback and failing checks, then dispatches your local coding agent to fix them." />
-<meta name="twitter:image" content="https://patchdeck.vercel.app/assets/og.png" />
+<meta name="twitter:image" content="https://patchdeck-eta.vercel.app/assets/og.png" />
 
 <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -41,7 +41,7 @@
   "operatingSystem": "macOS, Linux, Windows",
   "softwareVersion": "1.6.0",
   "description": "A local-first workbench for keeping GitHub pull requests and issues moving. Watches repositories, syncs review feedback and failed checks into one dashboard, then runs a local coding agent in an isolated worktree.",
-  "url": "https://patchdeck.vercel.app/",
+  "url": "https://patchdeck-eta.vercel.app/",
   "codeRepository": "https://github.com/jeremymcs/patchdeck",
   "license": "https://opensource.org/licenses/MIT",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://patchdeck.vercel.app/sitemap.xml
+Sitemap: https://patchdeck-eta.vercel.app/sitemap.xml

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://patchdeck.vercel.app/</loc>
+    <loc>https://patchdeck-eta.vercel.app/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
   "cleanUrls": true,
   "trailingSlash": false,
   "headers": [


### PR DESCRIPTION
Follow-up to #187, which merged before these two fixes were pushed. Both are on the same branch.

## 1. Canonical URLs pointed at a domain we do not own — please prioritise this one

The placeholder `https://patchdeck.vercel.app` shipped to `main` in #187. That hostname is **not ours**: it serves an unrelated project titled *"PatchDeck — Visual Network Designer"*. Vercel assigned this project `patchdeck-eta.vercel.app` precisely because the plain name was already taken.

Left in place, it hands our canonical signal, OG link previews and sitemap to a third party's site. Eight references were affected:

- `index.html` — `<link rel="canonical">`, `og:url`, `og:image`, `twitter:image`, and the JSON-LD `url`
- `public/robots.txt` — the `Sitemap:` line
- `public/sitemap.xml` — the `<loc>` element

All now point at `https://patchdeck-eta.vercel.app`. `site/README.md` records why the plain hostname must not be substituted back.

Production is currently serving the incorrect canonical, so this is worth merging promptly.

## 2. Dev server served the page with no stylesheet

`build.mjs --watch` cleared `dist/` and then relied on the Tailwind watcher to recreate `styles.css`, but the Tailwind CLI exits the moment stdin reaches EOF — which is what it gets when the process runs detached. Result: `styles.css` 404'd and the page rendered unstyled.

- run a one-shot CSS build before starting the watcher, so `styles.css` always exists regardless of whether the watcher survives
- give the watcher an open stdin pipe rather than an inherited or ignored one
- log when the watcher exits instead of failing silently

The one-shot `npm run build` path used by CI and Vercel was never affected.

Also pins `framework`, `buildCommand`, `outputDirectory` and `installCommand` in `vercel.json`, so deployments do not depend on dashboard auto-detection.

## Verification

Vercel project `patchdeck` is created and linked (root directory `site`). Verified against the live branch preview at `patchdeck-git-jeremymcs-website-fluxlabs-projects.vercel.app`:

- page, `styles.css`, all six screenshots, `favicon.svg`, `robots.txt`, `sitemap.xml` and `og.png` all return 200 with correct content types
- `cache-control: public, max-age=31536000, immutable` confirmed on `/assets/*`
- `x-content-type-options`, `x-frame-options`, `referrer-policy` and `permissions-policy` confirmed on all routes
- rendered in a real browser, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF9K9Y3sGMA2EAQVqF93JW